### PR TITLE
ENH: Remove '4d' naming convention across codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
 
     - name: Run USD conversion tests
       run: |
-        pytest tests/test_convert_vtk_4d_to_usd_polymesh.py -v -m "not slow" --cov=physiomotion4d --cov-append --cov-report=xml
+        pytest tests/test_convert_vtk_to_usd_polymesh.py -v -m "not slow" --cov=physiomotion4d --cov-append --cov-report=xml
       continue-on-error: true
 
     - name: Run USD utility tests

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -100,7 +100,7 @@ By Category
 **USD Tools**
    * :mod:`~physiomotion4d.usd_tools` - USD file utilities
    * :mod:`~physiomotion4d.usd_anatomy_tools` - Anatomical structure tools
-   * :class:`~physiomotion4d.ConvertVTK4DToUSD` - VTK to USD conversion
+   * :class:`~physiomotion4d.ConvertVTKToUSD` - VTK to USD conversion
 
 Module Index
 ============

--- a/docs/api/usd/index.rst
+++ b/docs/api/usd/index.rst
@@ -47,9 +47,9 @@ Convert VTK to USD
 
 .. code-block:: python
 
-   from physiomotion4d import ConvertVTK4DToUSD
+   from physiomotion4d import ConvertVTKToUSD
    
