### PR TITLE
ENH: Disable GPU Tests on github workflows unless manually triggered.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,17 +245,20 @@ jobs:
   # ============================================================================
   # GPU Tests (Self-hosted runners with CUDA)
   # ============================================================================
+  # NOTE: GPU tests are DISABLED for automatic runs because they wait indefinitely
+  # if no self-hosted runner is available. Enable manually via workflow_dispatch
+  # or by setting the 'run-gpu-tests' label on the PR.
   gpu-tests:
     name: GPU Tests (Python ${{ matrix.python-version }})
     runs-on: [self-hosted, linux, gpu]
     needs: unit-tests
-    timeout-minutes: 15
+    timeout-minutes: 30
+    # Only run GPU tests on manual trigger or if 'run-gpu-tests' label is present
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-gpu-tests')
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11"]
-    # Only run GPU tests if self-hosted runners are available
-    # Timeout after 15 minutes if no runner picks up the job
     continue-on-error: true
 
     steps:

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -1,8 +1,12 @@
 name: Slow Tests
 
+# NOTE: This workflow requires a self-hosted GPU runner to be available.
+# It will wait indefinitely in the queue if no runner is available.
+# Only scheduled runs and manual triggers are enabled.
+
 on:
   schedule:
-    # Run nightly at 2 AM UTC
+    # Run nightly at 2 AM UTC (only if runner is available)
     - cron: '0 2 * * *'
   workflow_dispatch:
 
@@ -10,7 +14,7 @@ jobs:
   test-slow-gpu:
     name: Slow Tests on GPU
     runs-on: [self-hosted, linux, gpu]
-    timeout-minutes: 15
+    timeout-minutes: 60
     continue-on-error: true
 
     steps:


### PR DESCRIPTION
No GPU-enabled runners currently exist, so GPU tests are disabled until runners can be procured.