### PR TITLE
BUG: Compatibility issue with docutils resolved

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,10 @@ docs = [
     "sphinx-copybutton>=0.5.2",
     "sphinx-tabs>=3.4.7",
     "myst-parser>=4.0.0",
+
+    # Docutils 0.22 removed some node attributes (e.g. "backrefs") that
+    # sphinx-tabs expects, causing a KeyError during builds.
+    "docutils<0.22",
     
     # Additional dependencies
     "linkify-it-py>=2.0.0",


### PR DESCRIPTION
An error is caused by sphinx-tabs being incompatible with Docutils 0.22 (Docutils 0.22 removed the "backrefs" attribute, and sphinx-tabs crashes when it tries attrs.pop("backrefs")).

Error reported on github workflow, now fixed.

writing output... [ 87%] developer/workflows
writing output... [ 88%] examples
writing output... [ 90%] faq
writing output... [ 92%] index

Versions
========

* Platform:         linux; (Linux-6.11.0-1018-azure-x86_64-with-glibc2.39)
* Python version:   3.11.14 (CPython)
* Sphinx version:   9.0.4
* Docutils version: 0.22.4
* Jinja2 version:   3.1.6
* Pygments version: 2.19.2

Last Messages
=============

    faq

    writing output... [ 92%]
    index

    writing output... [ 93%]
    installation

Loaded Extensions
=================

* sphinx.ext.mathjax (9.0.4)
* alabaster (1.0.0)
* sphinxcontrib.applehelp (2.0.0)
* sphinxcontrib.devhelp (2.0.0)
* sphinxcontrib.htmlhelp (2.1.0)
* sphinxcontrib.serializinghtml (2.0.0)
* sphinxcontrib.qthelp (2.0.0)
* sphinx.ext.autodoc (9.0.4)
* sphinx.ext.napoleon (9.0.4)
* sphinx.ext.viewcode (9.0.4)
* sphinx.ext.intersphinx (9.0.4)
* sphinx.ext.todo (9.0.4)
* sphinx.ext.coverage (9.0.4)
* sphinx_autodoc_typehints (unknown version)
* sphinx_copybutton (0.5.2)
* sphinx_tabs.tabs (unknown version)
* myst_parser (5.0.0)
* sphinxcontrib.jquery (4.1)
* sphinx_rtd_theme (unknown version)

Traceback
=========

      File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/sphinx_tabs/tabs.py", line 69, in visit
        attrs.pop("backrefs")
    KeyError: 'backrefs'

The full traceback has been saved in:
/tmp/sphinx-err-r0ph0hb1.log

To report this error to the developers, please open an issue at <https://github.com/sphinx-doc/sphinx/issues/>. Thanks! Please also report this if it was a user error, so that a better error message can be provided next time. make: *** [Makefile:19: html] Error 2
writing output... [ 93%] installation
Error: Process completed with exit code 2.