-   converter = ConvertVTK4DToUSD(
+   converter = ConvertVTKToUSD(
        output_file="animated_heart.usd",
        colormap="rainbow",
        verbose=True

--- a/docs/api/usd/polymesh.rst
+++ b/docs/api/usd/polymesh.rst
@@ -9,7 +9,7 @@ Surface mesh (polygon mesh) representation in USD.
 Class Reference
 ===============
 
-.. autoclass:: ConvertVTK4DToUSDPolyMesh
+.. autoclass:: ConvertVTKToUSDPolyMesh
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/usd/tetmesh.rst
+++ b/docs/api/usd/tetmesh.rst
@@ -9,7 +9,7 @@ Tetrahedral mesh representation in USD for volumetric models.
 Class Reference
 ===============
 
-.. autoclass:: ConvertVTK4DToUSDTetMesh
+.. autoclass:: ConvertVTKToUSDTetMesh
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/usd/vtk_conversion.rst
+++ b/docs/api/usd/vtk_conversion.rst
@@ -9,7 +9,7 @@ Convert VTK mesh files to USD format with animation support.
 Class Reference
 ===============
 
-.. autoclass:: ConvertVTK4DToUSD
+.. autoclass:: ConvertVTKToUSD
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -46,7 +46,7 @@ Core Components
 
 5. **USD Export Module**
 
-   * :class:`ConvertVTK4DToUSD`: VTK to USD conversion
+   * :class:`ConvertVTKToUSD`: VTK to USD conversion
    * :class:`USDTools`: USD manipulation
    * :class:`USDAnatomyTools`: Material application
 

--- a/docs/developer/architecture.rst
+++ b/docs/developer/architecture.rst
@@ -69,10 +69,10 @@ The package is organized into functional modules:
    │       └── register_models_pca.py             PCA-based
    │
    ├── USD Generation
-   │   ├── convert_vtk_4d_to_usd_base.py          Base converter
-   │   ├── convert_vtk_4d_to_usd_polymesh.py      Polygon meshes
-   │   ├── convert_vtk_4d_to_usd_tetmesh.py       Tetrahedral meshes
-   │   └── convert_vtk_4d_to_usd.py               Main converter
+   │   ├── convert_vtk_to_usd_base.py          Base converter
+   │   ├── convert_vtk_to_usd_polymesh.py      Polygon meshes
+   │   ├── convert_vtk_to_usd_tetmesh.py       Tetrahedral meshes
+   │   └── convert_vtk_to_usd.py               Main converter
    │
    └── Utilities
        ├── image_tools.py                          Image manipulation
@@ -107,9 +107,9 @@ Most PhysioMotion4D classes inherit from :class:`PhysioMotion4DBase`:
    │   │   └── RegisterImagesICON
    │   └── (Model registration classes)
    └── Conversion Classes
-       └── ConvertVTK4DToUSDBase
-           ├── ConvertVTK4DToUSDPolyMesh
-           └── ConvertVTK4DToUSDTetMesh
+       └── ConvertVTKToUSDBase
+           ├── ConvertVTKToUSDPolyMesh
+           └── ConvertVTKToUSDTetMesh
 
 The base class provides:
 

--- a/docs/developer/extending.rst
+++ b/docs/developer/extending.rst
@@ -54,7 +54,7 @@ Start with this template for new workflows:
    from physiomotion4d import PhysioMotion4DBase
    from physiomotion4d import SegmentChestTotalSegmentator
    from physiomotion4d import RegisterImagesICON
-   from physiomotion4d import ConvertVTK4DToUSDPolyMesh
+   from physiomotion4d import ConvertVTKToUSDPolyMesh
 
    class MyCustomWorkflow(PhysioMotion4DBase):
        """
@@ -95,7 +95,7 @@ Start with this template for new workflows:
            """Initialize processing components."""
            self.segmentator = SegmentChestTotalSegmentator(verbose=self.verbose)
            self.registrator = RegisterImagesICON(device="cuda:0")
-           self.usd_converter = ConvertVTK4DToUSDPolyMesh(verbose=self.verbose)
+           self.usd_converter = ConvertVTKToUSDPolyMesh(verbose=self.verbose)
 
        def process(self):
            """Execute complete workflow."""
@@ -146,7 +146,7 @@ Complete example of a custom workflow:
    from physiomotion4d import PhysioMotion4DBase
    from physiomotion4d.image_tools import read_image, write_image
    from physiomotion4d.contour_tools import extract_surface_mesh
-   from physiomotion4d import ConvertVTK4DToUSD
+   from physiomotion4d import ConvertVTKToUSD
    import SimpleITK as sitk
 
    class BrainVesselWorkflow(PhysioMotion4DBase):
@@ -189,7 +189,7 @@ Complete example of a custom workflow:
 
            # Convert to USD
            usd_file = f"{self.output_directory}/brain_vessels.usd"
-           converter = ConvertVTK4DToUSD()
+           converter = ConvertVTKToUSD()
            converter.convert(
                vtk_file=vessel_mesh,
                usd_file=usd_file,

--- a/docs/developer/usd_generation.rst
+++ b/docs/developer/usd_generation.rst
@@ -22,17 +22,17 @@ PhysioMotion4D provides comprehensive USD conversion capabilities:
 * **Anatomical Materials**: Organ-specific material painting
 * **Time-Varying Geometry**: 4D animation support
 
-All converters inherit from :class:`ConvertVTK4DToUSDBase`.
+All converters inherit from :class:`ConvertVTKToUSDBase`.
 
 Base Converter Class
 ====================
 
-ConvertVTK4DToUSDBase
+ConvertVTKToUSDBase
 ---------------------
 
 Abstract base class for USD conversion.
 
-.. autoclass:: physiomotion4d.ConvertVTK4DToUSDBase
+.. autoclass:: physiomotion4d.ConvertVTKToUSDBase
    :members:
    :undoc-members:
    :show-inheritance:
@@ -51,7 +51,7 @@ Polygon Mesh Converter
 
 Convert surface meshes (VTK PolyData) to USD.
 
-.. autoclass:: physiomotion4d.ConvertVTK4DToUSDPolyMesh
+.. autoclass:: physiomotion4d.ConvertVTKToUSDPolyMesh
    :members:
    :undoc-members:
    :show-inheritance:
@@ -66,10 +66,10 @@ Convert surface meshes (VTK PolyData) to USD.
 
 .. code-block:: python
 
-   from physiomotion4d import ConvertVTK4DToUSDPolyMesh
+   from physiomotion4d import ConvertVTKToUSDPolyMesh
    
    # Initialize converter
-   converter = ConvertVTK4DToUSDPolyMesh(
+   converter = ConvertVTKToUSDPolyMesh(
        start_time=0,
        end_time=1.0,
        fps=30,
@@ -137,7 +137,7 @@ Tetrahedral Mesh Converter
 
 Convert volumetric meshes (VTK UnstructuredGrid) to USD.
 
-.. autoclass:: physiomotion4d.ConvertVTK4DToUSDTetMesh
+.. autoclass:: physiomotion4d.ConvertVTKToUSDTetMesh
    :members:
    :undoc-members:
    :show-inheritance:
@@ -152,10 +152,10 @@ Convert volumetric meshes (VTK UnstructuredGrid) to USD.
 
 .. code-block:: python
 
-   from physiomotion4d import ConvertVTK4DToUSDTetMesh
+   from physiomotion4d import ConvertVTKToUSDTetMesh
    
    # Initialize for tetrahedral meshes
-   converter = ConvertVTK4DToUSDTetMesh(verbose=True)
+   converter = ConvertVTKToUSDTetMesh(verbose=True)
    
    # Convert volumetric mesh
    converter.convert(
@@ -263,10 +263,10 @@ Create animated USD files from 4D VTK sequences:
 
 .. code-block:: python
 
-   from physiomotion4d import ConvertVTK4DToUSD
+   from physiomotion4d import ConvertVTKToUSD
    
    # Initialize with timing
-   converter = ConvertVTK4DToUSD(
+   converter = ConvertVTKToUSD(
        start_time=0.0,
        end_time=2.0,    # 2 second animation
        fps=30,          # 30 frames per second
@@ -290,7 +290,7 @@ Control temporal resolution:
 .. code-block:: python
 
    # High temporal resolution
-   converter = ConvertVTK4DToUSD(
+   converter = ConvertVTKToUSD(
        start_time=0,
        end_time=1.0,
        fps=60  # Smooth animation
@@ -300,7 +300,7 @@ Control temporal resolution:
    num_frames = len(vtk_files)
    cycle_duration = 1.0  # 1 second cardiac cycle
    
-   converter = ConvertVTK4DToUSD(
+   converter = ConvertVTKToUSD(
        start_time=0,
        end_time=cycle_duration,
        fps=num_frames / cycle_duration
@@ -316,9 +316,9 @@ Visualize scalar data on meshes:
 
 .. code-block:: python
 
-   from physiomotion4d import ConvertVTK4DToUSDPolyMesh
+   from physiomotion4d import ConvertVTKToUSDPolyMesh
    
-   converter = ConvertVTK4DToUSDPolyMesh()
+   converter = ConvertVTKToUSDPolyMesh()
    
    # Available colormaps
    colormaps = [
@@ -423,7 +423,7 @@ Create multi-resolution meshes:
 
 .. code-block:: python
 
-   class LODConverter(ConvertVTK4DToUSDPolyMesh):
+   class LODConverter(ConvertVTKToUSDPolyMesh):
        """Converter with LOD support."""
        
        def create_lod_mesh(self, vtk_file, usd_file, lod_levels):
@@ -508,7 +508,7 @@ Convert multiple files efficiently:
    
    def batch_convert_to_usd(vtk_dir, usd_dir, num_workers=4):
        """Convert multiple VTK files to USD in parallel."""
-       converter = ConvertVTK4DToUSDPolyMesh()
+       converter = ConvertVTKToUSDPolyMesh()
        
        vtk_files = list(Path(vtk_dir).glob("*.vtk"))
        

--- a/docs/developer/workflows.rst
+++ b/docs/developer/workflows.rst
@@ -251,7 +251,7 @@ Create new workflows by inheriting from :class:`PhysioMotion4DBase`:
    from physiomotion4d import PhysioMotion4DBase
    from physiomotion4d import SegmentChestTotalSegmentator
    from physiomotion4d import RegisterImagesICON
-   from physiomotion4d import ConvertVTK4DToUSD
+   from physiomotion4d import ConvertVTKToUSD
    
    class MyCustomWorkflow(PhysioMotion4DBase):
        """Custom medical imaging workflow."""

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -230,14 +230,14 @@ Convert VTK mesh sequence to animated USD:
 
 .. code-block:: python
 
-   from physiomotion4d import ConvertVTK4DToUSDPolyMesh
+   from physiomotion4d import ConvertVTKToUSDPolyMesh
    import glob
 
    # Get VTK files
    vtk_files = sorted(glob.glob("heart_frame_*.vtp"))
 
    # Convert
-   converter = ConvertVTK4DToUSDPolyMesh()
+   converter = ConvertVTKToUSDPolyMesh()
    converter.set_input_filenames(vtk_files)
    converter.set_output_filename("heart_animation.usd")
    converter.set_frame_rate(30)  # FPS
@@ -561,7 +561,7 @@ Mix and match different components:
        SegmentChestVista3D,
        RegisterImagesICON,
        TransformTools,
-       ConvertVTK4DToUSDPolyMesh,
+       ConvertVTKToUSDPolyMesh,
        ContourTools
    )
    import itk
@@ -598,7 +598,7 @@ Mix and match different components:
        mesh.save(f"heart_{i:03d}.vtp")
 
    # Convert to USD
-   converter = ConvertVTK4DToUSDPolyMesh()
+   converter = ConvertVTKToUSDPolyMesh()
    converter.set_input_filenames([f"heart_{i:03d}.vtp" for i in range(10)])
    converter.set_output_filename("heart.usd")
    converter.convert()

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -168,10 +168,10 @@ Convert VTK time series to USD:
 
 .. code-block:: python
 
-   from physiomotion4d import ConvertVTK4DToUSDPolyMesh
+   from physiomotion4d import ConvertVTKToUSDPolyMesh
 
    # Initialize converter
-   converter = ConvertVTK4DToUSDPolyMesh()
+   converter = ConvertVTKToUSDPolyMesh()
 
    # Set input VTK files (time series)
    vtk_files = [f"heart_frame_{i:03d}.vtp" for i in range(10)]

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -62,7 +62,7 @@ Specific Test Modules
 
    # Data conversion (fast)
    pytest tests/test_convert_nrrd_4d_to_3d.py -v
-   pytest tests/test_convert_vtk_4d_to_usd_polymesh.py -v
+   pytest tests/test_convert_vtk_to_usd_polymesh.py -v
 
    # Image tools (fast)
    pytest tests/test_image_tools.py -v
@@ -114,7 +114,7 @@ Tests are organized by functionality:
    │   ├── test_contour_tools.py                 # Mesh extraction and manipulation
    │   ├── test_transform_tools.py               # Transform operations
    │   ├── test_image_tools.py                   # Image processing utilities
-   │   └── test_convert_vtk_4d_to_usd_polymesh.py # VTK to USD conversion
+   │   └── test_convert_vtk_to_usd_polymesh.py # VTK to USD conversion
    │
    └── USD Utility Tests
        ├── test_usd_merge.py                     # USD file merging

--- a/experiments/Colormap-VTK_To_USD/colormap_vtk_to_usd.ipynb
+++ b/experiments/Colormap-VTK_To_USD/colormap_vtk_to_usd.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Colormap Features for VTK to USD Conversion\n",
     "\n",
-    "This notebook demonstrates the colormap features of `ConvertVTK4DToUSD` for visualizing point data arrays in NVIDIA Omniverse.\n",
+    "This notebook demonstrates the colormap features of `ConvertVTKToUSD` for visualizing point data arrays in NVIDIA Omniverse.\n",
     "\n",
     "## Features Demonstrated\n",
     "\n",
@@ -34,10 +34,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:58:38.122269Z",
-     "iopub.status.busy": "2026-01-25T21:58:38.121719Z",
-     "iopub.status.idle": "2026-01-25T21:58:52.888277Z",
-     "shell.execute_reply": "2026-01-25T21:58:52.887117Z"
+     "iopub.execute_input": "2026-01-28T01:07:54.229564Z",
+     "iopub.status.busy": "2026-01-28T01:07:54.229190Z",
+     "iopub.status.idle": "2026-01-28T01:08:10.221917Z",
+     "shell.execute_reply": "2026-01-28T01:08:10.220909Z"
     }
    },
    "outputs": [],
@@ -47,7 +47,7 @@
     "import numpy as np\n",
     "import pyvista as pv\n",
     "\n",
-    "from physiomotion4d import ConvertVTK4DToUSD\n",
+    "from physiomotion4d import ConvertVTKToUSD\n",
     "\n",
     "\n",
     "# Create output directory\n",
@@ -72,10 +72,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:58:52.920157Z",
-     "iopub.status.busy": "2026-01-25T21:58:52.920157Z",
-     "iopub.status.idle": "2026-01-25T21:58:52.933384Z",
-     "shell.execute_reply": "2026-01-25T21:58:52.932624Z"
+     "iopub.execute_input": "2026-01-28T01:08:10.232929Z",
+     "iopub.status.busy": "2026-01-28T01:08:10.232929Z",
+     "iopub.status.idle": "2026-01-28T01:08:10.252021Z",
+     "shell.execute_reply": "2026-01-28T01:08:10.251013Z"
     }
    },
    "outputs": [],
@@ -130,10 +130,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:58:52.935500Z",
-     "iopub.status.busy": "2026-01-25T21:58:52.935500Z",
-     "iopub.status.idle": "2026-01-25T21:58:54.899501Z",
-     "shell.execute_reply": "2026-01-25T21:58:54.898506Z"
+     "iopub.execute_input": "2026-01-28T01:08:10.254170Z",
+     "iopub.status.busy": "2026-01-28T01:08:10.254170Z",
+     "iopub.status.idle": "2026-01-28T01:08:12.342965Z",
+     "shell.execute_reply": "2026-01-28T01:08:12.341674Z"
     }
    },
    "outputs": [],
@@ -145,7 +145,7 @@
     "meshes = [create_example_mesh_with_data(t) for t in range(20)]\n",
     "\n",
     "# Initialize converter\n",
-    "converter = ConvertVTK4DToUSD(\n",
+    "converter = ConvertVTKToUSD(\n",
     "    data_basename=\"CardiacModel\", input_polydata=meshes, mask_ids=None\n",
     ")\n",
     "\n",
@@ -182,10 +182,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:58:54.902510Z",
-     "iopub.status.busy": "2026-01-25T21:58:54.901499Z",
-     "iopub.status.idle": "2026-01-25T21:58:56.413498Z",
-     "shell.execute_reply": "2026-01-25T21:58:56.412570Z"
+     "iopub.execute_input": "2026-01-28T01:08:12.345424Z",
+     "iopub.status.busy": "2026-01-28T01:08:12.345424Z",
+     "iopub.status.idle": "2026-01-28T01:08:13.940763Z",
+     "shell.execute_reply": "2026-01-28T01:08:13.940256Z"
     }
    },
    "outputs": [],
@@ -195,7 +195,7 @@
     "\n",
     "meshes = [create_example_mesh_with_data(t) for t in range(20)]\n",
     "\n",
-    "converter = ConvertVTK4DToUSD(\n",
+    "converter = ConvertVTKToUSD(\n",
     "    data_basename=\"CardiacModel\", input_polydata=meshes, mask_ids=None\n",
     ")\n",
     "\n",
@@ -224,10 +224,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:58:56.415540Z",
-     "iopub.status.busy": "2026-01-25T21:58:56.415540Z",
-     "iopub.status.idle": "2026-01-25T21:58:58.913569Z",
-     "shell.execute_reply": "2026-01-25T21:58:58.913065Z"
+     "iopub.execute_input": "2026-01-28T01:08:13.943785Z",
+     "iopub.status.busy": "2026-01-28T01:08:13.942769Z",
+     "iopub.status.idle": "2026-01-28T01:08:16.443870Z",
+     "shell.execute_reply": "2026-01-28T01:08:16.442878Z"
     }
    },
    "outputs": [],
@@ -237,7 +237,7 @@
     "\n",
     "meshes = [create_example_mesh_with_data(t) for t in range(20)]\n",
     "\n",
-    "converter = ConvertVTK4DToUSD(\n",
+    "converter = ConvertVTKToUSD(\n",
     "    data_basename=\"TemperatureModel\", input_polydata=meshes, mask_ids=None\n",
     ")\n",
     "\n",
@@ -266,10 +266,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:58:58.916111Z",
-     "iopub.status.busy": "2026-01-25T21:58:58.916111Z",
-     "iopub.status.idle": "2026-01-25T21:59:01.729470Z",
-     "shell.execute_reply": "2026-01-25T21:59:01.728582Z"
+     "iopub.execute_input": "2026-01-28T01:08:16.446870Z",
+     "iopub.status.busy": "2026-01-28T01:08:16.445877Z",
+     "iopub.status.idle": "2026-01-28T01:08:19.333449Z",
+     "shell.execute_reply": "2026-01-28T01:08:19.332465Z"
     }
    },
    "outputs": [],
@@ -279,7 +279,7 @@
     "\n",
     "meshes = [create_example_mesh_with_data(t) for t in range(20)]\n",
     "\n",
-    "converter = ConvertVTK4DToUSD(\n",
+    "converter = ConvertVTKToUSD(\n",
     "    data_basename=\"CardiacModel\", input_polydata=meshes, mask_ids=None\n",
     ")\n",
     "\n",
@@ -308,10 +308,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:59:01.731098Z",
-     "iopub.status.busy": "2026-01-25T21:59:01.731098Z",
-     "iopub.status.idle": "2026-01-25T21:59:04.225923Z",
-     "shell.execute_reply": "2026-01-25T21:59:04.224898Z"
+     "iopub.execute_input": "2026-01-28T01:08:19.336369Z",
+     "iopub.status.busy": "2026-01-28T01:08:19.335370Z",
+     "iopub.status.idle": "2026-01-28T01:08:21.885779Z",
+     "shell.execute_reply": "2026-01-28T01:08:21.884780Z"
     }
    },
    "outputs": [],
@@ -321,7 +321,7 @@
     "\n",
     "meshes = [create_example_mesh_with_data(t) for t in range(20)]\n",
     "\n",
-    "converter = ConvertVTK4DToUSD(\n",
+    "converter = ConvertVTKToUSD(\n",
     "    data_basename=\"CardiacModel\", input_polydata=meshes, mask_ids=None\n",
     ")\n",
     "\n",
@@ -348,10 +348,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:59:04.227906Z",
-     "iopub.status.busy": "2026-01-25T21:59:04.227906Z",
-     "iopub.status.idle": "2026-01-25T21:59:04.497390Z",
-     "shell.execute_reply": "2026-01-25T21:59:04.496510Z"
+     "iopub.execute_input": "2026-01-28T01:08:21.887781Z",
+     "iopub.status.busy": "2026-01-28T01:08:21.887781Z",
+     "iopub.status.idle": "2026-01-28T01:08:22.263163Z",
+     "shell.execute_reply": "2026-01-28T01:08:22.262286Z"
     }
    },
    "outputs": [],
@@ -367,7 +367,7 @@
     "    regions = np.floor(3 * (z_values + 1) / 2)  # 3 regions\n",
     "    mesh.point_data[\"region_id\"] = regions\n",
     "\n",
-    "converter = ConvertVTK4DToUSD(\n",
+    "converter = ConvertVTKToUSD(\n",
     "    data_basename=\"RegionModel\", input_polydata=meshes, mask_ids=None\n",
     ")\n",
     "\n",
@@ -394,10 +394,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:59:04.499388Z",
-     "iopub.status.busy": "2026-01-25T21:59:04.499388Z",
-     "iopub.status.idle": "2026-01-25T21:59:06.614442Z",
-     "shell.execute_reply": "2026-01-25T21:59:06.613522Z"
+     "iopub.execute_input": "2026-01-28T01:08:22.265487Z",
+     "iopub.status.busy": "2026-01-28T01:08:22.264177Z",
+     "iopub.status.idle": "2026-01-28T01:08:24.416345Z",
+     "shell.execute_reply": "2026-01-28T01:08:24.415504Z"
     }
    },
    "outputs": [],
@@ -411,9 +411,7 @@
     "\n",
     "# Method chaining for concise code\n",
     "stage = (\n",
-    "    ConvertVTK4DToUSD(\n",
-    "        data_basename=\"CardiacModel\", input_polydata=meshes, mask_ids=None\n",
-    "    )\n",
+    "    ConvertVTKToUSD(data_basename=\"CardiacModel\", input_polydata=meshes, mask_ids=None)\n",
     "    .set_colormap(\n",
     "        color_by_array=\"transmembrane_potential\",\n",
     "        colormap=\"viridis\",\n",
@@ -460,10 +458,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:59:06.616441Z",
-     "iopub.status.busy": "2026-01-25T21:59:06.616441Z",
-     "iopub.status.idle": "2026-01-25T21:59:06.629553Z",
-     "shell.execute_reply": "2026-01-25T21:59:06.628531Z"
+     "iopub.execute_input": "2026-01-28T01:08:24.417994Z",
+     "iopub.status.busy": "2026-01-28T01:08:24.417994Z",
+     "iopub.status.idle": "2026-01-28T01:08:24.431917Z",
+     "shell.execute_reply": "2026-01-28T01:08:24.430667Z"
     }
    },
    "outputs": [],

--- a/experiments/Heart-GatedCT_To_USD/0-download_and_convert_4d_to_3d.ipynb
+++ b/experiments/Heart-GatedCT_To_USD/0-download_and_convert_4d_to_3d.ipynb
@@ -5,10 +5,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-26T14:30:09.829548Z",
-     "iopub.status.busy": "2026-01-26T14:30:09.829548Z",
-     "iopub.status.idle": "2026-01-26T14:30:30.149504Z",
-     "shell.execute_reply": "2026-01-26T14:30:30.149504Z"
+     "iopub.execute_input": "2026-01-28T03:20:44.628453Z",
+     "iopub.status.busy": "2026-01-28T03:20:44.628453Z",
+     "iopub.status.idle": "2026-01-28T03:21:01.117771Z",
+     "shell.execute_reply": "2026-01-28T03:21:01.116763Z"
     }
    },
    "outputs": [],
@@ -25,10 +25,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-26T14:30:30.152247Z",
-     "iopub.status.busy": "2026-01-26T14:30:30.151399Z",
-     "iopub.status.idle": "2026-01-26T14:30:30.165328Z",
-     "shell.execute_reply": "2026-01-26T14:30:30.164200Z"
+     "iopub.execute_input": "2026-01-28T03:21:01.120033Z",
+     "iopub.status.busy": "2026-01-28T03:21:01.119007Z",
+     "iopub.status.idle": "2026-01-28T03:21:01.133471Z",
+     "shell.execute_reply": "2026-01-28T03:21:01.131905Z"
     }
    },
    "outputs": [],
@@ -48,10 +48,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-26T14:30:30.167083Z",
-     "iopub.status.busy": "2026-01-26T14:30:30.166538Z",
-     "iopub.status.idle": "2026-01-26T14:30:30.180559Z",
-     "shell.execute_reply": "2026-01-26T14:30:30.179384Z"
+     "iopub.execute_input": "2026-01-28T03:21:01.135270Z",
+     "iopub.status.busy": "2026-01-28T03:21:01.135270Z",
+     "iopub.status.idle": "2026-01-28T03:21:01.148453Z",
+     "shell.execute_reply": "2026-01-28T03:21:01.146851Z"
     }
    },
    "outputs": [],
@@ -68,10 +68,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-26T14:30:30.183493Z",
-     "iopub.status.busy": "2026-01-26T14:30:30.182927Z",
-     "iopub.status.idle": "2026-01-26T14:31:22.343327Z",
-     "shell.execute_reply": "2026-01-26T14:31:22.342327Z"
+     "iopub.execute_input": "2026-01-28T03:21:01.150036Z",
+     "iopub.status.busy": "2026-01-28T03:21:01.150036Z",
+     "iopub.status.idle": "2026-01-28T03:21:45.375343Z",
+     "shell.execute_reply": "2026-01-28T03:21:45.374343Z"
     }
    },
    "outputs": [],

--- a/experiments/Heart-GatedCT_To_USD/1-register_images.ipynb
+++ b/experiments/Heart-GatedCT_To_USD/1-register_images.ipynb
@@ -137,7 +137,7 @@
    },
    "outputs": [],
    "source": [
-    "for i in range(21):\n",
+    "for i in range(0, 21, 4):  # Process every 4th slice to save time testing\n",
     "    print(f\"Processing slice {i:03d}\")\n",
     "    moving_image = itk.imread(os.path.join(data_dir, f\"slice_{i:03d}.mha\"))\n",
     "    result = seg.segment(moving_image, contrast_enhanced_study=True)\n",

--- a/experiments/Heart-GatedCT_To_USD/2-generate_segmentation.ipynb
+++ b/experiments/Heart-GatedCT_To_USD/2-generate_segmentation.ipynb
@@ -39,7 +39,7 @@
    "outputs": [],
    "source": [
     "# When re-running, you can bypass certain long-running steps\n",
-    "re_run_image_max = False\n",
+    "re_run_image_max = True\n",
     "use_fixed_image = True\n",
     "re_run_image_segmentation = True"
    ]
@@ -74,7 +74,7 @@
     "    arr = itk.array_from_image(image)\n",
     "    print(arr.shape)\n",
     "    arr = np.where(arr == 0, -1000, arr)\n",
-    "    for i in range(1, 21):\n",
+    "    for i in range(4, 21, 4):  # Process every 4th to save time for testing\n",
     "        print(f\"Processing slice {i:03d}...\")\n",
     "        tmp_arr = itk.array_from_image(\n",
     "            itk.imread(\n",

--- a/experiments/Heart-GatedCT_To_USD/3-transform_dynamic_and_static_contours.ipynb
+++ b/experiments/Heart-GatedCT_To_USD/3-transform_dynamic_and_static_contours.ipynb
@@ -20,7 +20,7 @@
     "import pyvista as pv\n",
     "\n",
     "from physiomotion4d.contour_tools import ContourTools\n",
-    "from physiomotion4d.convert_vtk_4d_to_usd import ConvertVTK4DToUSD\n",
+    "from physiomotion4d.convert_vtk_to_usd import ConvertVTKToUSD\n",
     "from physiomotion4d.segment_chest_total_segmentator import SegmentChestTotalSegmentator\n",
     "from physiomotion4d.usd_anatomy_tools import USDAnatomyTools"
    ]
@@ -99,7 +99,7 @@
     "\n",
     "    polydata = [pv.read(f) for f in files]\n",
     "\n",
-    "    converter = ConvertVTK4DToUSD(\n",
+    "    converter = ConvertVTKToUSD(\n",
     "        project_name,\n",
     "        polydata,\n",
     "        all_mask_ids,\n",

--- a/experiments/Heart-GatedCT_To_USD/4-merge_dynamic_and_static_usd.ipynb
+++ b/experiments/Heart-GatedCT_To_USD/4-merge_dynamic_and_static_usd.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "3ce61753-11ad-4ade-9afe-6ad1bc748e25",
    "metadata": {
     "execution": {
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "4c0ece8e",
    "metadata": {
     "execution": {
@@ -31,26 +31,45 @@
      "shell.execute_reply": "2026-01-26T17:18:11.503440Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-01-28 13:47:29 INFO USDTools Copying /World to /World\n",
+      "2026-01-28 13:47:31 INFO USDTools Copying /World to /World\n",
+      "2026-01-28 13:47:31 INFO USDTools Set stage time range: 0.0 to 20.0\n",
+      "2026-01-28 13:47:31 INFO USDTools Time codes per second: 1.0, Frames per second: 24.0\n",
+      "2026-01-28 13:47:45 INFO USDTools Referencing files: 1/2 (50.0%)\n",
+      "2026-01-28 13:47:45 INFO USDTools Referencing files: 2/2 (100.0%)\n",
+      "2026-01-28 13:47:45 INFO USDTools Time range: 0.0 to 20.0\n",
+      "2026-01-28 13:47:45 INFO USDTools Time codes per second: 1.0, Frames per second: 24.0\n",
+      "2026-01-28 13:47:45 INFO USDTools Flattening composed stage...\n",
+      "2026-01-28 13:47:46 INFO USDTools Set output TimeCodesPerSecond: 1.0\n",
+      "2026-01-28 13:47:46 INFO USDTools Set output FramesPerSecond: 24.0\n",
+      "2026-01-28 13:47:46 INFO USDTools Exporting to results/Slicer_CardiacGatedCT.flattened_merged_painted.usd\n"
+     ]
+    }
+   ],
    "source": [
     "usd_tools = USDTools()\n",
     "\n",
-    "if os.path.exists(\"Slicer_CardiacGatedCT.merged_painted.usd\"):\n",
-    "    os.remove(\"Slicer_CardiacGatedCT.merged_painted.usd\")\n",
+    "if os.path.exists(\"results/Slicer_CardiacGatedCT.merged_painted.usd\"):\n",
+    "    os.remove(\"results/Slicer_CardiacGatedCT.merged_painted.usd\")\n",
     "\n",
     "usd_tools.merge_usd_files(\n",
-    "    \"Slicer_CardiacGatedCT.merged_painted.usd\",\n",
+    "    \"results/Slicer_CardiacGatedCT.merged_painted.usd\",\n",
     "    [\n",
     "        \"results/Slicer_CardiacGatedCT.dynamic_anatomy_painted.usd\",\n",
     "        \"results/Slicer_CardiacGatedCT.static_anatomy_painted.usd\",\n",
     "    ],\n",
     ")\n",
     "\n",
-    "if os.path.exists(\"Slicer_CardiacGatedCT.flattened_merged_painted.usd\"):\n",
-    "    os.remove(\"Slicer_CardiacGatedCT.flattened_merged_painted.usd\")\n",
+    "if os.path.exists(\"results/Slicer_CardiacGatedCT.flattened_merged_painted.usd\"):\n",
+    "    os.remove(\"results/Slicer_CardiacGatedCT.flattened_merged_painted.usd\")\n",
     "\n",
     "usd_tools.merge_usd_files_flattened(\n",
-    "    \"Slicer_CardiacGatedCT.flattened_merged_painted.usd\",\n",
+    "    \"results/Slicer_CardiacGatedCT.flattened_merged_painted.usd\",\n",
     "    [\n",
     "        \"results/Slicer_CardiacGatedCT.dynamic_anatomy_painted.usd\",\n",
     "        \"results/Slicer_CardiacGatedCT.static_anatomy_painted.usd\",\n",

--- a/experiments/Heart-Model_To_Patient/heart_model_to_model_icp_itk.ipynb
+++ b/experiments/Heart-Model_To_Patient/heart_model_to_model_icp_itk.ipynb
@@ -24,13 +24,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:09:00.698907Z",
-     "iopub.status.busy": "2026-01-25T23:09:00.698907Z",
-     "iopub.status.idle": "2026-01-25T23:09:16.021036Z",
-     "shell.execute_reply": "2026-01-25T23:09:16.021036Z"
+     "iopub.execute_input": "2026-01-28T04:53:53.742202Z",
+     "iopub.status.busy": "2026-01-28T04:53:53.742202Z",
+     "iopub.status.idle": "2026-01-28T04:54:10.211821Z",
+     "shell.execute_reply": "2026-01-28T04:54:10.210829Z"
     }
    },
    "outputs": [],
@@ -62,25 +62,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:09:16.024037Z",
-     "iopub.status.busy": "2026-01-25T23:09:16.024037Z",
-     "iopub.status.idle": "2026-01-25T23:09:16.037029Z",
-     "shell.execute_reply": "2026-01-25T23:09:16.036036Z"
+     "iopub.execute_input": "2026-01-28T04:54:10.213827Z",
+     "iopub.status.busy": "2026-01-28T04:54:10.213827Z",
+     "iopub.status.idle": "2026-01-28T04:54:10.226834Z",
+     "shell.execute_reply": "2026-01-28T04:54:10.225840Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Patient data: C:\\src\\Projects\\PhysioMotion\\physiomotion4d\\data\\Slicer-Heart-CT\n",
-      "Output directory: C:\\src\\Projects\\PhysioMotion\\physiomotion4d\\experiments\\Heart-Model_To_Patient\\results_icp_itk\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Patient CT image (defines coordinate frame)\n",
     "patient_data_dir = Path.cwd().parent.parent / \"data\" / \"Slicer-Heart-CT\"\n",
@@ -108,36 +99,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:09:16.050039Z",
-     "iopub.status.busy": "2026-01-25T23:09:16.050039Z",
-     "iopub.status.idle": "2026-01-25T23:09:21.428363Z",
-     "shell.execute_reply": "2026-01-25T23:09:21.427317Z"
+     "iopub.execute_input": "2026-01-28T04:54:10.242361Z",
+     "iopub.status.busy": "2026-01-28T04:54:10.242361Z",
+     "iopub.status.idle": "2026-01-28T04:54:15.606185Z",
+     "shell.execute_reply": "2026-01-28T04:54:15.605225Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading patient CT image...\n",
-      "  Original size: itkSize3 ([307, 234, 152])\n",
-      "  Original spacing: itkVectorD3 ([1, 1, 1])\n",
-      "Resampling to sotropic...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Resampled size: itkSize3 ([307, 234, 152])\n",
-      "  Resampled spacing: itkVectorD3 ([1, 1, 1])\n",
-      "✓ Saved preprocessed image\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load patient CT image\n",
     "print(\"Loading patient CT image...\")\n",
@@ -169,26 +140,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:09:21.431310Z",
-     "iopub.status.busy": "2026-01-25T23:09:21.430399Z",
-     "iopub.status.idle": "2026-01-25T23:09:21.458333Z",
-     "shell.execute_reply": "2026-01-25T23:09:21.457414Z"
+     "iopub.execute_input": "2026-01-28T04:54:15.608742Z",
+     "iopub.status.busy": "2026-01-28T04:54:15.608190Z",
+     "iopub.status.idle": "2026-01-28T04:54:15.636899Z",
+     "shell.execute_reply": "2026-01-28T04:54:15.636394Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading heart segmentation mask...\n",
-      "  Mask size: itkSize3 ([307, 234, 152])\n",
-      "  Mask spacing: itkVectorD3 ([1, 1, 1])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load heart segmentation mask\n",
     "print(\"Loading heart segmentation mask...\")\n",
@@ -200,34 +161,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:09:21.462105Z",
-     "iopub.status.busy": "2026-01-25T23:09:21.462105Z",
-     "iopub.status.idle": "2026-01-25T23:09:21.835879Z",
-     "shell.execute_reply": "2026-01-25T23:09:21.834871Z"
+     "iopub.execute_input": "2026-01-28T04:54:15.639140Z",
+     "iopub.status.busy": "2026-01-28T04:54:15.639140Z",
+     "iopub.status.idle": "2026-01-28T04:54:15.983405Z",
+     "shell.execute_reply": "2026-01-28T04:54:15.982901Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Flipping image axes: True, True, False\n",
-      "✓ Images flipped to standard orientation\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword\n",
-      "__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword\n",
-      "__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Handle image orientation (flip if needed)\n",
     "flip0 = np.array(patient_image.GetDirection())[0, 0] < 0\n",
@@ -277,13 +220,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:09:21.837561Z",
-     "iopub.status.busy": "2026-01-25T23:09:21.837561Z",
-     "iopub.status.idle": "2026-01-25T23:09:22.292278Z",
-     "shell.execute_reply": "2026-01-25T23:09:22.291393Z"
+     "iopub.execute_input": "2026-01-28T04:54:15.985490Z",
+     "iopub.status.busy": "2026-01-28T04:54:15.985490Z",
+     "iopub.status.idle": "2026-01-28T04:54:16.485426Z",
+     "shell.execute_reply": "2026-01-28T04:54:16.484217Z"
     }
    },
    "outputs": [],
@@ -309,271 +252,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:09:22.295578Z",
-     "iopub.status.busy": "2026-01-25T23:09:22.295578Z",
-     "iopub.status.idle": "2026-01-25T23:13:38.482697Z",
-     "shell.execute_reply": "2026-01-25T23:13:38.481766Z"
+     "iopub.execute_input": "2026-01-28T04:54:16.487035Z",
+     "iopub.status.busy": "2026-01-28T04:54:16.487035Z",
+     "iopub.status.idle": "2026-01-28T04:58:37.962064Z",
+     "shell.execute_reply": "2026-01-28T04:58:37.961151Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading template heart model...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:31 INFO RegisterModelsICPITK ============================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:31 INFO RegisterModelsICPITK Affine Alignment Optimization\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:31 INFO RegisterModelsICPITK ============================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:31 INFO RegisterModelsICPITK No initial transform provided, performing centroid alignment...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:31 INFO RegisterModelsICPITK Initial parameters: [0.0, 0.0, 0.0, 648.7824535369873, 318.64792823791504, 960.5810470581055, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:31 INFO RegisterModelsICPITK Running optimization...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:31 INFO ContourTools Computing signed distance map...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:34 INFO RegisterModelsICPITK Converting mean shape points to ITK format...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:35 INFO RegisterModelsICPITK   Converted 167240 points to ITK format\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:35 INFO RegisterModelsICPITK    Metric 1: [641.31301971 314.62561106 970.95681231] -> 3.884600\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:09:50 INFO RegisterModelsICPITK    Metric 101: [641.58328949 314.82410161 970.47025035] -> 2.238399\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:10:06 INFO RegisterModelsICPITK    Metric 201: [641.60052126 314.79611158 970.38649148] -> 2.235116\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:10:21 INFO RegisterModelsICPITK    Metric 301: [641.62418337 314.77059305 970.30868317] -> 2.232240\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:10:36 INFO RegisterModelsICPITK    Metric 401: [641.77718166 313.41736318 968.48497062] -> 2.182409\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:10:52 INFO RegisterModelsICPITK    Metric 501: [641.86681087 313.26290034 968.27102602] -> 2.172417\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:11:07 INFO RegisterModelsICPITK    Metric 601: [641.88556329 313.258099   968.22524218] -> 2.171990\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:11:22 INFO RegisterModelsICPITK    Metric 701: [643.15658233 313.66718773 967.2753677 ] -> 2.154397\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:11:38 INFO RegisterModelsICPITK    Metric 801: [643.63558306 313.86258881 966.92913852] -> 2.140129\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:11:53 INFO RegisterModelsICPITK    Metric 901: [643.58995057 313.85676589 966.98945433] -> 2.140036\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:12:08 INFO RegisterModelsICPITK    Metric 1001: [643.60783311 313.87001701 966.98468263] -> 2.140001\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:12:23 INFO RegisterModelsICPITK    Metric 1101: [643.61164338 313.87484702 966.98608804] -> 2.139996\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:12:39 INFO RegisterModelsICPITK    Metric 1201: [643.62369701 313.87324301 966.96793353] -> 2.139987\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:12:54 INFO RegisterModelsICPITK    Metric 1301: [643.62741875 313.87414872 966.96379748] -> 2.139981\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:13:09 INFO RegisterModelsICPITK    Metric 1401: [643.62736594 313.87479995 966.96469609] -> 2.139981\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:13:25 INFO RegisterModelsICPITK    Metric 1501: [643.6272554  313.87604443 966.96529938] -> 2.139980\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:13:36 INFO RegisterModelsICPITK Optimization result: [-8.14300322e-02 -3.37112552e-02  5.60658146e-02  6.50784042e+02\n",
-      "  3.17801530e+02  9.56867714e+02  9.30311950e-01  8.66344398e-01\n",
-      "  8.00000000e-01 -3.00000000e-02 -2.21845401e-02  1.57768164e-02] -> 2.139976\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:13:37 INFO RegisterModelsICPITK Optimization completed!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:13:37 INFO RegisterModelsICPITK Final parameters: [-8.14300322e-02 -3.37112552e-02  5.60658146e-02  6.50784042e+02\n",
-      "  3.17801530e+02  9.56867714e+02  9.30311950e-01  8.66344398e-01\n",
-      "  8.00000000e-01 -3.00000000e-02 -2.21845401e-02  1.57768164e-02]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:13:37 INFO RegisterModelsICPITK Final mean distance: 2.14\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "✓ ICP affine registration complete\n",
-      "   Transform = ComposeScaleSkewVersor3DTransform (0000027D9E4A1EE0)\n",
-      "  RTTI typeinfo:   class itk::ComposeScaleSkewVersor3DTransform<double>\n",
-      "  Reference Count: 1\n",
-      "  Modified Time: 6414\n",
-      "  Debug: Off\n",
-      "  Object Name: \n",
-      "  Observers: \n",
-      "    none\n",
-      "  Matrix: \n",
-      "    0.922349 -0.119527 -0.0828587 \n",
-      "    0.108854 0.846143 0.137537 \n",
-      "    0.0538863 -0.145213 0.784111 \n",
-      "  Offset: [650.784, 317.802, 956.868]\n",
-      "  Center: [0, 0, 0]\n",
-      "  Translation: [650.784, 317.802, 956.868]\n",
-      "  Inverse: \n",
-      "    1.05997 0.164018 0.0832395 \n",
-      "    -0.120883 1.12859 -0.210735 \n",
-      "    -0.0952307 0.197736 1.23058 \n",
-      "  Singular: 0\n",
-      "  Versor: [ -0.08143, -0.0337113, 0.0560658, 0.99453 ]\n",
-      "  Scale:       [0.930312, 0.866344, 0.8]\n",
-      "  Skew:        [-0.03, -0.0221845, 0.0157768]\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Saved ICP-aligned model surface\n",
-      "  Saved ICP transform\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load the pca model\n",
     "print(\"Loading template heart model...\")\n",
@@ -612,25 +300,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:13:38.484553Z",
-     "iopub.status.busy": "2026-01-25T23:13:38.484553Z",
-     "iopub.status.idle": "2026-01-25T23:13:42.313976Z",
-     "shell.execute_reply": "2026-01-25T23:13:42.313140Z"
+     "iopub.execute_input": "2026-01-28T04:58:37.964061Z",
+     "iopub.status.busy": "2026-01-28T04:58:37.964061Z",
+     "iopub.status.idle": "2026-01-28T04:58:41.925393Z",
+     "shell.execute_reply": "2026-01-28T04:58:41.924315Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "✓ Applied ICP transform to full model mesh\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Apply ICP transform to the full average mesh (not just surface)\n",
     "# This gets the volumetric mesh into patient space for PCA registration\n",
@@ -651,31 +330,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:13:42.315746Z",
-     "iopub.status.busy": "2026-01-25T23:13:42.315746Z",
-     "iopub.status.idle": "2026-01-25T23:13:44.483254Z",
-     "shell.execute_reply": "2026-01-25T23:13:44.481923Z"
+     "iopub.execute_input": "2026-01-28T04:58:41.927133Z",
+     "iopub.status.busy": "2026-01-28T04:58:41.927133Z",
+     "iopub.status.idle": "2026-01-28T04:58:44.346432Z",
+     "shell.execute_reply": "2026-01-28T04:58:44.345436Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "27d6263ff5274a07b8a21dc0882f6354",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:49390/index.html?ui=P_0x27db368d960_0&reconnect=auto\" class=\"pyvis…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create side-by-side comparison\n",
     "plotter = pv.Plotter(window_size=[600, 600])\n",
@@ -712,7 +376,7 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "27d6263ff5274a07b8a21dc0882f6354": {
+     "5652c700abd24c5ba4fd978202aa93d0": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLModel",
@@ -727,15 +391,15 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_49bd60e132c9432180cf9963dec32fe7",
+       "layout": "IPY_MODEL_b1d4b84b44c141cbbb4e543180e75873",
        "placeholder": "​",
-       "style": "IPY_MODEL_4166c7a4967946a882518eb6952f2df8",
+       "style": "IPY_MODEL_7f099bbf876a4689bb37f515331a40db",
        "tabbable": null,
        "tooltip": null,
-       "value": "<iframe src=\"http://localhost:49390/index.html?ui=P_0x27db368d960_0&reconnect=auto\" class=\"pyvista\" style=\"width: 600px; height: 600px; border: 1px solid rgb(221,221,221);\"></iframe>"
+       "value": "<iframe src=\"http://localhost:64733/index.html?ui=P_0x24532d69270_0&reconnect=auto\" class=\"pyvista\" style=\"width: 600px; height: 600px; border: 1px solid rgb(221,221,221);\"></iframe>"
       }
      },
-     "4166c7a4967946a882518eb6952f2df8": {
+     "7f099bbf876a4689bb37f515331a40db": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -753,7 +417,7 @@
        "text_color": null
       }
      },
-     "49bd60e132c9432180cf9963dec32fe7": {
+     "b1d4b84b44c141cbbb4e543180e75873": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",

--- a/experiments/Heart-Model_To_Patient/heart_model_to_model_registration_pca.ipynb
+++ b/experiments/Heart-Model_To_Patient/heart_model_to_model_registration_pca.ipynb
@@ -25,13 +25,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:13:49.929346Z",
-     "iopub.status.busy": "2026-01-25T23:13:49.929346Z",
-     "iopub.status.idle": "2026-01-25T23:14:05.275944Z",
-     "shell.execute_reply": "2026-01-25T23:14:05.274950Z"
+     "iopub.execute_input": "2026-01-28T04:58:51.452983Z",
+     "iopub.status.busy": "2026-01-28T04:58:51.452983Z",
+     "iopub.status.idle": "2026-01-28T04:59:07.507777Z",
+     "shell.execute_reply": "2026-01-28T04:59:07.506545Z"
     }
    },
    "outputs": [],
@@ -64,26 +64,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:14:05.277943Z",
-     "iopub.status.busy": "2026-01-25T23:14:05.276943Z",
-     "iopub.status.idle": "2026-01-25T23:14:05.290946Z",
-     "shell.execute_reply": "2026-01-25T23:14:05.289946Z"
+     "iopub.execute_input": "2026-01-28T04:59:07.510391Z",
+     "iopub.status.busy": "2026-01-28T04:59:07.509377Z",
+     "iopub.status.idle": "2026-01-28T04:59:07.522327Z",
+     "shell.execute_reply": "2026-01-28T04:59:07.521437Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Patient data: C:\\src\\Projects\\PhysioMotion\\physiomotion4d\\data\\Slicer-Heart-CT\n",
-      "PCA Model data: C:\\src\\Projects\\PhysioMotion\\physiomotion4d\\data\\KCL-Heart-Model\\pca\n",
-      "Output directory: C:\\src\\Projects\\PhysioMotion\\physiomotion4d\\experiments\\Heart-Model_To_Patient\\results_pca\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Patient CT image (defines coordinate frame)\n",
     "patient_data_dir = Path.cwd().parent.parent / \"data\" / \"Slicer-Heart-CT\"\n",
@@ -118,36 +108,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:14:05.303040Z",
-     "iopub.status.busy": "2026-01-25T23:14:05.303040Z",
-     "iopub.status.idle": "2026-01-25T23:14:10.491095Z",
-     "shell.execute_reply": "2026-01-25T23:14:10.490082Z"
+     "iopub.execute_input": "2026-01-28T04:59:07.536643Z",
+     "iopub.status.busy": "2026-01-28T04:59:07.536227Z",
+     "iopub.status.idle": "2026-01-28T04:59:12.862400Z",
+     "shell.execute_reply": "2026-01-28T04:59:12.861388Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading patient CT image...\n",
-      "  Original size: itkSize3 ([307, 234, 152])\n",
-      "  Original spacing: itkVectorD3 ([1, 1, 1])\n",
-      "Resampling to sotropic...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Resampled size: itkSize3 ([307, 234, 152])\n",
-      "  Resampled spacing: itkVectorD3 ([1, 1, 1])\n",
-      "✓ Saved preprocessed image\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load patient CT image\n",
     "print(\"Loading patient CT image...\")\n",
@@ -179,26 +149,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:14:10.493230Z",
-     "iopub.status.busy": "2026-01-25T23:14:10.493230Z",
-     "iopub.status.idle": "2026-01-25T23:14:10.521857Z",
-     "shell.execute_reply": "2026-01-25T23:14:10.520614Z"
+     "iopub.execute_input": "2026-01-28T04:59:12.864413Z",
+     "iopub.status.busy": "2026-01-28T04:59:12.863405Z",
+     "iopub.status.idle": "2026-01-28T04:59:12.893198Z",
+     "shell.execute_reply": "2026-01-28T04:59:12.892189Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading heart segmentation mask...\n",
-      "  Mask size: itkSize3 ([307, 234, 152])\n",
-      "  Mask spacing: itkVectorD3 ([1, 1, 1])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load heart segmentation mask\n",
     "print(\"Loading heart segmentation mask...\")\n",
@@ -210,34 +170,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:14:10.523769Z",
-     "iopub.status.busy": "2026-01-25T23:14:10.523769Z",
-     "iopub.status.idle": "2026-01-25T23:14:10.869642Z",
-     "shell.execute_reply": "2026-01-25T23:14:10.868649Z"
+     "iopub.execute_input": "2026-01-28T04:59:12.895205Z",
+     "iopub.status.busy": "2026-01-28T04:59:12.895205Z",
+     "iopub.status.idle": "2026-01-28T04:59:13.240466Z",
+     "shell.execute_reply": "2026-01-28T04:59:13.239436Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Flipping image axes: True, True, False\n",
-      "✓ Images flipped to standard orientation\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword\n",
-      "__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword\n",
-      "__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Handle image orientation (flip if needed)\n",
     "flip0 = np.array(patient_heart_mask_image.GetDirection())[0, 0] < 0\n",
@@ -287,13 +229,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:14:10.872641Z",
-     "iopub.status.busy": "2026-01-25T23:14:10.872641Z",
-     "iopub.status.idle": "2026-01-25T23:14:11.351318Z",
-     "shell.execute_reply": "2026-01-25T23:14:11.350400Z"
+     "iopub.execute_input": "2026-01-28T04:59:13.242448Z",
+     "iopub.status.busy": "2026-01-28T04:59:13.242448Z",
+     "iopub.status.idle": "2026-01-28T04:59:13.709334Z",
+     "shell.execute_reply": "2026-01-28T04:59:13.708342Z"
     }
    },
    "outputs": [],
@@ -319,117 +261,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:14:11.353420Z",
-     "iopub.status.busy": "2026-01-25T23:14:11.353420Z",
-     "iopub.status.idle": "2026-01-25T23:14:39.267588Z",
-     "shell.execute_reply": "2026-01-25T23:14:39.266062Z"
+     "iopub.execute_input": "2026-01-28T04:59:13.711338Z",
+     "iopub.status.busy": "2026-01-28T04:59:13.711338Z",
+     "iopub.status.idle": "2026-01-28T04:59:41.708720Z",
+     "shell.execute_reply": "2026-01-28T04:59:41.707726Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading PCA heart model...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:20 INFO RegisterModelsICP ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:20 INFO RegisterModelsICP AFFINE ICP Alignment\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:20 INFO RegisterModelsICP ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:20 INFO RegisterModelsICP Step 1: Translating by [648.62508965 318.68302345 962.48420525] to align centroids...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Template surface: 167240 points\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:22 INFO RegisterModelsICP Step 2: Performing rigid ICP (max iterations: 2000)...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:31 INFO RegisterModelsICP Step 3: Performing affine ICP (max iterations: 2000)...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:38 INFO RegisterModelsICP AFFINE ICP registration complete!\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "✓ ICP affine registration complete\n",
-      "   Transform = AffineTransform (000001751E2376E0)\n",
-      "  RTTI typeinfo:   class itk::AffineTransform<double,3>\n",
-      "  Reference Count: 1\n",
-      "  Modified Time: 1622\n",
-      "  Debug: Off\n",
-      "  Object Name: \n",
-      "  Observers: \n",
-      "    none\n",
-      "  Matrix: \n",
-      "    0.987866 -0.0938189 -0.132732 \n",
-      "    0.0351459 0.871548 0.0948309 \n",
-      "    0.0471311 -0.0327586 0.795693 \n",
-      "  Offset: [648.613, 318.376, 960.745]\n",
-      "  Center: [0, 0, 0]\n",
-      "  Translation: [648.613, 318.376, 960.745]\n",
-      "  Inverse: \n",
-      "    1.00092 0.113513 0.153439 \n",
-      "    -0.0337609 1.13844 -0.141311 \n",
-      "    -0.0606774 0.0401457 1.24186 \n",
-      "  Singular: 0\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Saved ICP-aligned model surface\n",
-      "  Saved ICP transform\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load the pca model\n",
     "print(\"Loading PCA heart model...\")\n",
@@ -465,25 +306,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:14:39.269849Z",
-     "iopub.status.busy": "2026-01-25T23:14:39.269849Z",
-     "iopub.status.idle": "2026-01-25T23:14:43.107136Z",
-     "shell.execute_reply": "2026-01-25T23:14:43.106149Z"
+     "iopub.execute_input": "2026-01-28T04:59:41.710720Z",
+     "iopub.status.busy": "2026-01-28T04:59:41.710720Z",
+     "iopub.status.idle": "2026-01-28T04:59:45.590398Z",
+     "shell.execute_reply": "2026-01-28T04:59:45.589453Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "✓ Applied ICP transform to full model mesh\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Apply ICP transform to the full average mesh (not just surface)\n",
     "# This gets the volumetric mesh into patient space for PCA registration\n",
@@ -504,111 +336,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:14:43.108216Z",
-     "iopub.status.busy": "2026-01-25T23:14:43.108216Z",
-     "iopub.status.idle": "2026-01-25T23:14:53.267323Z",
-     "shell.execute_reply": "2026-01-25T23:14:53.266322Z"
+     "iopub.execute_input": "2026-01-28T04:59:45.591907Z",
+     "iopub.status.busy": "2026-01-28T04:59:45.591907Z",
+     "iopub.status.idle": "2026-01-28T04:59:55.952578Z",
+     "shell.execute_reply": "2026-01-28T04:59:55.951525Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:43 INFO Loading PCA data from SlicerSALT format...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:43 INFO   JSON file: C:\\src\\Projects\\PhysioMotion\\physiomotion4d\\data\\KCL-Heart-Model\\pca\\pca.json\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:43 INFO   Group key: All\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:43 INFO Reading JSON file...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:49 INFO   Loaded 20 standard deviations\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:49 INFO   Loaded pca_eigenvectors with shape (20, 501720)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:49 INFO   ✓ Data validation successful!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:49 INFO SlicerSALT PCA data loaded successfully!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:49 INFO ContourTools Computing signed distance map...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:52 INFO RegisterModelsPCA Converting mean shape points to ITK format...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA   Converted 167240 points to ITK format\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✓ PCA registrar initialized\n",
-      "  Using ICP-aligned mesh as starting point\n",
-      "  Number of points: 167240\n",
-      "  Number of PCA modes: 10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "## Initialize PCA Registration\n",
     "print(\"=\" * 70)\n",
@@ -643,265 +380,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:14:53.269317Z",
-     "iopub.status.busy": "2026-01-25T23:14:53.269317Z",
-     "iopub.status.idle": "2026-01-25T23:16:01.292383Z",
-     "shell.execute_reply": "2026-01-25T23:16:01.291470Z"
+     "iopub.execute_input": "2026-01-28T04:59:55.955305Z",
+     "iopub.status.busy": "2026-01-28T04:59:55.955305Z",
+     "iopub.status.idle": "2026-01-28T05:01:06.260685Z",
+     "shell.execute_reply": "2026-01-28T05:01:06.259363Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA PCA-BASED MODEL-TO-IMAGE REGISTRATION\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA Number of points: 167240\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA Modes to use: 10\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA Number of PCA modes: 10\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA PCA coefficient bounds: ±3.0 std deviations\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA Optimization method: L-BFGS-B\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA Max iterations: 50\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA Running optimization...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "======================================================================\n",
-      "PCA-BASED SHAPE OPTIMIZATION\n",
-      "======================================================================\n",
-      "\n",
-      "Running complete PCA registration pipeline...\n",
-      "  (Starting from ICP-aligned mesh)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA    Metric 1: [593.01240769 333.90696725 949.69421552] -> 1.441956\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:14:53 INFO RegisterModelsPCA        Params [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:14 INFO RegisterModelsPCA    Metric 101: [594.15839096 334.06816475 950.34479732] -> 0.583731\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:14 INFO RegisterModelsPCA        Params [-0.08501075  0.50888893  0.32244617  0.89410169 -0.493096   -0.4215842\n",
-      "  1.89489911  0.72931129  0.07801494  0.53128607]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:35 INFO RegisterModelsPCA    Metric 201: [594.15273778 334.06106884 950.3432304 ] -> 0.583472\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:35 INFO RegisterModelsPCA        Params [-0.08462336  0.50410698  0.32624994  0.87993223 -0.48942946 -0.40500646\n",
-      "  1.8892027   0.75056334  0.06835057  0.55045798]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:51 INFO RegisterModelsPCA Optimization completed!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:51 INFO RegisterModelsPCA Optimized PCA coefficients: [-0.08458345  0.5042206   0.32643991  0.88003898 -0.48936161 -0.40511381\n",
-      "  1.88942977  0.7505073   0.06830632  0.55040812]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:51 INFO RegisterModelsPCA Final mean intensity: 0.58\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:51 INFO RegisterModelsPCA Creating final registered model...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:51 INFO RegisterModelsPCA Transforming points: 1/167240 (0.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:52 INFO RegisterModelsPCA Transforming points: 16725/167240 (10.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:53 INFO RegisterModelsPCA Transforming points: 33449/167240 (20.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:54 INFO RegisterModelsPCA Transforming points: 50173/167240 (30.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:55 INFO RegisterModelsPCA Transforming points: 66897/167240 (40.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:56 INFO RegisterModelsPCA Transforming points: 83621/167240 (50.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:57 INFO RegisterModelsPCA Transforming points: 100345/167240 (60.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:58 INFO RegisterModelsPCA Transforming points: 117069/167240 (70.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:15:59 INFO RegisterModelsPCA Transforming points: 133793/167240 (80.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:00 INFO RegisterModelsPCA Transforming points: 150517/167240 (90.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:01 INFO RegisterModelsPCA Transforming points: 167240/167240 (100.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:01 INFO RegisterModelsPCA Registered model created with 167240 points\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "✓ PCA registration complete\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"\\n\" + \"=\" * 70)\n",
     "print(\"PCA-BASED SHAPE OPTIMIZATION\")\n",
@@ -929,44 +417,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:01.294477Z",
-     "iopub.status.busy": "2026-01-25T23:16:01.294477Z",
-     "iopub.status.idle": "2026-01-25T23:16:01.307479Z",
-     "shell.execute_reply": "2026-01-25T23:16:01.306420Z"
+     "iopub.execute_input": "2026-01-28T05:01:06.262391Z",
+     "iopub.status.busy": "2026-01-28T05:01:06.261826Z",
+     "iopub.status.idle": "2026-01-28T05:01:06.274944Z",
+     "shell.execute_reply": "2026-01-28T05:01:06.274440Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "======================================================================\n",
-      "REGISTRATION RESULTS\n",
-      "======================================================================\n",
-      "\n",
-      "Final Registration Metrics:\n",
-      "  Final mean intensity: 0.5835\n",
-      "\n",
-      "Optimized PCA Coefficients (in units of std deviations):\n",
-      "  Mode  1: -0.0846\n",
-      "  Mode  2:  0.5042\n",
-      "  Mode  3:  0.3264\n",
-      "  Mode  4:  0.8800\n",
-      "  Mode  5: -0.4894\n",
-      "  Mode  6: -0.4051\n",
-      "  Mode  7:  1.8894\n",
-      "  Mode  8:  0.7505\n",
-      "  Mode  9:  0.0683\n",
-      "  Mode 10:  0.5504\n",
-      "\n",
-      "✓ Registration pipeline complete!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"\\n\" + \"=\" * 70)\n",
     "print(\"REGISTRATION RESULTS\")\n",
@@ -992,39 +452,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:01.309476Z",
-     "iopub.status.busy": "2026-01-25T23:16:01.309476Z",
-     "iopub.status.idle": "2026-01-25T23:16:01.534746Z",
-     "shell.execute_reply": "2026-01-25T23:16:01.533728Z"
+     "iopub.execute_input": "2026-01-28T05:01:06.276609Z",
+     "iopub.status.busy": "2026-01-28T05:01:06.276609Z",
+     "iopub.status.idle": "2026-01-28T05:01:06.545574Z",
+     "shell.execute_reply": "2026-01-28T05:01:06.544204Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Saving results...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Saved final PCA-registered mesh\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Saved PCA coefficients\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"\\nSaving results...\")\n",
     "\n",
@@ -1050,31 +487,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:01.536716Z",
-     "iopub.status.busy": "2026-01-25T23:16:01.535727Z",
-     "iopub.status.idle": "2026-01-25T23:16:03.985515Z",
-     "shell.execute_reply": "2026-01-25T23:16:03.984423Z"
+     "iopub.execute_input": "2026-01-28T05:01:06.549117Z",
+     "iopub.status.busy": "2026-01-28T05:01:06.548567Z",
+     "iopub.status.idle": "2026-01-28T05:01:08.798687Z",
+     "shell.execute_reply": "2026-01-28T05:01:08.797605Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "016284dce50f48549e29976e01a8a42f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:65356/index.html?ui=P_0x1753686ac20_0&reconnect=auto\" class=\"pyvis…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create side-by-side comparison\n",
     "plotter = pv.Plotter(shape=(1, 2), window_size=[1000, 600])\n",
@@ -1122,30 +544,7 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "016284dce50f48549e29976e01a8a42f": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_19f0141373f845739dcbe0fdbbca35f6",
-       "placeholder": "​",
-       "style": "IPY_MODEL_834246bf5bff44cf81418e00f6a00925",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "<iframe src=\"http://localhost:65356/index.html?ui=P_0x1753686ac20_0&reconnect=auto\" class=\"pyvista\" style=\"width: 1000px; height: 600px; border: 1px solid rgb(221,221,221);\"></iframe>"
-      }
-     },
-     "19f0141373f845739dcbe0fdbbca35f6": {
+     "3f6e61466def44298a2fc538775464f5": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1198,7 +597,7 @@
        "width": null
       }
      },
-     "834246bf5bff44cf81418e00f6a00925": {
+     "ae666f4536a34d4b803b08ac02261a2b": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -1214,6 +613,29 @@
        "description_width": "",
        "font_size": null,
        "text_color": null
+      }
+     },
+     "ecadb909a1de4dd4abc239c7b312c969": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_3f6e61466def44298a2fc538775464f5",
+       "placeholder": "​",
+       "style": "IPY_MODEL_ae666f4536a34d4b803b08ac02261a2b",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "<iframe src=\"http://localhost:62435/index.html?ui=P_0x2a1b687afb0_0&reconnect=auto\" class=\"pyvista\" style=\"width: 1000px; height: 600px; border: 1px solid rgb(221,221,221);\"></iframe>"
       }
      }
     },

--- a/experiments/Heart-Model_To_Patient/heart_model_to_patient.ipynb
+++ b/experiments/Heart-Model_To_Patient/heart_model_to_patient.ipynb
@@ -9,13 +9,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:12.259076Z",
-     "iopub.status.busy": "2026-01-25T23:16:12.259076Z",
-     "iopub.status.idle": "2026-01-25T23:16:28.538425Z",
-     "shell.execute_reply": "2026-01-25T23:16:28.537058Z"
+     "iopub.execute_input": "2026-01-28T05:01:15.881411Z",
+     "iopub.status.busy": "2026-01-28T05:01:15.881411Z",
+     "iopub.status.idle": "2026-01-28T05:01:31.910491Z",
+     "shell.execute_reply": "2026-01-28T05:01:31.909641Z"
     }
    },
    "outputs": [],
@@ -44,13 +44,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:28.540433Z",
-     "iopub.status.busy": "2026-01-25T23:16:28.540433Z",
-     "iopub.status.idle": "2026-01-25T23:16:28.552636Z",
-     "shell.execute_reply": "2026-01-25T23:16:28.551770Z"
+     "iopub.execute_input": "2026-01-28T05:01:31.912529Z",
+     "iopub.status.busy": "2026-01-28T05:01:31.912529Z",
+     "iopub.status.idle": "2026-01-28T05:01:31.925486Z",
+     "shell.execute_reply": "2026-01-28T05:01:31.924541Z"
     }
    },
    "outputs": [],
@@ -78,13 +78,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:28.554292Z",
-     "iopub.status.busy": "2026-01-25T23:16:28.554292Z",
-     "iopub.status.idle": "2026-01-25T23:16:29.008200Z",
-     "shell.execute_reply": "2026-01-25T23:16:29.006856Z"
+     "iopub.execute_input": "2026-01-28T05:01:31.927533Z",
+     "iopub.status.busy": "2026-01-28T05:01:31.927533Z",
+     "iopub.status.idle": "2026-01-28T05:01:32.377510Z",
+     "shell.execute_reply": "2026-01-28T05:01:32.376511Z"
     }
    },
    "outputs": [],
@@ -95,13 +95,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:29.009776Z",
-     "iopub.status.busy": "2026-01-25T23:16:29.009776Z",
-     "iopub.status.idle": "2026-01-25T23:16:29.037827Z",
-     "shell.execute_reply": "2026-01-25T23:16:29.036781Z"
+     "iopub.execute_input": "2026-01-28T05:01:32.379493Z",
+     "iopub.status.busy": "2026-01-28T05:01:32.379493Z",
+     "iopub.status.idle": "2026-01-28T05:01:32.408082Z",
+     "shell.execute_reply": "2026-01-28T05:01:32.407029Z"
     }
    },
    "outputs": [],
@@ -142,41 +142,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:29.040575Z",
-     "iopub.status.busy": "2026-01-25T23:16:29.039817Z",
-     "iopub.status.idle": "2026-01-25T23:16:29.368847Z",
-     "shell.execute_reply": "2026-01-25T23:16:29.367847Z"
+     "iopub.execute_input": "2026-01-28T05:01:32.410091Z",
+     "iopub.status.busy": "2026-01-28T05:01:32.410091Z",
+     "iopub.status.idle": "2026-01-28T05:01:32.754828Z",
+     "shell.execute_reply": "2026-01-28T05:01:32.753925Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword\n",
-      "__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword\n",
-      "__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Flipping patient image...\n",
-      "True True False\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Flipping patient mask image...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "flip0 = np.array(patient_mask.GetDirection())[0, 0] < 0\n",
     "flip1 = np.array(patient_mask.GetDirection())[1, 1] < 0\n",
@@ -205,13 +180,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:29.386194Z",
-     "iopub.status.busy": "2026-01-25T23:16:29.385222Z",
-     "iopub.status.idle": "2026-01-25T23:16:40.604493Z",
-     "shell.execute_reply": "2026-01-25T23:16:40.603581Z"
+     "iopub.execute_input": "2026-01-28T05:01:32.756828Z",
+     "iopub.status.busy": "2026-01-28T05:01:32.756828Z",
+     "iopub.status.idle": "2026-01-28T05:01:44.256331Z",
+     "shell.execute_reply": "2026-01-28T05:01:44.255302Z"
     }
    },
    "outputs": [],
@@ -229,13 +204,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:40.607487Z",
-     "iopub.status.busy": "2026-01-25T23:16:40.607487Z",
-     "iopub.status.idle": "2026-01-25T23:16:47.372579Z",
-     "shell.execute_reply": "2026-01-25T23:16:47.371666Z"
+     "iopub.execute_input": "2026-01-28T05:01:44.259221Z",
+     "iopub.status.busy": "2026-01-28T05:01:44.259221Z",
+     "iopub.status.idle": "2026-01-28T05:01:51.224517Z",
+     "shell.execute_reply": "2026-01-28T05:01:51.223247Z"
     }
    },
    "outputs": [],
@@ -264,252 +239,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:16:47.374627Z",
-     "iopub.status.busy": "2026-01-25T23:16:47.374627Z",
-     "iopub.status.idle": "2026-01-25T23:20:54.103579Z",
-     "shell.execute_reply": "2026-01-25T23:20:54.102568Z"
+     "iopub.execute_input": "2026-01-28T05:01:51.226530Z",
+     "iopub.status.busy": "2026-01-28T05:01:51.226530Z",
+     "iopub.status.idle": "2026-01-28T05:06:05.306555Z",
+     "shell.execute_reply": "2026-01-28T05:06:05.305412Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:47 INFO WorkflowRegisterHeartModelToPatient ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:47 INFO WorkflowRegisterHeartModelToPatient Stage 1: ICP Alignment (RegisterModelsICP)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:47 INFO WorkflowRegisterHeartModelToPatient ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:47 INFO RegisterModelsICPITK ============================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:47 INFO RegisterModelsICPITK Affine Alignment Optimization\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:47 INFO RegisterModelsICPITK ============================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:47 INFO RegisterModelsICPITK No initial transform provided, performing centroid alignment...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:47 INFO RegisterModelsICPITK Initial parameters: [0.0, 0.0, 0.0, 648.7824535369873, 318.64792823791504, 960.5810470581055, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:47 INFO RegisterModelsICPITK Running optimization...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:47 INFO ContourTools Computing signed distance map...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:50 INFO RegisterModelsICPITK Converting mean shape points to ITK format...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:51 INFO RegisterModelsICPITK   Converted 167240 points to ITK format\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:16:51 INFO RegisterModelsICPITK    Metric 1: [641.31301971 314.62561106 970.95681231] -> 3.884600\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:17:06 INFO RegisterModelsICPITK    Metric 101: [641.58328949 314.82410161 970.47025035] -> 2.238399\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:17:21 INFO RegisterModelsICPITK    Metric 201: [641.60052126 314.79611158 970.38649148] -> 2.235116\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:17:37 INFO RegisterModelsICPITK    Metric 301: [641.62418337 314.77059305 970.30868317] -> 2.232240\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:17:52 INFO RegisterModelsICPITK    Metric 401: [641.77718166 313.41736318 968.48497062] -> 2.182409\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:18:08 INFO RegisterModelsICPITK    Metric 501: [641.86681087 313.26290034 968.27102602] -> 2.172417\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:18:23 INFO RegisterModelsICPITK    Metric 601: [641.88556329 313.258099   968.22524218] -> 2.171990\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:18:38 INFO RegisterModelsICPITK    Metric 701: [643.15658233 313.66718773 967.2753677 ] -> 2.154397\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:18:53 INFO RegisterModelsICPITK    Metric 801: [643.63558306 313.86258881 966.92913852] -> 2.140129\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:19:09 INFO RegisterModelsICPITK    Metric 901: [643.58995057 313.85676589 966.98945433] -> 2.140036\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:19:24 INFO RegisterModelsICPITK    Metric 1001: [643.60783311 313.87001701 966.98468263] -> 2.140001\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:19:39 INFO RegisterModelsICPITK    Metric 1101: [643.61164338 313.87484702 966.98608804] -> 2.139996\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:19:54 INFO RegisterModelsICPITK    Metric 1201: [643.62369701 313.87324301 966.96793353] -> 2.139987\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:10 INFO RegisterModelsICPITK    Metric 1301: [643.62741875 313.87414872 966.96379748] -> 2.139981\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:25 INFO RegisterModelsICPITK    Metric 1401: [643.62736594 313.87479995 966.96469609] -> 2.139981\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:40 INFO RegisterModelsICPITK    Metric 1501: [643.6272554  313.87604443 966.96529938] -> 2.139980\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:51 INFO RegisterModelsICPITK Optimization result: [-8.14300322e-02 -3.37112552e-02  5.60658146e-02  6.50784042e+02\n",
-      "  3.17801530e+02  9.56867714e+02  9.30311950e-01  8.66344398e-01\n",
-      "  8.00000000e-01 -3.00000000e-02 -2.21845401e-02  1.57768164e-02] -> 2.139976\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:53 INFO RegisterModelsICPITK Optimization completed!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:53 INFO RegisterModelsICPITK Final parameters: [-8.14300322e-02 -3.37112552e-02  5.60658146e-02  6.50784042e+02\n",
-      "  3.17801530e+02  9.56867714e+02  9.30311950e-01  8.66344398e-01\n",
-      "  8.00000000e-01 -3.00000000e-02 -2.21845401e-02  1.57768164e-02]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:53 INFO RegisterModelsICPITK Final mean distance: 2.14\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:53 INFO WorkflowRegisterHeartModelToPatient Stage 1 complete: ICP alignment finished.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Rough alignment using ICP\n",
     "icp_results = registrar.register_model_to_model_icp()\n",
@@ -524,364 +263,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:20:54.105633Z",
-     "iopub.status.busy": "2026-01-25T23:20:54.105633Z",
-     "iopub.status.idle": "2026-01-25T23:22:32.363065Z",
-     "shell.execute_reply": "2026-01-25T23:22:32.362167Z"
+     "iopub.execute_input": "2026-01-28T05:06:05.308063Z",
+     "iopub.status.busy": "2026-01-28T05:06:05.308063Z",
+     "iopub.status.idle": "2026-01-28T05:07:43.163672Z",
+     "shell.execute_reply": "2026-01-28T05:07:43.162768Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:54 INFO WorkflowRegisterHeartModelToPatient ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:54 INFO WorkflowRegisterHeartModelToPatient Stage 2: PCA-Based Registration (RegisterModelsPCA)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:54 INFO WorkflowRegisterHeartModelToPatient ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:54 INFO Loading PCA data from SlicerSALT format...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:54 INFO   JSON file: C:\\src\\Projects\\PhysioMotion\\physiomotion4d\\experiments\\..\\data\\KCL-Heart-Model\\pca\\pca.json\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:54 INFO   Group key: All\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:20:54 INFO Reading JSON file...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:00 INFO   Loaded 20 standard deviations\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:00 INFO   Loaded pca_eigenvectors with shape (20, 501720)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:00 INFO   ✓ Data validation successful!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:00 INFO SlicerSALT PCA data loaded successfully!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:00 INFO ContourTools Computing signed distance map...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:03 INFO RegisterModelsPCA Converting mean shape points to ITK format...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA   Converted 167240 points to ITK format\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA PCA-BASED MODEL-TO-IMAGE REGISTRATION\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA Number of points: 167240\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA Modes to use: 10\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA Number of PCA modes: 10\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA PCA coefficient bounds: ±3.0 std deviations\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA Optimization method: L-BFGS-B\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA Max iterations: 50\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA Running optimization...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA    Metric 1: [597.29945341 328.56259488 943.46860912] -> 0.368634\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:04 INFO RegisterModelsPCA        Params [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:26 INFO RegisterModelsPCA    Metric 101: [597.25625369 328.37795667 943.15016755] -> 0.131406\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:26 INFO RegisterModelsPCA        Params [ 0.18617459  0.11820061  0.14207092 -0.45480116  0.04744076 -0.25310697\n",
-      " -0.2157557   0.00629705  0.11690776 -0.0412029 ]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:48 INFO RegisterModelsPCA    Metric 201: [597.25007131 328.36674133 943.14424849] -> 0.131047\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:21:48 INFO RegisterModelsPCA        Params [ 0.18713054  0.11675004  0.14613837 -0.47058366  0.03907    -0.24922638\n",
-      " -0.24331215  0.02890439  0.1156488   0.00600978]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:09 INFO RegisterModelsPCA    Metric 301: [597.24970927 328.36661881 943.14419681] -> 0.131047\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:09 INFO RegisterModelsPCA        Params [ 0.18715834  0.11656601  0.1460866  -0.47040611  0.03940149 -0.24948611\n",
-      " -0.24383915  0.02935952  0.1159562   0.00592741]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:11 INFO RegisterModelsPCA Optimization completed!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:11 INFO RegisterModelsPCA Optimized PCA coefficients: [ 0.18715834  0.11656601  0.14608659 -0.47040611  0.03940149 -0.24948611\n",
-      " -0.24383915  0.02935952  0.1159562   0.00592741]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:11 INFO RegisterModelsPCA Final mean intensity: 0.13\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:11 INFO RegisterModelsPCA Creating final registered model...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:11 INFO RegisterModelsPCA Transforming points: 1/167240 (0.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:12 INFO RegisterModelsPCA Transforming points: 16725/167240 (10.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:13 INFO RegisterModelsPCA Transforming points: 33449/167240 (20.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:13 INFO RegisterModelsPCA Transforming points: 50173/167240 (30.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:14 INFO RegisterModelsPCA Transforming points: 66897/167240 (40.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:15 INFO RegisterModelsPCA Transforming points: 83621/167240 (50.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:16 INFO RegisterModelsPCA Transforming points: 100345/167240 (60.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:17 INFO RegisterModelsPCA Transforming points: 117069/167240 (70.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:18 INFO RegisterModelsPCA Transforming points: 133793/167240 (80.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:19 INFO RegisterModelsPCA Transforming points: 150517/167240 (90.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:20 INFO RegisterModelsPCA Transforming points: 167240/167240 (100.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:20 INFO RegisterModelsPCA Registered model created with 167240 points\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:31 INFO WorkflowRegisterHeartModelToPatient Stage 2 complete: PCA registration finished.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pca_results = registrar.register_model_to_model_pca()\n",
     "pca_coefficients = pca_results[\"pca_coefficients\"]\n",
@@ -901,150 +292,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:22:32.365570Z",
-     "iopub.status.busy": "2026-01-25T23:22:32.365570Z",
-     "iopub.status.idle": "2026-01-25T23:24:41.396858Z",
-     "shell.execute_reply": "2026-01-25T23:24:41.396858Z"
+     "iopub.execute_input": "2026-01-28T05:07:43.165673Z",
+     "iopub.status.busy": "2026-01-28T05:07:43.165673Z",
+     "iopub.status.idle": "2026-01-28T05:09:52.930697Z",
+     "shell.execute_reply": "2026-01-28T05:09:52.929287Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:32 INFO WorkflowRegisterHeartModelToPatient ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:32 INFO WorkflowRegisterHeartModelToPatient Stage 3: Mask-to-Mask Deformable Registration\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:32 INFO WorkflowRegisterHeartModelToPatient ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:32 INFO RegisterModelsDistanceMaps ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:32 INFO RegisterModelsDistanceMaps DEFORMABLE Mask-based Registration\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:32 INFO RegisterModelsDistanceMaps ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:32 INFO RegisterModelsDistanceMaps Generating binary masks from models...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:32 INFO ContourTools Computing signed distance map...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Starting deformable mask-to-mask registration...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:35 INFO RegisterModelsDistanceMaps Dilating fixed mask by 25.0mm for ROI...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:37 INFO ContourTools Computing signed distance map...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:40 INFO RegisterModelsDistanceMaps Dilating moving mask by 25.0mm for ROI...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:41 INFO RegisterModelsDistanceMaps Mask generation complete\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:22:41 INFO RegisterModelsDistanceMaps Performing ANTs Deformable registration...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "antsRegistration --dimensionality 3 -r identity --output [C:\\Users\\saylward\\AppData\\Local\\Temp\\tmpd3xkv6h_,00000208099BB288,00000208099BB368] --transform SyN[0.2,3,0] --metric MI[00000208099BB2E8,00000208099BB2C8,1,32] --convergence [100x70x50x0,1e-6,10] --shrink-factors 8x4x2x1 --smoothing-sigmas 3x2x1x0vox -x [00000208099BB328,00000208099BB3A8] --float 1 --write-composite-transform 0 -v 1\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:38 INFO RegisterModelsDistanceMaps Transforming moving model...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:40 INFO RegisterModelsDistanceMaps DEFORMABLE mask-based registration complete!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:40 INFO WorkflowRegisterHeartModelToPatient Stage 3 complete: Mask-to-mask registration finished.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Registration complete!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Perform deformable registration\n",
     "print(\"Starting deformable mask-to-mask registration...\")\n",
@@ -1063,110 +320,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:24:41.399859Z",
-     "iopub.status.busy": "2026-01-25T23:24:41.399859Z",
-     "iopub.status.idle": "2026-01-25T23:25:15.623437Z",
-     "shell.execute_reply": "2026-01-25T23:25:15.622537Z"
+     "iopub.execute_input": "2026-01-28T05:09:52.932334Z",
+     "iopub.status.busy": "2026-01-28T05:09:52.932334Z",
+     "iopub.status.idle": "2026-01-28T05:10:28.133249Z",
+     "shell.execute_reply": "2026-01-28T05:10:28.132335Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:41 INFO WorkflowRegisterHeartModelToPatient ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:41 INFO WorkflowRegisterHeartModelToPatient Stage 4: Labelmap-to-Image Refinement (Icon Registration)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:41 INFO WorkflowRegisterHeartModelToPatient ======================================================================\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:41 INFO WorkflowRegisterHeartModelToPatient Auto-generating ROI masks (dilation: 25mm)...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Starting deformable registration...\n",
-      "This may take several minutes depending on GPU availability.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:42 INFO WorkflowRegisterHeartModelToPatient ROI masks auto-generated successfully.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:42 INFO WorkflowRegisterHeartModelToPatient Auto-generating masks from models (dilation:0mm)...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:43 INFO WorkflowRegisterHeartModelToPatient Masks auto-generated successfully.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:43 INFO WorkflowRegisterHeartModelToPatient Auto-generating ROI masks (dilation: 25mm)...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:24:44 INFO WorkflowRegisterHeartModelToPatient ROI masks auto-generated successfully.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "antsRegistration --dimensionality 3 -r identity --output [C:\\Users\\saylward\\AppData\\Local\\Temp\\tmpgshq98se,0000020828C77E68,0000020828C77D68] --transform SyN[0.2,3,0] --metric MI[0000020828C77F88,0000020828C77FE8,1,32] --convergence [100x70x50x0,1e-6,10] --shrink-factors 8x4x2x1 --smoothing-sigmas 3x2x1x0vox -x [0000020828C77D08,0000020828C77D28] --float 1 --write-composite-transform 0 -v 1\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:14 INFO WorkflowRegisterHeartModelToPatient Stage 4 complete: Mask-to-image registration finished.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Registration complete!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Starting deformable registration...\")\n",
     "print(\"This may take several minutes depending on GPU availability.\")\n",
@@ -1185,52 +348,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:25:15.625429Z",
-     "iopub.status.busy": "2026-01-25T23:25:15.625429Z",
-     "iopub.status.idle": "2026-01-25T23:25:16.427563Z",
-     "shell.execute_reply": "2026-01-25T23:25:16.426649Z"
+     "iopub.execute_input": "2026-01-28T05:10:28.135327Z",
+     "iopub.status.busy": "2026-01-28T05:10:28.135327Z",
+     "iopub.status.idle": "2026-01-28T05:10:28.997087Z",
+     "shell.execute_reply": "2026-01-28T05:10:28.996191Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--- ICP forward transform time: 0.0 seconds\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--- PCA setup time: 0.7905173301696777 seconds\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PCA + ICP transform time: 0.0 seconds\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "M2M inverse transform time: 0.0 seconds\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "M2I inverse transform time: 0.0 seconds\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import time\n",
     "\n",
@@ -1266,115 +393,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:25:16.429143Z",
-     "iopub.status.busy": "2026-01-25T23:25:16.429143Z",
-     "iopub.status.idle": "2026-01-25T23:25:33.341791Z",
-     "shell.execute_reply": "2026-01-25T23:25:33.341176Z"
+     "iopub.execute_input": "2026-01-28T05:10:28.999096Z",
+     "iopub.status.busy": "2026-01-28T05:10:28.999096Z",
+     "iopub.status.idle": "2026-01-28T05:10:45.787422Z",
+     "shell.execute_reply": "2026-01-28T05:10:45.786534Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:17 INFO WorkflowRegisterHeartModelToPatient Applying transforms to model...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:17 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 1/379158 (0.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:18 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 37916/379158 (10.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:19 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 75831/379158 (20.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:20 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 113746/379158 (30.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:21 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 151661/379158 (40.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:23 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 189576/379158 (50.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:24 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 227491/379158 (60.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:25 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 265406/379158 (70.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:26 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 303321/379158 (80.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:27 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 341236/379158 (90.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:28 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 379151/379158 (100.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:28 INFO WorkflowRegisterHeartModelToPatient Transforming model points: 379158/379158 (100.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 18:25:28 INFO WorkflowRegisterHeartModelToPatient Transform application complete.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Verify registration using the transform member function\n",
     "surface_transformed = registrar.m2i_template_model_surface\n",
@@ -1393,31 +421,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:25:33.343884Z",
-     "iopub.status.busy": "2026-01-25T23:25:33.343884Z",
-     "iopub.status.idle": "2026-01-25T23:25:35.616837Z",
-     "shell.execute_reply": "2026-01-25T23:25:35.615874Z"
+     "iopub.execute_input": "2026-01-28T05:10:45.789422Z",
+     "iopub.status.busy": "2026-01-28T05:10:45.789422Z",
+     "iopub.status.idle": "2026-01-28T05:10:48.149250Z",
+     "shell.execute_reply": "2026-01-28T05:10:48.148258Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "975410584fd248d1b0048c0801d617a2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:59182/index.html?ui=P_0x207d51cb8b0_0&reconnect=auto\" class=\"pyvis…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load meshes from registrar member variables\n",
     "patient_surface = registrar.patient_model_surface\n",
@@ -1455,42 +468,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:25:35.619792Z",
-     "iopub.status.busy": "2026-01-25T23:25:35.618878Z",
-     "iopub.status.idle": "2026-01-25T23:25:35.994948Z",
-     "shell.execute_reply": "2026-01-25T23:25:35.993835Z"
+     "iopub.execute_input": "2026-01-28T05:10:48.151250Z",
+     "iopub.status.busy": "2026-01-28T05:10:48.151250Z",
+     "iopub.status.idle": "2026-01-28T05:10:48.420499Z",
+     "shell.execute_reply": "2026-01-28T05:10:48.419505Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c74e1fbe6af14be0995ddb4f45406094",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:59182/index.html?ui=P_0x207abcb7340_1&reconnect=auto\" class=\"pyvis…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deformation statistics:\n",
-      "  Min: 0.19 mm\n",
-      "  Max: 16.51 mm\n",
-      "  Mean: 6.36 mm\n",
-      "  Std: 2.71 mm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The transformed mesh has deformation magnitude stored as point data\n",
     "if \"DeformationMagnitude\" in registered_surface.point_data:\n",
@@ -1538,7 +525,25 @@
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "0f63defa5ba74c40a0ce233118b085e3": {
+     "2093ac4075e6409ea5710e134d6d6ce7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "491867dd74e340e39f039d73e5348a7d": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1591,25 +596,30 @@
        "width": null
       }
      },
-     "25a64794d18146c4afa354755bac562f": {
+     "71fede1064a74135a22884ee12ec714e": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
+      "model_name": "HTMLModel",
       "state": {
+       "_dom_classes": [],
        "_model_module": "@jupyter-widgets/controls",
        "_model_module_version": "2.0.0",
-       "_model_name": "HTMLStyleModel",
+       "_model_name": "HTMLModel",
        "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
+       "_view_module": "@jupyter-widgets/controls",
        "_view_module_version": "2.0.0",
-       "_view_name": "StyleView",
-       "background": null,
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_491867dd74e340e39f039d73e5348a7d",
+       "placeholder": "​",
+       "style": "IPY_MODEL_2093ac4075e6409ea5710e134d6d6ce7",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "<iframe src=\"http://localhost:60712/index.html?ui=P_0x23954cafa00_1&reconnect=auto\" class=\"pyvista\" style=\"width: 99%; height: 600px; border: 1px solid rgb(221,221,221);\"></iframe>"
       }
      },
-     "4dd7b512b1ec415b889d8f821e30f72e": {
+     "bfb58405421943f2b0be365536a1f655": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "2.0.0",
       "model_name": "LayoutModel",
@@ -1662,7 +672,7 @@
        "width": null
       }
      },
-     "975410584fd248d1b0048c0801d617a2": {
+     "c0ff603527a746358621b8055640de71": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLModel",
@@ -1677,15 +687,15 @@
        "_view_name": "HTMLView",
        "description": "",
        "description_allow_html": false,
-       "layout": "IPY_MODEL_4dd7b512b1ec415b889d8f821e30f72e",
+       "layout": "IPY_MODEL_bfb58405421943f2b0be365536a1f655",
        "placeholder": "​",
-       "style": "IPY_MODEL_9b3d3ecc1d2a462785558f56f0d839d4",
+       "style": "IPY_MODEL_cb7e363f20e14fa78ae04aa06b7c13a6",
        "tabbable": null,
        "tooltip": null,
-       "value": "<iframe src=\"http://localhost:59182/index.html?ui=P_0x207d51cb8b0_0&reconnect=auto\" class=\"pyvista\" style=\"width: 99%; height: 600px; border: 1px solid rgb(221,221,221);\"></iframe>"
+       "value": "<iframe src=\"http://localhost:60712/index.html?ui=P_0x23954cac580_0&reconnect=auto\" class=\"pyvista\" style=\"width: 99%; height: 600px; border: 1px solid rgb(221,221,221);\"></iframe>"
       }
      },
-     "9b3d3ecc1d2a462785558f56f0d839d4": {
+     "cb7e363f20e14fa78ae04aa06b7c13a6": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "2.0.0",
       "model_name": "HTMLStyleModel",
@@ -1701,29 +711,6 @@
        "description_width": "",
        "font_size": null,
        "text_color": null
-      }
-     },
-     "c74e1fbe6af14be0995ddb4f45406094": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/controls",
-       "_model_module_version": "2.0.0",
-       "_model_name": "HTMLModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/controls",
-       "_view_module_version": "2.0.0",
-       "_view_name": "HTMLView",
-       "description": "",
-       "description_allow_html": false,
-       "layout": "IPY_MODEL_0f63defa5ba74c40a0ce233118b085e3",
-       "placeholder": "​",
-       "style": "IPY_MODEL_25a64794d18146c4afa354755bac562f",
-       "tabbable": null,
-       "tooltip": null,
-       "value": "<iframe src=\"http://localhost:59182/index.html?ui=P_0x207abcb7340_1&reconnect=auto\" class=\"pyvista\" style=\"width: 99%; height: 600px; border: 1px solid rgb(221,221,221);\"></iframe>"
       }
      }
     },

--- a/experiments/Heart-VTKSeries_To_USD/0-download_and_convert_4d_to_3d.ipynb
+++ b/experiments/Heart-VTKSeries_To_USD/0-download_and_convert_4d_to_3d.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:59:36.797751Z",
-     "iopub.status.busy": "2026-01-25T21:59:36.797751Z",
-     "iopub.status.idle": "2026-01-25T21:59:51.594549Z",
-     "shell.execute_reply": "2026-01-25T21:59:51.593560Z"
+     "iopub.execute_input": "2026-01-28T03:10:32.956639Z",
+     "iopub.status.busy": "2026-01-28T03:10:32.956639Z",
+     "iopub.status.idle": "2026-01-28T03:10:52.527875Z",
+     "shell.execute_reply": "2026-01-28T03:10:52.526864Z"
     }
    },
    "outputs": [],
@@ -21,13 +21,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:59:51.596556Z",
-     "iopub.status.busy": "2026-01-25T21:59:51.595561Z",
-     "iopub.status.idle": "2026-01-25T21:59:51.609549Z",
-     "shell.execute_reply": "2026-01-25T21:59:51.608556Z"
+     "iopub.execute_input": "2026-01-28T03:10:52.529863Z",
+     "iopub.status.busy": "2026-01-28T03:10:52.529863Z",
+     "iopub.status.idle": "2026-01-28T03:10:52.542863Z",
+     "shell.execute_reply": "2026-01-28T03:10:52.541871Z"
     }
    },
    "outputs": [],
@@ -44,13 +44,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:59:51.611553Z",
-     "iopub.status.busy": "2026-01-25T21:59:51.611553Z",
-     "iopub.status.idle": "2026-01-25T21:59:51.624557Z",
-     "shell.execute_reply": "2026-01-25T21:59:51.623560Z"
+     "iopub.execute_input": "2026-01-28T03:10:52.544885Z",
+     "iopub.status.busy": "2026-01-28T03:10:52.544885Z",
+     "iopub.status.idle": "2026-01-28T03:10:52.557879Z",
+     "shell.execute_reply": "2026-01-28T03:10:52.556885Z"
     }
    },
    "outputs": [],
@@ -64,13 +64,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:59:51.627069Z",
-     "iopub.status.busy": "2026-01-25T21:59:51.627069Z",
-     "iopub.status.idle": "2026-01-25T21:59:51.641073Z",
-     "shell.execute_reply": "2026-01-25T21:59:51.639074Z"
+     "iopub.execute_input": "2026-01-28T03:10:52.559877Z",
+     "iopub.status.busy": "2026-01-28T03:10:52.559877Z",
+     "iopub.status.idle": "2026-01-28T03:10:52.573876Z",
+     "shell.execute_reply": "2026-01-28T03:10:52.571757Z"
     }
    },
    "outputs": [],

--- a/experiments/Heart-VTKSeries_To_USD/1-heart_vtkseries_to_usd.ipynb
+++ b/experiments/Heart-VTKSeries_To_USD/1-heart_vtkseries_to_usd.ipynb
@@ -2,14 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "0e42811d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T21:59:57.702165Z",
-     "iopub.status.busy": "2026-01-25T21:59:57.702165Z",
-     "iopub.status.idle": "2026-01-25T22:00:13.248934Z",
-     "shell.execute_reply": "2026-01-25T22:00:13.248009Z"
+     "iopub.execute_input": "2026-01-28T03:11:00.648640Z",
+     "iopub.status.busy": "2026-01-28T03:11:00.647590Z",
+     "iopub.status.idle": "2026-01-28T03:11:16.707171Z",
+     "shell.execute_reply": "2026-01-28T03:11:16.706256Z"
     }
    },
    "outputs": [],
@@ -19,19 +19,19 @@
     "\n",
     "import pyvista as pv\n",
     "\n",
-    "from physiomotion4d.convert_vtk_4d_to_usd import ConvertVTK4DToUSD"
+    "from physiomotion4d.convert_vtk_to_usd import ConvertVTKToUSD"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "689c2ca8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T22:00:13.251518Z",
-     "iopub.status.busy": "2026-01-25T22:00:13.251154Z",
-     "iopub.status.idle": "2026-01-25T22:00:13.264483Z",
-     "shell.execute_reply": "2026-01-25T22:00:13.262766Z"
+     "iopub.execute_input": "2026-01-28T03:11:16.709241Z",
+     "iopub.status.busy": "2026-01-28T03:11:16.709241Z",
+     "iopub.status.idle": "2026-01-28T03:11:16.722251Z",
+     "shell.execute_reply": "2026-01-28T03:11:16.721251Z"
     }
    },
    "outputs": [],
@@ -73,405 +73,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "3403756a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T22:00:13.266634Z",
-     "iopub.status.busy": "2026-01-25T22:00:13.266634Z",
-     "iopub.status.idle": "2026-01-25T22:09:38.183945Z",
-     "shell.execute_reply": "2026-01-25T22:09:38.182950Z"
+     "iopub.execute_input": "2026-01-28T03:11:16.724246Z",
+     "iopub.status.busy": "2026-01-28T03:11:16.724246Z",
+     "iopub.status.idle": "2026-01-28T03:20:37.260399Z",
+     "shell.execute_reply": "2026-01-28T03:20:37.259344Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_000.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2447615\n",
-      "  Point data arrays: []\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_001.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2445206\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_002.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2426984\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_003.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2438093\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_004.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2421625\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_005.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2438623\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_006.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2415877\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_007.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2410130\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_008.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2324145\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_009.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2401768\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_010.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2413592\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_011.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2426177\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_012.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2446419\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_013.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2446930\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_014.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2451615\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_015.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2457819\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_016.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2431088\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_017.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2440157\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_018.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2434151\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_019.vtp\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2436484\n",
-      "Processing file: ..\\..\\data\\Slicer-Heart-CT\\slice_020.vtp\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:00:33 INFO ConvertVTK4DToUSD Routing to PolyMesh converter (surface meshes)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:00:33 INFO ConvertVTK4DToUSDPolyMesh Converting Heart_VTKSeries_To_USD_all\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:00:33 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 1/21 (4.8%)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Number of points: 2447615\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:00:41 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 2/21 (9.5%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:00:48 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 3/21 (14.3%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:00:56 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 4/21 (19.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:01:03 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 5/21 (23.8%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:01:11 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 6/21 (28.6%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:01:19 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 7/21 (33.3%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:01:25 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 8/21 (38.1%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:01:33 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 9/21 (42.9%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:01:39 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 10/21 (47.6%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:01:48 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 11/21 (52.4%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:01:54 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 12/21 (57.1%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:02:01 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 13/21 (61.9%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:02:10 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 14/21 (66.7%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:02:16 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 15/21 (71.4%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:02:23 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 16/21 (76.2%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:02:32 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 17/21 (81.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:02:39 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 18/21 (85.7%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:02:45 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 19/21 (90.5%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:02:51 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 20/21 (95.2%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:03:02 INFO ConvertVTK4DToUSDPolyMesh Processing time point: 21/21 (100.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:03:08 INFO ConvertVTK4DToUSDPolyMesh Detected topology changes for label 'default' - will use time-varying mesh approach\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:03:08 INFO ConvertVTK4DToUSDPolyMesh Creating time-varying UsdGeomMesh for label: default (topology changes detected)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:03:08 INFO ConvertVTK4DToUSDPolyMesh Creating meshes for default: 1/21 (4.8%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:06:11 INFO ConvertVTK4DToUSDPolyMesh Creating meshes for default: 11/21 (52.4%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:09:09 INFO ConvertVTK4DToUSDPolyMesh Creating meshes for default: 21/21 (100.0%)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-01-25 17:09:30 INFO ConvertVTK4DToUSDPolyMesh Time taken to create USD mesh: 381.5863037109375 seconds\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "USD files created!\n",
-      "  - C:\\src\\Projects\\PhysioMotion\\physiomotion4d\\experiments\\Heart-VTKSeries_To_USD\\results\\Heart_VTKSeries_To_USD_all.usd\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "project_name = \"Heart_VTKSeries_To_USD_all\"\n",
     "\n",
@@ -493,7 +105,7 @@
     "    input_polydata.append(pd)\n",
     "\n",
     "# Convert with transmembrane potential coloring\n",
-    "converter = ConvertVTK4DToUSD(\n",
+    "converter = ConvertVTKToUSD(\n",
     "    project_name,\n",
     "    input_polydata,\n",
     ")\n",

--- a/experiments/Lung-GatedCT_To_USD/0-register_dirlab_4dct.ipynb
+++ b/experiments/Lung-GatedCT_To_USD/0-register_dirlab_4dct.ipynb
@@ -5,10 +5,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:25:43.746666Z",
-     "iopub.status.busy": "2026-01-25T23:25:43.746666Z",
-     "iopub.status.idle": "2026-01-25T23:25:59.013922Z",
-     "shell.execute_reply": "2026-01-25T23:25:59.013027Z"
+     "iopub.execute_input": "2026-01-28T05:10:57.845147Z",
+     "iopub.status.busy": "2026-01-28T05:10:57.845147Z",
+     "iopub.status.idle": "2026-01-28T05:11:15.035220Z",
+     "shell.execute_reply": "2026-01-28T05:11:15.034221Z"
     }
    },
    "outputs": [],
@@ -42,10 +42,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:25:59.016273Z",
-     "iopub.status.busy": "2026-01-25T23:25:59.015720Z",
-     "iopub.status.idle": "2026-01-25T23:25:59.028881Z",
-     "shell.execute_reply": "2026-01-25T23:25:59.027922Z"
+     "iopub.execute_input": "2026-01-28T05:11:15.037311Z",
+     "iopub.status.busy": "2026-01-28T05:11:15.037311Z",
+     "iopub.status.idle": "2026-01-28T05:11:15.050359Z",
+     "shell.execute_reply": "2026-01-28T05:11:15.049366Z"
     }
    },
    "outputs": [],
@@ -122,10 +122,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:25:59.030879Z",
-     "iopub.status.busy": "2026-01-25T23:25:59.030879Z",
-     "iopub.status.idle": "2026-01-25T23:52:09.374119Z",
-     "shell.execute_reply": "2026-01-25T23:52:09.373214Z"
+     "iopub.execute_input": "2026-01-28T05:11:15.051369Z",
+     "iopub.status.busy": "2026-01-28T05:11:15.051369Z",
+     "iopub.status.idle": "2026-01-28T06:06:40.330576Z",
+     "shell.execute_reply": "2026-01-28T06:06:40.329585Z"
     }
    },
    "outputs": [],

--- a/experiments/Lung-GatedCT_To_USD/1-make_dirlab_models.ipynb
+++ b/experiments/Lung-GatedCT_To_USD/1-make_dirlab_models.ipynb
@@ -6,10 +6,10 @@
    "id": "3ce61753-11ad-4ade-9afe-6ad1bc748e25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:52:17.129963Z",
-     "iopub.status.busy": "2026-01-25T23:52:17.129963Z",
-     "iopub.status.idle": "2026-01-25T23:52:33.102190Z",
-     "shell.execute_reply": "2026-01-25T23:52:33.101196Z"
+     "iopub.execute_input": "2026-01-28T06:06:49.266434Z",
+     "iopub.status.busy": "2026-01-28T06:06:49.266434Z",
+     "iopub.status.idle": "2026-01-28T06:07:06.547812Z",
+     "shell.execute_reply": "2026-01-28T06:07:06.546812Z"
     }
    },
    "outputs": [],
@@ -20,7 +20,7 @@
     "from data_dirlab_4d_ct import DataDirLab4DCT\n",
     "\n",
     "from physiomotion4d.contour_tools import ContourTools\n",
-    "from physiomotion4d.convert_vtk_4d_to_usd import ConvertVTK4DToUSD\n",
+    "from physiomotion4d.convert_vtk_to_usd import ConvertVTKToUSD\n",
     "from physiomotion4d.segment_chest_total_segmentator import SegmentChestTotalSegmentator\n",
     "\n",
     "\n",
@@ -38,10 +38,10 @@
    "id": "240f1d14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:52:33.104189Z",
-     "iopub.status.busy": "2026-01-25T23:52:33.103190Z",
-     "iopub.status.idle": "2026-01-25T23:52:33.117190Z",
-     "shell.execute_reply": "2026-01-25T23:52:33.116196Z"
+     "iopub.execute_input": "2026-01-28T06:07:06.550830Z",
+     "iopub.status.busy": "2026-01-28T06:07:06.549788Z",
+     "iopub.status.idle": "2026-01-28T06:07:06.562706Z",
+     "shell.execute_reply": "2026-01-28T06:07:06.561801Z"
     }
    },
    "outputs": [],
@@ -71,10 +71,10 @@
    "id": "4e3e9fa5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:52:33.119190Z",
-     "iopub.status.busy": "2026-01-25T23:52:33.118190Z",
-     "iopub.status.idle": "2026-01-25T23:52:33.132191Z",
-     "shell.execute_reply": "2026-01-25T23:52:33.131196Z"
+     "iopub.execute_input": "2026-01-28T06:07:06.564706Z",
+     "iopub.status.busy": "2026-01-28T06:07:06.564706Z",
+     "iopub.status.idle": "2026-01-28T06:07:06.577709Z",
+     "shell.execute_reply": "2026-01-28T06:07:06.576813Z"
     }
    },
    "outputs": [],
@@ -114,7 +114,7 @@
     "    )\n",
     "\n",
     "    print(f\"Converting vtp models to USD for {case_name}\")\n",
-    "    converter = ConvertVTK4DToUSD(\n",
+    "    converter = ConvertVTKToUSD(\n",
     "        \"DirLab4DCT\",\n",
     "        transformed_contours,\n",
     "        mask_ids=all_mask_ids,\n",
@@ -131,10 +131,10 @@
    "id": "61830d5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:52:33.134190Z",
-     "iopub.status.busy": "2026-01-25T23:52:33.134190Z",
-     "iopub.status.idle": "2026-01-25T23:58:15.870221Z",
-     "shell.execute_reply": "2026-01-25T23:58:15.868611Z"
+     "iopub.execute_input": "2026-01-28T06:07:06.580766Z",
+     "iopub.status.busy": "2026-01-28T06:07:06.580766Z",
+     "iopub.status.idle": "2026-01-28T06:20:33.496446Z",
+     "shell.execute_reply": "2026-01-28T06:20:33.495447Z"
     }
    },
    "outputs": [],

--- a/experiments/Lung-GatedCT_To_USD/2-paint_dirlab_models.ipynb
+++ b/experiments/Lung-GatedCT_To_USD/2-paint_dirlab_models.ipynb
@@ -2,14 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "3ce61753-11ad-4ade-9afe-6ad1bc748e25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:58:21.478383Z",
-     "iopub.status.busy": "2026-01-25T23:58:21.478383Z",
-     "iopub.status.idle": "2026-01-25T23:58:36.964437Z",
-     "shell.execute_reply": "2026-01-25T23:58:36.963364Z"
+     "iopub.execute_input": "2026-01-28T06:20:45.190874Z",
+     "iopub.status.busy": "2026-01-28T06:20:45.190874Z",
+     "iopub.status.idle": "2026-01-28T06:21:02.083178Z",
+     "shell.execute_reply": "2026-01-28T06:21:02.082265Z"
     }
    },
    "outputs": [],
@@ -30,14 +30,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "3cc90c5c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-25T23:58:36.967363Z",
-     "iopub.status.busy": "2026-01-25T23:58:36.967363Z",
-     "iopub.status.idle": "2026-01-25T23:58:37.492390Z",
-     "shell.execute_reply": "2026-01-25T23:58:37.490540Z"
+     "iopub.execute_input": "2026-01-28T06:21:02.085264Z",
+     "iopub.status.busy": "2026-01-28T06:21:02.085264Z",
+     "iopub.status.idle": "2026-01-28T06:21:03.484858Z",
+     "shell.execute_reply": "2026-01-28T06:21:03.482705Z"
     }
    },
    "outputs": [],

--- a/experiments/Lung-GatedCT_To_USD/Experiment_ArrangeOnStage.ipynb
+++ b/experiments/Lung-GatedCT_To_USD/Experiment_ArrangeOnStage.ipynb
@@ -3,7 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:21:09.961444Z",
+     "iopub.status.busy": "2026-01-28T06:21:09.960762Z",
+     "iopub.status.idle": "2026-01-28T06:21:26.113875Z",
+     "shell.execute_reply": "2026-01-28T06:21:26.112758Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -16,7 +23,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:21:26.115881Z",
+     "iopub.status.busy": "2026-01-28T06:21:26.114881Z",
+     "iopub.status.idle": "2026-01-28T06:21:26.129326Z",
+     "shell.execute_reply": "2026-01-28T06:21:26.128332Z"
+    }
+   },
    "outputs": [],
    "source": [
     "os.makedirs(\"Results_ArrangeOnStage\", exist_ok=True)"
@@ -25,7 +39,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:21:26.130327Z",
+     "iopub.status.busy": "2026-01-28T06:21:26.130327Z",
+     "iopub.status.idle": "2026-01-28T06:21:26.538058Z",
+     "shell.execute_reply": "2026-01-28T06:21:26.537084Z"
+    }
+   },
    "outputs": [],
    "source": [
     "case_names = [\n",

--- a/experiments/Lung-GatedCT_To_USD/Experiment_CombineModels.ipynb
+++ b/experiments/Lung-GatedCT_To_USD/Experiment_CombineModels.ipynb
@@ -2,8 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:21:34.595236Z",
+     "iopub.status.busy": "2026-01-28T06:21:34.595236Z",
+     "iopub.status.idle": "2026-01-28T06:21:51.245476Z",
+     "shell.execute_reply": "2026-01-28T06:21:51.244557Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -15,8 +22,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:21:51.248570Z",
+     "iopub.status.busy": "2026-01-28T06:21:51.247477Z",
+     "iopub.status.idle": "2026-01-28T06:21:51.260536Z",
+     "shell.execute_reply": "2026-01-28T06:21:51.259572Z"
+    }
+   },
    "outputs": [],
    "source": [
     "os.makedirs(\"results_CombineModels\", exist_ok=True)"
@@ -24,8 +38,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:21:51.263590Z",
+     "iopub.status.busy": "2026-01-28T06:21:51.263590Z",
+     "iopub.status.idle": "2026-01-28T06:21:52.258962Z",
+     "shell.execute_reply": "2026-01-28T06:21:52.258962Z"
+    }
+   },
    "outputs": [],
    "source": [
     "all_mask_t00 = itk.imread(\"results/Case1Pack_T00_all_mask_org.mha\")\n",
@@ -42,8 +63,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:21:52.260965Z",
+     "iopub.status.busy": "2026-01-28T06:21:52.260965Z",
+     "iopub.status.idle": "2026-01-28T06:21:52.607773Z",
+     "shell.execute_reply": "2026-01-28T06:21:52.605773Z"
+    }
+   },
    "outputs": [],
    "source": [
     "TfmTools = TransformTools()\n",
@@ -61,8 +89,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:21:52.610798Z",
+     "iopub.status.busy": "2026-01-28T06:21:52.610798Z",
+     "iopub.status.idle": "2026-01-28T06:21:52.622882Z",
+     "shell.execute_reply": "2026-01-28T06:21:52.620893Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import pyvista as pv"
@@ -70,8 +105,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:21:52.627599Z",
+     "iopub.status.busy": "2026-01-28T06:21:52.627599Z",
+     "iopub.status.idle": "2026-01-28T06:21:58.637615Z",
+     "shell.execute_reply": "2026-01-28T06:21:58.637615Z"
+    }
+   },
    "outputs": [],
    "source": [
     "lung_model_t30 = pv.read(\"results/Case1Pack_T30_dynamic_anatomy_lungGatedBase.vtp\")\n",

--- a/experiments/Lung-GatedCT_To_USD/Experiment_SegReg.ipynb
+++ b/experiments/Lung-GatedCT_To_USD/Experiment_SegReg.ipynb
@@ -3,7 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:22:07.933354Z",
+     "iopub.status.busy": "2026-01-28T06:22:07.933354Z",
+     "iopub.status.idle": "2026-01-28T06:22:23.810941Z",
+     "shell.execute_reply": "2026-01-28T06:22:23.809983Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -20,7 +27,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:22:23.813189Z",
+     "iopub.status.busy": "2026-01-28T06:22:23.812762Z",
+     "iopub.status.idle": "2026-01-28T06:22:24.053600Z",
+     "shell.execute_reply": "2026-01-28T06:22:24.052481Z"
+    }
+   },
    "outputs": [],
    "source": [
     "fixed_image = DataDirLab4DCT().fix_image(\n",
@@ -34,7 +48,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:22:24.055595Z",
+     "iopub.status.busy": "2026-01-28T06:22:24.055237Z",
+     "iopub.status.idle": "2026-01-28T06:23:25.813330Z",
+     "shell.execute_reply": "2026-01-28T06:23:25.812458Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Register images\n",
@@ -51,7 +72,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:23:25.816423Z",
+     "iopub.status.busy": "2026-01-28T06:23:25.815408Z",
+     "iopub.status.idle": "2026-01-28T06:24:44.780078Z",
+     "shell.execute_reply": "2026-01-28T06:24:44.779086Z"
+    }
+   },
    "outputs": [],
    "source": [
     "img = itk.imread(\"results_SegReg/Experiment_reg.mha\")\n",
@@ -65,7 +93,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:24:44.782079Z",
+     "iopub.status.busy": "2026-01-28T06:24:44.782079Z",
+     "iopub.status.idle": "2026-01-28T06:24:44.795154Z",
+     "shell.execute_reply": "2026-01-28T06:24:44.794079Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# This section requires the Vista3D container to be running\n",

--- a/experiments/Lung-GatedCT_To_USD/Experiment_SubSurfaceScatter.ipynb
+++ b/experiments/Lung-GatedCT_To_USD/Experiment_SubSurfaceScatter.ipynb
@@ -3,7 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:24:53.147223Z",
+     "iopub.status.busy": "2026-01-28T06:24:53.147223Z",
+     "iopub.status.idle": "2026-01-28T06:24:53.278166Z",
+     "shell.execute_reply": "2026-01-28T06:24:53.277157Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -14,7 +21,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:24:53.280641Z",
+     "iopub.status.busy": "2026-01-28T06:24:53.280641Z",
+     "iopub.status.idle": "2026-01-28T06:24:53.293065Z",
+     "shell.execute_reply": "2026-01-28T06:24:53.292194Z"
+    }
+   },
    "outputs": [],
    "source": [
     "os.makedirs(\"results_SubsurfaceScatter\", exist_ok=True)"
@@ -23,7 +37,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T06:24:53.295069Z",
+     "iopub.status.busy": "2026-01-28T06:24:53.295069Z",
+     "iopub.status.idle": "2026-01-28T06:24:53.338447Z",
+     "shell.execute_reply": "2026-01-28T06:24:53.337546Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Initialize stage and define material/shader paths\n",

--- a/experiments/Reconstruct4DCT/reconstruct_4d_ct.ipynb
+++ b/experiments/Reconstruct4DCT/reconstruct_4d_ct.ipynb
@@ -4,7 +4,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e22cbc66",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T01:08:30.856632Z",
+     "iopub.status.busy": "2026-01-28T01:08:30.856632Z",
+     "iopub.status.idle": "2026-01-28T01:08:45.835184Z",
+     "shell.execute_reply": "2026-01-28T01:08:45.834192Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -19,7 +26,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bce36d34",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T01:08:45.837185Z",
+     "iopub.status.busy": "2026-01-28T01:08:45.837185Z",
+     "iopub.status.idle": "2026-01-28T01:08:54.394121Z",
+     "shell.execute_reply": "2026-01-28T01:08:54.393133Z"
+    }
+   },
    "outputs": [],
    "source": [
     "data_dir = os.path.join(\"..\", \"..\", \"data\", \"Slicer-Heart-CT\")\n",
@@ -73,7 +87,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "18b6e62a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T01:08:54.396121Z",
+     "iopub.status.busy": "2026-01-28T01:08:54.396121Z",
+     "iopub.status.idle": "2026-01-28T01:08:54.408645Z",
+     "shell.execute_reply": "2026-01-28T01:08:54.408645Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def register_slices(\n",
@@ -287,7 +308,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c1f34f87",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T01:08:54.411156Z",
+     "iopub.status.busy": "2026-01-28T01:08:54.411156Z",
+     "iopub.status.idle": "2026-01-28T02:23:55.854599Z",
+     "shell.execute_reply": "2026-01-28T02:23:55.836115Z"
+    }
+   },
    "outputs": [],
    "source": [
     "forward_transform_arr = None\n",
@@ -313,7 +341,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3bb5099c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T02:23:55.868225Z",
+     "iopub.status.busy": "2026-01-28T02:23:55.868225Z",
+     "iopub.status.idle": "2026-01-28T02:27:47.365606Z",
+     "shell.execute_reply": "2026-01-28T02:27:47.364605Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",

--- a/experiments/Reconstruct4DCT/reconstruct_4d_ct_class.ipynb
+++ b/experiments/Reconstruct4DCT/reconstruct_4d_ct_class.ipynb
@@ -17,7 +17,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T02:27:58.753365Z",
+     "iopub.status.busy": "2026-01-28T02:27:58.753365Z",
+     "iopub.status.idle": "2026-01-28T02:28:24.604923Z",
+     "shell.execute_reply": "2026-01-28T02:28:24.603868Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -40,7 +47,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T02:28:24.607503Z",
+     "iopub.status.busy": "2026-01-28T02:28:24.606992Z",
+     "iopub.status.idle": "2026-01-28T02:28:24.619692Z",
+     "shell.execute_reply": "2026-01-28T02:28:24.618754Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Load image files\n",
@@ -57,7 +71,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T02:28:24.630197Z",
+     "iopub.status.busy": "2026-01-28T02:28:24.629184Z",
+     "iopub.status.idle": "2026-01-28T02:28:24.634457Z",
+     "shell.execute_reply": "2026-01-28T02:28:24.633702Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Configuration\n",
@@ -114,7 +135,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T02:28:24.636172Z",
+     "iopub.status.busy": "2026-01-28T02:28:24.636172Z",
+     "iopub.status.idle": "2026-01-28T02:28:27.563046Z",
+     "shell.execute_reply": "2026-01-28T02:28:27.562056Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Load fixed/reference image\n",
@@ -137,7 +165,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T02:28:27.565236Z",
+     "iopub.status.busy": "2026-01-28T02:28:27.564217Z",
+     "iopub.status.idle": "2026-01-28T02:28:27.578230Z",
+     "shell.execute_reply": "2026-01-28T02:28:27.577229Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# This cell will be run for each registration method in the loop below\n",
@@ -161,7 +196,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T02:28:27.581229Z",
+     "iopub.status.busy": "2026-01-28T02:28:27.580228Z",
+     "iopub.status.idle": "2026-01-28T02:54:39.563351Z",
+     "shell.execute_reply": "2026-01-28T02:54:39.562350Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Store results for each method\n",
@@ -234,7 +276,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T02:54:39.570420Z",
+     "iopub.status.busy": "2026-01-28T02:54:39.570420Z",
+     "iopub.status.idle": "2026-01-28T03:06:02.874064Z",
+     "shell.execute_reply": "2026-01-28T03:06:02.872057Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Save registered images and transforms for each method\n",
@@ -324,7 +373,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T03:06:02.877072Z",
+     "iopub.status.busy": "2026-01-28T03:06:02.877072Z",
+     "iopub.status.idle": "2026-01-28T03:07:19.325787Z",
+     "shell.execute_reply": "2026-01-28T03:07:19.324787Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Optional: Reconstruct time series with upsampling to fixed image resolution\n",
@@ -378,7 +434,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T03:07:19.327786Z",
+     "iopub.status.busy": "2026-01-28T03:07:19.327786Z",
+     "iopub.status.idle": "2026-01-28T03:07:19.341663Z",
+     "shell.execute_reply": "2026-01-28T03:07:19.339906Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Print registration losses for each method\n",
@@ -409,7 +472,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-28T03:07:19.344450Z",
+     "iopub.status.busy": "2026-01-28T03:07:19.344450Z",
+     "iopub.status.idle": "2026-01-28T03:10:22.657425Z",
+     "shell.execute_reply": "2026-01-28T03:10:22.656436Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Generate grid image for visualization\n",

--- a/src/physiomotion4d/__init__.py
+++ b/src/physiomotion4d/__init__.py
@@ -23,10 +23,10 @@ from .contour_tools import ContourTools
 
 # Data processing utilities
 from .convert_nrrd_4d_to_3d import ConvertNRRD4DTo3D
-from .convert_vtk_4d_to_usd import ConvertVTK4DToUSD
-from .convert_vtk_4d_to_usd_base import ConvertVTK4DToUSDBase
-from .convert_vtk_4d_to_usd_polymesh import ConvertVTK4DToUSDPolyMesh
-from .convert_vtk_4d_to_usd_tetmesh import ConvertVTK4DToUSDTetMesh
+from .convert_vtk_to_usd import ConvertVTKToUSD
+from .convert_vtk_to_usd_base import ConvertVTKToUSDBase
+from .convert_vtk_to_usd_polymesh import ConvertVTKToUSDPolyMesh
+from .convert_vtk_to_usd_tetmesh import ConvertVTKToUSDTetMesh
 
 # Utility classes
 from .image_tools import ImageTools
@@ -92,8 +92,8 @@ __all__ = [
     "USDAnatomyTools",
     # Data processing utilities
     "ConvertNRRD4DTo3D",
-    "ConvertVTK4DToUSD",
-    "ConvertVTK4DToUSDBase",
-    "ConvertVTK4DToUSDPolyMesh",
-    "ConvertVTK4DToUSDTetMesh",
+    "ConvertVTKToUSD",
+    "ConvertVTKToUSDBase",
+    "ConvertVTKToUSDPolyMesh",
+    "ConvertVTKToUSDTetMesh",
 ]

--- a/src/physiomotion4d/convert_vtk_to_usd.py
+++ b/src/physiomotion4d/convert_vtk_to_usd.py
@@ -8,22 +8,22 @@ import pyvista as pv
 import vtk
 from pxr import Usd
 
-from .convert_vtk_4d_to_usd_base import ConvertVTK4DToUSDBase
-from .convert_vtk_4d_to_usd_polymesh import ConvertVTK4DToUSDPolyMesh
-from .convert_vtk_4d_to_usd_tetmesh import ConvertVTK4DToUSDTetMesh
+from .convert_vtk_to_usd_base import ConvertVTKToUSDBase
+from .convert_vtk_to_usd_polymesh import ConvertVTKToUSDPolyMesh
+from .convert_vtk_to_usd_tetmesh import ConvertVTKToUSDTetMesh
 from .physiomotion4d_base import PhysioMotion4DBase
 
 
-class ConvertVTK4DToUSD(PhysioMotion4DBase):
+class ConvertVTKToUSD(PhysioMotion4DBase):
     """
     Unified converter supporting both PolyData and UnstructuredGrid.
 
     Automatically routes meshes to appropriate specialized converter:
-    - PolyData → ConvertVTK4DToUSDPolyMesh
-    - UnstructuredGrid (volumetric) → ConvertVTK4DToUSDTetMesh
-    - UnstructuredGrid (surface) → ConvertVTK4DToUSDPolyMesh
+    - PolyData → ConvertVTKToUSDPolyMesh
+    - UnstructuredGrid (volumetric) → ConvertVTKToUSDTetMesh
+    - UnstructuredGrid (surface) → ConvertVTKToUSDPolyMesh
 
-    Maintains API compatibility with original ConvertVTK4DToUSD class.
+    Maintains API compatibility with original ConvertVTKToUSD class.
 
     Supports:
     - PolyData: Surface meshes exported as UsdGeomMesh
@@ -39,7 +39,7 @@ class ConvertVTK4DToUSD(PhysioMotion4DBase):
 
     Example Usage:
         >>> # Create converter with meshes
-        >>> converter = ConvertVTK4DToUSDAll(
+        >>> converter = ConvertVTKToUSD(
         ...     data_basename='CardiacModel', input_polydata=meshes, mask_ids=None
         ... )
         >>>
@@ -106,7 +106,7 @@ class ConvertVTK4DToUSD(PhysioMotion4DBase):
                   Metadata includes: 'n_components', 'dtype', 'range', 'present_in_steps'
         """
         # Create temporary converter to analyze arrays
-        temp_converter = ConvertVTK4DToUSDPolyMesh(
+        temp_converter = ConvertVTKToUSDPolyMesh(
             self.data_basename, self.input_polydata, self.mask_ids
         )
         return temp_converter.list_available_arrays()
@@ -116,7 +116,7 @@ class ConvertVTK4DToUSD(PhysioMotion4DBase):
         color_by_array: Optional[str] = None,
         colormap: str = "plasma",
         intensity_range: Optional[tuple[float, float]] = None,
-    ) -> "ConvertVTK4DToUSD":
+    ) -> "ConvertVTKToUSD":
         """
         Configure colormap settings for vertex coloring.
 
@@ -153,9 +153,9 @@ class ConvertVTK4DToUSD(PhysioMotion4DBase):
         Convert meshes to USD, automatically routing by mesh type.
 
         Analyzes input meshes and routes to appropriate specialized converter:
-        1. Only PolyData → ConvertVTK4DToUSDPolyMesh
-        2. Only UnstructuredGrid (volumetric) → ConvertVTK4DToUSDTetMesh
-        3. Only UnstructuredGrid (surface mode) → ConvertVTK4DToUSDPolyMesh
+        1. Only PolyData → ConvertVTKToUSDPolyMesh
+        2. Only UnstructuredGrid (volumetric) → ConvertVTKToUSDTetMesh
+        3. Only UnstructuredGrid (surface mode) → ConvertVTKToUSDPolyMesh
         4. Mixed types → NotImplementedError (use original class)
 
         Args:
@@ -193,7 +193,7 @@ class ConvertVTK4DToUSD(PhysioMotion4DBase):
         # Case 1: Only PolyData (or surface-converted UGrid)
         if has_polydata and not has_ugrid:
             self.log_info("Routing to PolyMesh converter (surface meshes)")
-            poly_converter = ConvertVTK4DToUSDPolyMesh(
+            poly_converter = ConvertVTKToUSDPolyMesh(
                 self.data_basename,
                 self.input_polydata,
                 self.mask_ids,
@@ -209,7 +209,7 @@ class ConvertVTK4DToUSD(PhysioMotion4DBase):
         # Case 2: Only UnstructuredGrid (tetmesh)
         if has_ugrid and not has_polydata:
             self.log_info("Routing to TetMesh converter (volumetric meshes)")
-            tet_converter: ConvertVTK4DToUSDBase = ConvertVTK4DToUSDTetMesh(
+            tet_converter: ConvertVTKToUSDBase = ConvertVTKToUSDTetMesh(
                 self.data_basename,
                 self.input_polydata,
                 self.mask_ids,
@@ -227,8 +227,8 @@ class ConvertVTK4DToUSD(PhysioMotion4DBase):
             raise NotImplementedError(
                 "Mixed PolyData and UnstructuredGrid not yet supported in "
                 "refactored version. Please use one of the following solutions:\n"
-                "1. Use the original ConvertVTK4DToUSD class from "
-                "convert_vtk_4d_to_usd.py\n"
+                "1. Use the original ConvertVTKToUSD class from "
+                "convert_vtk_to_usd.py\n"
                 "2. Separate your meshes by type and convert in two passes\n"
                 "3. Convert all UnstructuredGrid to surface with convert_to_surface=True"
             )

--- a/src/physiomotion4d/convert_vtk_to_usd_base.py
+++ b/src/physiomotion4d/convert_vtk_to_usd_base.py
@@ -1,4 +1,4 @@
-"""Abstract base class for converting 4D VTK data to animated USD meshes."""
+"""Abstract base class for converting VTK data to animated USD meshes."""
 
 import logging
 import os
@@ -48,7 +48,7 @@ MeshLabelData: TypeAlias = dict[str, MeshValue]
 MeshTimeData: TypeAlias = dict[int, dict[str, MeshLabelData]]
 
 
-class ConvertVTK4DToUSDBase(PhysioMotion4DBase, ABC):
+class ConvertVTKToUSDBase(PhysioMotion4DBase, ABC):
     """
     Abstract base class for VTK to USD conversion.
 

--- a/src/physiomotion4d/convert_vtk_to_usd_polymesh.py
+++ b/src/physiomotion4d/convert_vtk_to_usd_polymesh.py
@@ -8,15 +8,15 @@ import pyvista as pv
 import vtk
 from pxr import Gf, Sdf, UsdGeom
 
-from .convert_vtk_4d_to_usd_base import (
-    ConvertVTK4DToUSDBase,
+from .convert_vtk_to_usd_base import (
+    ConvertVTKToUSDBase,
     MeshLabelData,
     MeshTimeData,
     RgbColor,
 )
 
 
-class ConvertVTK4DToUSDPolyMesh(ConvertVTK4DToUSDBase):
+class ConvertVTKToUSDPolyMesh(ConvertVTKToUSDBase):
     """
     Converter for VTK PolyData to USD Mesh.
 
@@ -27,7 +27,7 @@ class ConvertVTK4DToUSDPolyMesh(ConvertVTK4DToUSDBase):
     - Per-vertex colormap visualization
 
     Example Usage:
-        >>> converter = ConvertVTK4DToUSDPolyMesh(
+        >>> converter = ConvertVTKToUSDPolyMesh(
         ...     data_basename='SurfaceModel', input_polydata=meshes, mask_ids=None
         ... )
         >>> converter.set_colormap(color_by_array='pressure', colormap='rainbow')

--- a/src/physiomotion4d/convert_vtk_to_usd_tetmesh.py
+++ b/src/physiomotion4d/convert_vtk_to_usd_tetmesh.py
@@ -7,18 +7,18 @@ import pyvista as pv
 import vtk
 from pxr import Gf, Sdf, UsdGeom, Vt
 
-from .convert_vtk_4d_to_usd_base import (
+from .convert_vtk_to_usd_base import (
     VTK_QUAD,
     VTK_TETRA,
     VTK_TRIANGLE,
-    ConvertVTK4DToUSDBase,
+    ConvertVTKToUSDBase,
     MeshLabelData,
     MeshTimeData,
     RgbColor,
 )
 
 
-class ConvertVTK4DToUSDTetMesh(ConvertVTK4DToUSDBase):
+class ConvertVTKToUSDTetMesh(ConvertVTKToUSDBase):
     """
     Converter for VTK UnstructuredGrid to USD TetMesh.
 
@@ -30,7 +30,7 @@ class ConvertVTK4DToUSDTetMesh(ConvertVTK4DToUSDBase):
     Requires OpenUSD v24.03+ for UsdGeomTetMesh support.
 
     Example Usage:
-        >>> converter = ConvertVTK4DToUSDTetMesh(
+        >>> converter = ConvertVTKToUSDTetMesh(
         ...     data_basename='VolumetricModel', input_polydata=ugrid_meshes, mask_ids=None
         ... )
         >>> stage = converter.convert('output.usd')

--- a/src/physiomotion4d/workflow_convert_heart_gated_ct_to_usd.py
+++ b/src/physiomotion4d/workflow_convert_heart_gated_ct_to_usd.py
@@ -15,7 +15,7 @@ import pyvista as pv
 
 from physiomotion4d.contour_tools import ContourTools
 from physiomotion4d.convert_nrrd_4d_to_3d import ConvertNRRD4DTo3D
-from physiomotion4d.convert_vtk_4d_to_usd import ConvertVTK4DToUSD
+from physiomotion4d.convert_vtk_to_usd import ConvertVTKToUSD
 from physiomotion4d.physiomotion4d_base import PhysioMotion4DBase
 from physiomotion4d.register_images_ants import RegisterImagesANTs
 from physiomotion4d.register_images_base import RegisterImagesBase
@@ -422,7 +422,7 @@ class WorkflowConvertHeartGatedCTToUSD(PhysioMotion4DBase):
             self.log_info("Creating %s anatomy USD...", anatomy_type)
 
             # Convert VTK contours to USD
-            converter = ConvertVTK4DToUSD(
+            converter = ConvertVTKToUSD(
                 self.project_name,
                 self._transformed_contours[anatomy_type],
                 self.segmenter.all_mask_ids,

--- a/statistics.md
+++ b/statistics.md
@@ -48,8 +48,8 @@ PhysioMotion4D is a sophisticated medical imaging package for generating anatomi
 | `workflow_register_heart_model_to_patient.py` | 745   | Model-to-patient registration workflow         |
 | `register_images_ants.py`                     | 725   | ANTs-based image registration                  |
 | `segment_chest_base.py`                       | 672   | Base class for chest segmentation              |
-| `convert_vtk_4d_to_usd_polymesh.py`           | 622   | Polymesh USD conversion                        |
-| `convert_vtk_4d_to_usd_base.py`               | 585   | Base USD conversion functionality              |
+| `convert_vtk_to_usd_polymesh.py`           | 622   | Polymesh USD conversion                        |
+| `convert_vtk_to_usd_base.py`               | 585   | Base USD conversion functionality              |
 | `workflow_convert_heart_gated_ct_to_usd.py`   | 539   | Heart CT to USD workflow                       |
 | `usd_tools.py`                                | 536   | USD file manipulation                          |
 | `register_time_series_images.py`              | 528   | Time series registration                       |

--- a/tests/GITHUB_WORKFLOWS.md
+++ b/tests/GITHUB_WORKFLOWS.md
@@ -94,7 +94,7 @@ Tests that require downloading external data, executed in sequence with caching.
 
 4. **USD Conversion Tests**
    ```bash
-   pytest tests/test_convert_vtk_4d_to_usd_polymesh.py -v -m "not slow" --cov=src/physiomotion4d --cov-append --cov-report=xml
+   pytest tests/test_convert_vtk_to_usd_polymesh.py -v -m "not slow" --cov=src/physiomotion4d --cov-append --cov-report=xml
    ```
    - Tests VTK to USD conversion
    - Uses contour data

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,7 +28,7 @@ This directory contains comprehensive test suites for the PhysioMotion4D package
 ### Geometry & Visualization Tests
 - **`test_contour_tools.py`** - PyVista mesh extraction and manipulation
 - **`test_transform_tools.py`** - ITK transform operations and visualization
-- **`test_convert_vtk_4d_to_usd_polymesh.py`** - VTK to USD conversion
+- **`test_convert_vtk_to_usd_polymesh.py`** - VTK to USD conversion
 
 ### USD Utility Tests
 - **`test_usd_merge.py`** - USD file merging with material preservation
@@ -127,7 +127,7 @@ test_convert_nrrd_4d_to_3d
     ↓                    ↓
 test_segment_chest_total_segmentator ────→ test_contour_tools
     ↓                                           ↓
-test_segment_chest_vista_3d                test_convert_vtk_4d_to_usd_polymesh
+test_segment_chest_vista_3d                test_convert_vtk_to_usd_polymesh
 ```
 
 Fixtures in `conftest.py` automatically manage these dependencies.

--- a/tests/TESTING_GUIDE.md
+++ b/tests/TESTING_GUIDE.md
@@ -70,7 +70,7 @@ test_convert_nrrd_4d_to_3d
     ↓                    ↓
 test_segment_chest_total_segmentator ────→ test_contour_tools
     ↓                                           ↓
-test_segment_chest_vista_3d                test_convert_vtk_4d_to_usd_polymesh
+test_segment_chest_vista_3d                test_convert_vtk_to_usd_polymesh
 ```
 
 ### Test Markers

--- a/tests/test_convert_vtk_to_usd_polymesh.py
+++ b/tests/test_convert_vtk_to_usd_polymesh.py
@@ -11,12 +11,12 @@ import pytest
 import pyvista as pv
 from pxr import UsdGeom
 
-from physiomotion4d.convert_vtk_4d_to_usd_polymesh import ConvertVTK4DToUSDPolyMesh
+from physiomotion4d.convert_vtk_to_usd_polymesh import ConvertVTKToUSDPolyMesh
 
 
 @pytest.mark.requires_data
 @pytest.mark.slow
-class TestConvertVTK4DToUSDPolyMesh:
+class TestConvertVTKToUSDPolyMesh:
     """Test suite for VTK to USD PolyMesh conversion."""
 
     @pytest.fixture(scope="class")
@@ -54,8 +54,8 @@ class TestConvertVTK4DToUSDPolyMesh:
         return meshes
 
     def test_converter_initialization(self):
-        """Test that ConvertVTK4DToUSDPolyMesh initializes correctly."""
-        converter = ConvertVTK4DToUSDPolyMesh(
+        """Test that ConvertVTKToUSDPolyMesh initializes correctly."""
+        converter = ConvertVTKToUSDPolyMesh(
             data_basename="TestModel", input_polydata=[], mask_ids=None
         )
 
@@ -68,7 +68,7 @@ class TestConvertVTK4DToUSDPolyMesh:
         """Test that converter correctly identifies supported mesh types."""
         mesh = contour_meshes[0]
 
-        converter = ConvertVTK4DToUSDPolyMesh(
+        converter = ConvertVTKToUSDPolyMesh(
             data_basename="TestModel", input_polydata=[mesh], mask_ids=None
         )
 
@@ -89,7 +89,7 @@ class TestConvertVTK4DToUSDPolyMesh:
         print("\nConverting single time point to USD...")
         print(f"  Mesh: {mesh.n_points} points, {mesh.n_cells} cells")
 
-        converter = ConvertVTK4DToUSDPolyMesh(
+        converter = ConvertVTKToUSDPolyMesh(
             data_basename="HeartSingle", input_polydata=[mesh], mask_ids=None
         )
 
@@ -117,7 +117,7 @@ class TestConvertVTK4DToUSDPolyMesh:
         print("\nConverting multiple time points to USD...")
         print(f"  Time points: {len(contour_meshes)}")
 
-        converter = ConvertVTK4DToUSDPolyMesh(
+        converter = ConvertVTKToUSDPolyMesh(
             data_basename="HeartMulti", input_polydata=contour_meshes, mask_ids=None
         )
 
@@ -161,7 +161,7 @@ class TestConvertVTK4DToUSDPolyMesh:
 
         print("\nConverting mesh with deformation magnitude...")
 
-        converter = ConvertVTK4DToUSDPolyMesh(
+        converter = ConvertVTKToUSDPolyMesh(
             data_basename="HeartDeformation", input_polydata=[contours], mask_ids=None
         )
 
@@ -194,7 +194,7 @@ class TestConvertVTK4DToUSDPolyMesh:
 
         print("\nConverting mesh with colormap...")
 
-        converter = ConvertVTK4DToUSDPolyMesh(
+        converter = ConvertVTKToUSDPolyMesh(
             data_basename="HeartColormap", input_polydata=[mesh], mask_ids=None
         )
 
@@ -246,7 +246,7 @@ class TestConvertVTK4DToUSDPolyMesh:
         print("\nConverting UnstructuredGrid to USD...")
         print(f"  Grid: {ugrid.n_points} points, {ugrid.n_cells} cells")
 
-        converter = ConvertVTK4DToUSDPolyMesh(
+        converter = ConvertVTKToUSDPolyMesh(
             data_basename="CubeSurface",
             input_polydata=[ugrid],
             mask_ids=None,
@@ -268,7 +268,7 @@ class TestConvertVTK4DToUSDPolyMesh:
         usd_output_dir = output_dir / "usd_polymesh"
         usd_output_dir.mkdir(exist_ok=True)
 
-        converter = ConvertVTK4DToUSDPolyMesh(
+        converter = ConvertVTKToUSDPolyMesh(
             data_basename="HeartStructure",
             input_polydata=[contour_meshes[0]],
             mask_ids=None,
@@ -313,7 +313,7 @@ class TestConvertVTK4DToUSDPolyMesh:
         print(f"  Mesh 1: {mesh1.n_points} points, {mesh1.n_cells} cells")
         print(f"  Mesh 2: {mesh2.n_points} points, {mesh2.n_cells} cells")
 
-        converter = ConvertVTK4DToUSDPolyMesh(
+        converter = ConvertVTKToUSDPolyMesh(
             data_basename="HeartVarying", input_polydata=[mesh1, mesh2], mask_ids=None
         )
 
@@ -362,7 +362,7 @@ class TestConvertVTK4DToUSDPolyMesh:
 
             # Convert each anatomy separately
             for anatomy, mesh in meshes_dict.items():
-                converter = ConvertVTK4DToUSDPolyMesh(
+                converter = ConvertVTKToUSDPolyMesh(
                     data_basename=f"{anatomy.capitalize()}",
                     input_polydata=[mesh],
                     mask_ids=None,


### PR DESCRIPTION
Remove '4d' suffix from module names, function names, and references throughout the codebase. Update documentation, examples, and notebooks to reflect simplified naming convention. The temporal dimension is implicit in the physiomotion4d package name, and most methods work on 3D as well as 4D data.