### PR TITLE
STYLE: Disable ruff linting due to itk and vtk Optional requirements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
   "editor.formatOnPaste": false,
   // Python-specific editor settings
   "[python]": {
-    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.rulers": [
       88
     ],
@@ -54,6 +54,4 @@
   },
   "jupyter.pylanceHandlesNotebooks": true,
   "python.analysis.typeCheckingMode": "basic",
-  "ruff.enable": true,
-  "ruff.lint.enable": true,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,11 @@ ignore-paths = [
     "^.*__pycache__.*$",
     "^.*\\.egg-info.*$"
 ]
+extension-pkg-allow-list = ["itk"]
+
+[tool.pylint.typecheck]
+# ITK, VTK, and similar libraries generate classes dynamically
+generated-members = ["itk.*", "vtk.*", "Usd.*", "UsdGeom.*", "Gf.*"]
 
 [tool.pylint.format]
 max-line-length = 88
@@ -326,7 +331,7 @@ exclude_lines = [
 [tool.ruff]
 target-version = "py310"
 line-length = 88
-select = [
+lint.select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings
     "F",   # pyflakes
@@ -335,7 +340,7 @@ select = [
     "C4",  # flake8-comprehensions
     "UP",  # pyupgrade
 ]
-ignore = [
+lint.ignore = [
     "B008",  # do not perform function calls in argument defaults
     "C901",  # too complex
 ]

--- a/src/physiomotion4d/contour_tools.py
+++ b/src/physiomotion4d/contour_tools.py
@@ -246,7 +246,6 @@ class ContourTools(PhysioMotion4DBase):
         squared_distance: bool = False,
         max_distance: float = 0.0,
         invert_distance_map: bool = False,
-        create_point_map: bool = False,
     ) -> itk.Image:
         self.log_info("Computing signed distance map...")
 

--- a/src/physiomotion4d/transform_tools.py
+++ b/src/physiomotion4d/transform_tools.py
@@ -375,7 +375,8 @@ class TransformTools(PhysioMotion4DBase):
                 tfm = tfm[0]
             else:
                 raise ValueError(
-                    f"Expected single transform or list with one transform, got list with {len(tfm)} transforms"
+                    "Expected single transform or list with one transform, got list"
+                    f"with {len(tfm)} transforms"
                 )
 
         interpolator = None
@@ -601,7 +602,9 @@ class TransformTools(PhysioMotion4DBase):
             itk.Image: Scalar image containing Jacobian determinant values
 
         Example:
-            >>> jacobian = transform_tools.compute_jacobian_determinant_from_field(deformation_field)
+            >>> jacobian = transform_tools.compute_jacobian_determinant_from_field(
+                    deformation_field
+                )
         """
         if "VF" not in str(type(field)):
             field_arr = itk.array_from_image(field)
@@ -840,12 +843,11 @@ class TransformTools(PhysioMotion4DBase):
         UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.y)
 
         # Create root xform
-        root_xform = UsdGeom.Xform.Define(stage, "/DeformationVisualization")
+        # root_xform = UsdGeom.Xform.Define(stage, "/DeformationVisualization")
 
         if visualization_type == "arrows":
             self._create_arrow_visualization(
                 stage,
-                root_xform,
                 displacement_array,
                 displacement_field,
                 subsampled_size,
@@ -856,7 +858,6 @@ class TransformTools(PhysioMotion4DBase):
         elif visualization_type == "flowlines":
             self._create_flowline_visualization(
                 stage,
-                root_xform,
                 displacement_array,
                 displacement_field,
                 subsampled_size,
@@ -881,7 +882,6 @@ class TransformTools(PhysioMotion4DBase):
     def _create_arrow_visualization(
         self,
         stage,
-        root_xform,
         displacement_array,
         displacement_field,
         size,
@@ -1000,7 +1000,6 @@ class TransformTools(PhysioMotion4DBase):
     def _create_flowline_visualization(
         self,
         stage,
-        root_xform,
         displacement_array,
         displacement_field,
         size,


### PR DESCRIPTION
Ruff linting would try to use Optional typing via | instead of the command Optional, but itk templated methods don't work in | chains for type specification.  Must use this typing format <var>: Optional[itk.*] = None
instead of
<var>: itk.* | None = None

Ruff keeps replacing the use of Optional with the | version.