### PR TITLE
ENH: Add commit and simplify-staged Claude Code skills

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -10,8 +10,8 @@ $ARGUMENTS
 Instructions:
 
 0. Run `git branch --show-current` to check the active branch.
-   If the branch is `main`, stop immediately and report:
-   "ERROR: Refusing to commit directly to main. Please switch to a feature branch first."
+   If the output is empty (detached HEAD) or the branch is `main`, stop immediately and report:
+   "ERROR: Refusing to commit in detached HEAD state or directly to main. Please switch to a named feature branch first."
    Do not proceed further.
 
 1. Run `git diff HEAD` and `git status` to understand what has changed.
@@ -38,9 +38,9 @@ Instructions:
 4. If the commit fails because a pre-commit hook rejected it:
    a. Read the hook output carefully.
    b. Fix every reported issue (formatting, lint errors, type errors, test failures, etc.).
-      - For `ruff` formatting/lint: run ruff only on the modified Python files
-        (`git diff HEAD --name-only`), not the whole repo. Pass only those `.py`
-        files to `ruff check --fix` and `ruff format`.
+      - For `ruff` formatting/lint: use `git diff --diff-filter=d --name-only HEAD -- '*.py'`
+        to list modified, non-deleted `.py` files, then pass only those to
+        `ruff check --fix` and `ruff format`. Do not run ruff project-wide.
       - For `mypy` errors: fix the type annotations in the flagged files.
       - For other hook failures: diagnose and fix the root cause; do NOT use `--no-verify`.
    c. Return to step 3 and retry — repeat until the commit succeeds or you have exhausted reasonable fixes.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -38,7 +38,9 @@ Instructions:
 4. If the commit fails because a pre-commit hook rejected it:
    a. Read the hook output carefully.
    b. Fix every reported issue (formatting, lint errors, type errors, test failures, etc.).
-      - For `ruff` formatting/lint: run `ruff check . --fix && ruff format .`
+      - For `ruff` formatting/lint: run ruff only on the modified Python files
+        (`git diff HEAD --name-only`), not the whole repo. Pass only those `.py`
+        files to `ruff check --fix` and `ruff format`.
       - For `mypy` errors: fix the type annotations in the flagged files.
       - For other hook failures: diagnose and fix the root cause; do NOT use `--no-verify`.
    c. Return to step 3 and retry — repeat until the commit succeeds or you have exhausted reasonable fixes.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,42 @@
+---
+description: Stage all changes, draft a commit message from the diff, fix any pre-commit hook failures, and repeat until the commit succeeds.
+---
+
+Commit all pending changes in the PhysioMotion4D repository.
+
+$ARGUMENTS
+
+Instructions:
+
+0. Run `git branch --show-current` to check the active branch.
+   If the branch is `main`, stop immediately and report:
+   "ERROR: Refusing to commit directly to main. Please switch to a feature branch first."
+   Do not proceed further.
+
+1. Run `git diff HEAD` and `git status` to understand what has changed.
+   - Read any modified source files that are not self-explanatory from the diff alone.
+   - Do NOT commit files that look like secrets, large binaries, or generated artefacts that belong in .gitignore.
+   - Do NOT add any untracked files to the commit
+   - ONLY perform the equivalent to a `git commit -a`
+
+2. Draft a commit message following the project convention (match style of recent `git log --oneline -10`):
+   - Subject line: `<TAG>: <imperative summary>` (≤72 chars), where TAG is one of:
+     `ENH` (new feature / enhancement), `FIX` (bug fix), `REF` (refactor),
+     `TST` (tests only), `DOC` (docs/comments only), `MNT` (maintenance / config).
+   - Optional body: 1–3 sentences explaining *why*, not *what*.
+
+3. Attempt the commit:
+   ```
+   git commit -a -m "<subject>" -m "<body with co-author line>"
+   ```
+
+4. If the commit fails because a pre-commit hook rejected it:
+   a. Read the hook output carefully.
+   b. Fix every reported issue (formatting, lint errors, type errors, test failures, etc.).
+      - For `ruff` formatting/lint: run `ruff check . --fix && ruff format .`
+      - For `mypy` errors: fix the type annotations in the flagged files.
+      - For other hook failures: diagnose and fix the root cause; do NOT use `--no-verify`.
+   c. Return to step 3 and retry — repeat until the commit succeeds or you have exhausted reasonable fixes.
+   d. If an issue cannot be fixed automatically (e.g. a failing test unrelated to the current changes), report it to the user and stop.
+
+5. After a successful commit, print the one-line commit summary (`git log --oneline -1`).

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,8 +1,9 @@
 ---
-description: Stage all changes, draft a commit message from the diff, fix any pre-commit hook failures, and repeat until the commit succeeds.
+description: Stage all tracked modifications and deletions, draft a commit message from the diff, fix any pre-commit hook failures, and repeat until the commit succeeds.
 ---
 
-Commit all pending changes in the PhysioMotion4D repository.
+Commit all tracked pending changes in the PhysioMotion4D repository
+(equivalent to `git commit -a`, excluding new untracked files).
 
 $ARGUMENTS
 
@@ -15,9 +16,9 @@ Instructions:
 
 1. Run `git diff HEAD` and `git status` to understand what has changed.
    - Read any modified source files that are not self-explanatory from the diff alone.
-   - Do NOT commit files that look like secrets, large binaries, or generated artefacts that belong in .gitignore.
-   - Do NOT add any untracked files to the commit
-   - ONLY perform the equivalent to a `git commit -a`
+   - If any tracked file contains secrets, large binaries, or generated artefacts
+     that should not be committed, display an error, stop processing, and abort
+   - Do NOT add any untracked files to the commit.
 
 2. Draft a commit message following the project convention (match style of recent `git log --oneline -10`):
    - Subject line: `<TAG>: <imperative summary>` (≤72 chars), where TAG is one of:
@@ -25,9 +26,13 @@ Instructions:
      `TST` (tests only), `DOC` (docs/comments only), `MNT` (maintenance / config).
    - Optional body: 1–3 sentences explaining *why*, not *what*.
 
-3. Attempt the commit:
+3. Attempt the commit. Include a body only when it adds meaningful context:
+   ```bash
+   git commit -a -m "<subject>" -m "<body>"
    ```
-   git commit -a -m "<subject>" -m "<body with co-author line>"
+   Subject-only form when no body is needed:
+   ```bash
+   git commit -a -m "<subject>"
    ```
 
 4. If the commit fails because a pre-commit hook rejected it:
@@ -39,4 +44,5 @@ Instructions:
    c. Return to step 3 and retry — repeat until the commit succeeds or you have exhausted reasonable fixes.
    d. If an issue cannot be fixed automatically (e.g. a failing test unrelated to the current changes), report it to the user and stop.
 
-5. After a successful commit, print the one-line commit summary (`git log --oneline -1`).
+5. After a successful commit, print the one-line commit summary (`git log --oneline -1`)
+   and remind the user: "Remember to `git push` when you are ready to publish this commit."

--- a/.claude/skills/simplify-staged/SKILL.md
+++ b/.claude/skills/simplify-staged/SKILL.md
@@ -25,7 +25,8 @@ and skill levels. Every change should meet the following bar before it is commit
 
 2. For each modified Python file, read the **entire file** — not just the diff.
    Understanding the unchanged context is necessary to judge whether the new code
-   fits naturally.
+   fits naturally. If a path from `git diff HEAD --name-only` no longer exists on
+   disk (deleted or renamed), skip it — do not attempt to read or edit it.
 
 3. For each changed section, apply the checks below. Fix every issue found directly
    in the file using small, targeted edits. Do not refactor code that was not changed.
@@ -56,8 +57,9 @@ and skill levels. Every change should meet the following bar before it is commit
 - [ ] Is there dead code (unreachable branches, unused imports, stale comments)?
       Remove it.
 
-4. After editing, run ruff only on the Python files that appear in the diff
-   (`git diff HEAD --name-only`). Pass only those `.py` files to
+4. After editing, run ruff only on Python files that are modified and still exist
+   on disk. Use `git diff --diff-filter=d --name-only HEAD -- '*.py'` to list
+   changed, non-deleted `.py` files, then pass only that list to
    `ruff check --fix` and `ruff format`. Do not run ruff project-wide — it
    may reformat files outside the current change set.
 

--- a/.claude/skills/simplify-staged/SKILL.md
+++ b/.claude/skills/simplify-staged/SKILL.md
@@ -56,7 +56,10 @@ and skill levels. Every change should meet the following bar before it is commit
 - [ ] Is there dead code (unreachable branches, unused imports, stale comments)?
       Remove it.
 
-4. After editing, run `ruff check . --fix && ruff format .` to enforce code style.
+4. After editing, run ruff only on the Python files that appear in the diff
+   (`git diff HEAD --name-only`). Pass only those `.py` files to
+   `ruff check --fix` and `ruff format`. Do not run ruff project-wide — it
+   may reformat files outside the current change set.
 
 5. Report a concise summary of every change made, grouped by file. If a file needed
    no changes, say so explicitly. Do not describe changes you did not make.

--- a/.claude/skills/simplify-staged/SKILL.md
+++ b/.claude/skills/simplify-staged/SKILL.md
@@ -1,0 +1,62 @@
+---
+description: Review and simplify code in all tracked files modified since HEAD, applying open-source clarity and quality standards before committing.
+---
+
+Review and simplify the code in all files that would be staged by `git commit -a`.
+
+$ARGUMENTS
+
+## Goals
+
+This is an open-source project that welcomes contributors with a range of backgrounds
+and skill levels. Every change should meet the following bar before it is committed:
+
+- **Readable** — logic is immediately clear to a developer unfamiliar with the file.
+- **Focused** — each function or method does one thing; no hidden side effects.
+- **Consistent** — style, naming, and patterns match the surrounding codebase.
+- **Well-typed** — full type hints; no `Any` unless unavoidable and documented.
+- **Documented** — every public method has a docstring that states what it does,
+  its arguments, and return value.
+
+## Instructions
+
+1. Run `git diff HEAD` to get the full diff of tracked modified files.
+   Also run `git diff HEAD --name-only` to list just the changed files.
+
+2. For each modified Python file, read the **entire file** — not just the diff.
+   Understanding the unchanged context is necessary to judge whether the new code
+   fits naturally.
+
+3. For each changed section, apply the checks below. Fix every issue found directly
+   in the file using small, targeted edits. Do not refactor code that was not changed.
+
+### Clarity checks
+- [ ] Are variable and parameter names self-describing? Rename single-letter or
+      cryptic names (except conventional loop indices and math variables).
+- [ ] Are boolean flags or ternary chains better expressed as an early return,
+      a guard clause, or a named predicate?
+- [ ] Are there any magic numbers or string literals that should be named constants?
+- [ ] Is any comment explaining *what* the code does (redundant) rather than *why*?
+      Remove what-comments; keep why-comments.
+
+### Reuse and abstraction checks
+- [ ] Is logic duplicated across two or more changed sites? Extract a helper only
+      if it will be called from at least two places *within the current change set*.
+      Do not introduce speculative abstractions.
+- [ ] Does the new code re-implement something already available in the existing
+      codebase (check `docs/API_MAP.md`) or in the standard library / dependencies
+      already listed in `pyproject.toml`?
+
+### Quality checks
+- [ ] Are there missing or incorrect type annotations? Fix them.
+- [ ] Does every new public method have a complete docstring (summary, Args, Returns,
+      and shape/axis notes for array/image parameters)?
+- [ ] Are error messages descriptive enough for a contributor who has never seen
+      this code to understand what went wrong and where?
+- [ ] Is there dead code (unreachable branches, unused imports, stale comments)?
+      Remove it.
+
+4. After editing, run `ruff check . --fix && ruff format .` to enforce code style.
+
+5. Report a concise summary of every change made, grouped by file. If a file needed
+   no changes, say so explicitly. Do not describe changes you did not make.

--- a/docs/API_MAP.md
+++ b/docs/API_MAP.md
@@ -787,18 +787,20 @@ _Re-run `py utils/generate_api_map.py` whenever public APIs change._
 
 ## utils/claude_github_reviews.py
 
-- `def get_repo_root()` (line 51)
-- `def get_repo_slug(repo_root)` (line 65): Derive owner/repo from the git remote URL (upstream, falling back to origin).
-- `def parse_github_datetime(iso_str)` (line 90): Parse GitHub API timestamps (may end with Z).
-- `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 106): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
-- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 146): Keep inline comments with created_at > cutoff and reviews with
-- `def fetch_pr_data(pr_number, repo)` (line 224)
-- `def fetch_inline_comments(pr_number, repo)` (line 230)
-- `def fetch_reviews(pr_number, repo)` (line 235)
-- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 308)
-- `def invoke_claude(prompt, repo_root)` (line 425): Invoke Claude Code non-interactively via stdin.
-- `def parse_args()` (line 473)
-- `def main()` (line 517)
+- `def get_current_branch(repo_root)` (line 51): Return the name of the currently checked-out branch.
+- `def git_fetch(repo_root, remote, branch)` (line 66): Run ``git fetch <remote> <branch>``, printing progress.
+- `def get_repo_root()` (line 80)
+- `def get_repo_slug(repo_root)` (line 94): Derive owner/repo from the git remote URL (upstream, falling back to origin).
+- `def parse_github_datetime(iso_str)` (line 119): Parse GitHub API timestamps (may end with Z).
+- `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 135): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
+- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 175): Keep inline comments with created_at > cutoff and reviews with
+- `def fetch_pr_data(pr_number, repo)` (line 253)
+- `def fetch_inline_comments(pr_number, repo)` (line 259)
+- `def fetch_reviews(pr_number, repo)` (line 264)
+- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 337)
+- `def invoke_claude(prompt, repo_root)` (line 454): Invoke Claude Code non-interactively via stdin.
+- `def parse_args()` (line 502)
+- `def main()` (line 547)
 
 ## utils/generate_api_map.py
 

--- a/docs/API_MAP.md
+++ b/docs/API_MAP.md
@@ -787,20 +787,19 @@ _Re-run `py utils/generate_api_map.py` whenever public APIs change._
 
 ## utils/claude_github_reviews.py
 
-- `def get_current_branch(repo_root)` (line 51): Return the name of the currently checked-out branch.
-- `def git_fetch(repo_root, remote, branch)` (line 66): Run ``git fetch <remote> <branch>``, printing progress.
-- `def get_repo_root()` (line 80)
-- `def get_repo_slug(repo_root)` (line 94): Derive owner/repo from the git remote URL (upstream, falling back to origin).
-- `def parse_github_datetime(iso_str)` (line 119): Parse GitHub API timestamps (may end with Z).
-- `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 135): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
-- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 175): Keep inline comments with created_at > cutoff and reviews with
-- `def fetch_pr_data(pr_number, repo)` (line 253)
-- `def fetch_inline_comments(pr_number, repo)` (line 259)
-- `def fetch_reviews(pr_number, repo)` (line 264)
-- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 337)
-- `def invoke_claude(prompt, repo_root)` (line 454): Invoke Claude Code non-interactively via stdin.
-- `def parse_args()` (line 502)
-- `def main()` (line 547)
+- `def git_fetch(repo_root, remote, branch)` (line 51): Run ``git fetch <remote> <branch>``, printing progress.
+- `def get_repo_root()` (line 65)
+- `def get_repo_slug(repo_root)` (line 79): Derive owner/repo from the git remote URL (upstream, falling back to origin).
+- `def parse_github_datetime(iso_str)` (line 104): Parse GitHub API timestamps (may end with Z).
+- `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 120): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
+- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 160): Keep inline comments with created_at > cutoff and reviews with
+- `def fetch_pr_data(pr_number, repo)` (line 238)
+- `def fetch_inline_comments(pr_number, repo)` (line 244)
+- `def fetch_reviews(pr_number, repo)` (line 249)
+- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 322)
+- `def invoke_claude(prompt, repo_root)` (line 439): Invoke Claude Code non-interactively via stdin.
+- `def parse_args()` (line 487)
+- `def main()` (line 533)
 
 ## utils/generate_api_map.py
 

--- a/docs/API_MAP.md
+++ b/docs/API_MAP.md
@@ -788,17 +788,17 @@ _Re-run `py utils/generate_api_map.py` whenever public APIs change._
 ## utils/claude_github_reviews.py
 
 - `def get_repo_root()` (line 51)
-- `def get_repo_slug(repo_root)` (line 65): Derive owner/repo from the git remote origin URL.
-- `def parse_github_datetime(iso_str)` (line 86): Parse GitHub API timestamps (may end with Z).
-- `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 102): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
-- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 142): Keep inline comments with created_at > cutoff and reviews with
-- `def fetch_pr_data(pr_number, repo)` (line 220)
-- `def fetch_inline_comments(pr_number, repo)` (line 226)
-- `def fetch_reviews(pr_number, repo)` (line 231)
-- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 304)
-- `def invoke_claude(prompt, repo_root)` (line 421): Invoke Claude Code non-interactively via stdin.
-- `def parse_args()` (line 469)
-- `def main()` (line 513)
+- `def get_repo_slug(repo_root)` (line 65): Derive owner/repo from the git remote URL (upstream, falling back to origin).
+- `def parse_github_datetime(iso_str)` (line 90): Parse GitHub API timestamps (may end with Z).
+- `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 106): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
+- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 146): Keep inline comments with created_at > cutoff and reviews with
+- `def fetch_pr_data(pr_number, repo)` (line 224)
+- `def fetch_inline_comments(pr_number, repo)` (line 230)
+- `def fetch_reviews(pr_number, repo)` (line 235)
+- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 308)
+- `def invoke_claude(prompt, repo_root)` (line 425): Invoke Claude Code non-interactively via stdin.
+- `def parse_args()` (line 473)
+- `def main()` (line 517)
 
 ## utils/generate_api_map.py
 

--- a/utils/claude_github_reviews.py
+++ b/utils/claude_github_reviews.py
@@ -15,10 +15,10 @@ Workflow:
 Usage:
   py utils/claude_github_reviews.py --pr 42
   py utils/claude_github_reviews.py --pr 42 --repo owner/repo
-  py utils/claude_github_reviews.py --pr 42 --prompt_only
-  py utils/claude_github_reviews.py --pr 42 --since_last_push --prompt_only
+  py utils/claude_github_reviews.py --pr 42 --prompt-only
+  py utils/claude_github_reviews.py --pr 42 --since-last-push --prompt-only
 
-  With --since_last_push, only inline comments and PR-level reviews created after
+  With --since-last-push, only inline comments and PR-level reviews created after
   the latest reflog time for refs/remotes/<remote>/<PR_head_branch> are included.
   That time is when this clone last saw the remote ref move (push or fetch), not
   necessarily the exact server push timestamp.
@@ -46,21 +46,6 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 # Git / repo helpers
 # ---------------------------------------------------------------------------
-
-
-def get_current_branch(repo_root: Path) -> str:
-    """Return the name of the currently checked-out branch."""
-    try:
-        out = subprocess.run(
-            ["git", "branch", "--show-current"],
-            check=True,
-            text=True,
-            capture_output=True,
-            cwd=repo_root,
-        )
-        return out.stdout.strip()
-    except subprocess.CalledProcessError:
-        return ""
 
 
 def git_fetch(repo_root: Path, remote: str, branch: str) -> None:
@@ -518,17 +503,18 @@ def parse_args() -> argparse.Namespace:
         "--repo",
         metavar="OWNER/REPO",
         default=None,
-        help="GitHub repo slug (default: inferred from git remote origin)",
+        help="GitHub repo slug (default: inferred from git remote upstream, falling back to origin)",
     )
     parser.add_argument(
-        "--prompt_only",
+        "--prompt-only",
         "--dry-run",
         dest="prompt_only",
         action="store_true",
         help="Print the prompt that would be sent to Claude and exit without changes",
     )
     parser.add_argument(
-        "--since_last_push",
+        "--since-last-push",
+        dest="since_last_push",
         action="store_true",
         help=(
             "Only include inline comments and reviews after the latest reflog time "
@@ -539,7 +525,7 @@ def parse_args() -> argparse.Namespace:
         "--remote",
         metavar="NAME",
         default="origin",
-        help="Git remote name for fetch/reflog (default: origin; used with --since_last_push)",
+        help="Git remote name for fetch/reflog (default: origin; used with --since-last-push)",
     )
     return parser.parse_args()
 
@@ -576,18 +562,18 @@ def main() -> None:
     if args.since_last_push:
         head_ref = pr_data.get("head", {}).get("ref")
         if not head_ref:
-            print("[ERROR] PR has no head branch ref; cannot use --since_last_push.")
+            print("[ERROR] PR has no head branch ref; cannot use --since-last-push.")
             sys.exit(1)
         if head_ref == "main":
             print(
-                "[ERROR] PR head branch is 'main'; --since_last_push is not meaningful here."
+                "[ERROR] PR head branch is 'main'; --since-last-push is not meaningful here."
             )
             sys.exit(1)
         git_fetch(repo_root, args.remote, head_ref)
         remote_ref = f"refs/remotes/{args.remote}/{head_ref}"
         cutoff = get_remote_reflog_cutoff(repo_root, args.remote, head_ref)
         print()
-        print("[*] --since_last_push")
+        print("[*] --since-last-push")
         print(f"    Remote ref : {remote_ref}")
         print(f"    Cutoff     : {cutoff.isoformat()}")
         inline_comments, reviews = filter_since_cutoff(inline_comments, reviews, cutoff)
@@ -620,16 +606,16 @@ def main() -> None:
         if args.since_last_push:
             print()
             print(
-                "[prompt_only] --since_last_push: using cutoff and counts above "
+                "[prompt-only] --since-last-push: using cutoff and counts above "
                 "(full prompt follows)."
             )
         print(f"\n{separator}")
-        print("PROMPT (prompt_only — not sent to Claude)")
+        print("PROMPT (prompt-only — not sent to Claude)")
         print(separator)
         print(prompt)
         print(separator)
-        print("\n[prompt_only] No files changed.")
-        print(f"[prompt_only] Summary would be written to: {summary_filename}")
+        print("\n[prompt-only] No files changed.")
+        print(f"[prompt-only] Summary would be written to: {summary_filename}")
         sys.exit(0)
 
     invoke_claude(prompt, repo_root)

--- a/utils/claude_github_reviews.py
+++ b/utils/claude_github_reviews.py
@@ -16,9 +16,9 @@ Usage:
   py utils/claude_github_reviews.py --pr 42
   py utils/claude_github_reviews.py --pr 42 --repo owner/repo
   py utils/claude_github_reviews.py --pr 42 --prompt_only
-  py utils/claude_github_reviews.py --pr 42 --since-last-push --prompt_only
+  py utils/claude_github_reviews.py --pr 42 --since_last_push --prompt_only
 
-  With --since-last-push, only inline comments and PR-level reviews created after
+  With --since_last_push, only inline comments and PR-level reviews created after
   the latest reflog time for refs/remotes/<remote>/<PR_head_branch> are included.
   That time is when this clone last saw the remote ref move (push or fetch), not
   necessarily the exact server push timestamp.
@@ -46,6 +46,35 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 # Git / repo helpers
 # ---------------------------------------------------------------------------
+
+
+def get_current_branch(repo_root: Path) -> str:
+    """Return the name of the currently checked-out branch."""
+    try:
+        out = subprocess.run(
+            ["git", "branch", "--show-current"],
+            check=True,
+            text=True,
+            capture_output=True,
+            cwd=repo_root,
+        )
+        return out.stdout.strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def git_fetch(repo_root: Path, remote: str, branch: str) -> None:
+    """Run ``git fetch <remote> <branch>``, printing progress."""
+    print(f"[*] Fetching {remote}/{branch} ...")
+    try:
+        subprocess.run(
+            ["git", "fetch", remote, branch],
+            check=True,
+            cwd=repo_root,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"[ERROR] git fetch {remote} {branch} failed (exit {exc.returncode}).")
+        sys.exit(exc.returncode)
 
 
 def get_repo_root() -> Path:
@@ -493,13 +522,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--prompt_only",
+        "--dry-run",
+        dest="prompt_only",
         action="store_true",
         help="Print the prompt that would be sent to Claude and exit without changes",
     )
     parser.add_argument(
-        "--since-last-push",
+        "--since_last_push",
         action="store_true",
-        dest="since_last_push",
         help=(
             "Only include inline comments and reviews after the latest reflog time "
             "for refs/remotes/<remote>/<PR_head_branch> (this clone)"
@@ -508,8 +538,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--remote",
         metavar="NAME",
-        default="upstream",
-        help="Git remote name for reflog (default: upstream; used with --since-last-push)",
+        default="origin",
+        help="Git remote name for fetch/reflog (default: origin; used with --since_last_push)",
     )
     return parser.parse_args()
 
@@ -546,12 +576,18 @@ def main() -> None:
     if args.since_last_push:
         head_ref = pr_data.get("head", {}).get("ref")
         if not head_ref:
-            print("[ERROR] PR has no head branch ref; cannot use --since-last-push.")
+            print("[ERROR] PR has no head branch ref; cannot use --since_last_push.")
             sys.exit(1)
+        if head_ref == "main":
+            print(
+                "[ERROR] PR head branch is 'main'; --since_last_push is not meaningful here."
+            )
+            sys.exit(1)
+        git_fetch(repo_root, args.remote, head_ref)
         remote_ref = f"refs/remotes/{args.remote}/{head_ref}"
         cutoff = get_remote_reflog_cutoff(repo_root, args.remote, head_ref)
         print()
-        print("[*] --since-last-push")
+        print("[*] --since_last_push")
         print(f"    Remote ref : {remote_ref}")
         print(f"    Cutoff     : {cutoff.isoformat()}")
         inline_comments, reviews = filter_since_cutoff(inline_comments, reviews, cutoff)
@@ -584,11 +620,11 @@ def main() -> None:
         if args.since_last_push:
             print()
             print(
-                "[prompt_only] --since-last-push: using cutoff and counts above "
+                "[prompt_only] --since_last_push: using cutoff and counts above "
                 "(full prompt follows)."
             )
         print(f"\n{separator}")
-        print("PROMPT (dry run — not sent to Claude)")
+        print("PROMPT (prompt_only — not sent to Claude)")
         print(separator)
         print(prompt)
         print(separator)

--- a/utils/claude_github_reviews.py
+++ b/utils/claude_github_reviews.py
@@ -15,8 +15,8 @@ Workflow:
 Usage:
   py utils/claude_github_reviews.py --pr 42
   py utils/claude_github_reviews.py --pr 42 --repo owner/repo
-  py utils/claude_github_reviews.py --pr 42 --dry-run
-  py utils/claude_github_reviews.py --pr 42 --since-last-push --dry-run
+  py utils/claude_github_reviews.py --pr 42 --prompt_only
+  py utils/claude_github_reviews.py --pr 42 --since-last-push --prompt_only
 
   With --since-last-push, only inline comments and PR-level reviews created after
   the latest reflog time for refs/remotes/<remote>/<PR_head_branch> are included.
@@ -63,18 +63,22 @@ def get_repo_root() -> Path:
 
 
 def get_repo_slug(repo_root: Path) -> str:
-    """Derive owner/repo from the git remote origin URL."""
-    try:
-        out = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
-            check=True,
-            text=True,
-            capture_output=True,
-            cwd=repo_root,
-        )
-        remote = out.stdout.strip()
-    except subprocess.CalledProcessError:
-        print("[ERROR] Could not read git remote origin.")
+    """Derive owner/repo from the git remote URL (upstream, falling back to origin)."""
+    for remote_name in ("upstream", "origin"):
+        try:
+            out = subprocess.run(
+                ["git", "remote", "get-url", remote_name],
+                check=True,
+                text=True,
+                capture_output=True,
+                cwd=repo_root,
+            )
+            remote = out.stdout.strip()
+            break
+        except subprocess.CalledProcessError:
+            continue
+    else:
+        print("[ERROR] Could not read git remote URL from 'upstream' or 'origin'.")
         sys.exit(1)
     m = re.search(r"[:/]([^/:]+/[^/:]+?)(?:\.git)?$", remote)
     if not m:
@@ -432,7 +436,7 @@ def invoke_claude(prompt: str, repo_root: Path) -> None:
 
     try:
         subprocess.run(
-            ["claude", "--print", "--allowedTools", "Read,Edit,Glob,Grep"],
+            ["claude", "--print", "--allowedTools", "Read,Write,Edit,Glob,Grep"],
             input=prompt,
             text=True,
             encoding="utf-8",
@@ -456,7 +460,7 @@ def _save_prompt_fallback(prompt: str, repo_root: Path) -> None:
     print("[*] Prompt saved to .claude_review_prompt.txt")
     print("    Run manually with:")
     print(
-        '      claude --print --allowedTools "Read,Edit,Glob,Grep" '
+        '      claude --print --allowedTools "Read,Write,Edit,Glob,Grep" '
         "< .claude_review_prompt.txt"
     )
 
@@ -488,7 +492,7 @@ def parse_args() -> argparse.Namespace:
         help="GitHub repo slug (default: inferred from git remote origin)",
     )
     parser.add_argument(
-        "--dry-run",
+        "--prompt_only",
         action="store_true",
         help="Print the prompt that would be sent to Claude and exit without changes",
     )
@@ -504,8 +508,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--remote",
         metavar="NAME",
-        default="origin",
-        help="Git remote name for reflog (default: origin; used with --since-last-push)",
+        default="upstream",
+        help="Git remote name for reflog (default: upstream; used with --since-last-push)",
     )
     return parser.parse_args()
 
@@ -575,12 +579,12 @@ def main() -> None:
         summary_filename=summary_filename,
     )
 
-    if args.dry_run:
+    if args.prompt_only:
         separator = "=" * 60
         if args.since_last_push:
             print()
             print(
-                "[dry-run] --since-last-push: using cutoff and counts above "
+                "[prompt_only] --since-last-push: using cutoff and counts above "
                 "(full prompt follows)."
             )
         print(f"\n{separator}")
@@ -588,8 +592,8 @@ def main() -> None:
         print(separator)
         print(prompt)
         print(separator)
-        print("\n[dry-run] No files changed.")
-        print(f"[dry-run] Summary would be written to: {summary_filename}")
+        print("\n[prompt_only] No files changed.")
+        print(f"[prompt_only] Summary would be written to: {summary_filename}")
         sys.exit(0)
 
     invoke_claude(prompt, repo_root)


### PR DESCRIPTION
Provides /commit (auto-drafts message, fixes pre-commit hook failures, guards against committing to main) and /simplify-staged (reviews staged files for open-source clarity, reuse, and type-annotation standards before committing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing commit and review guidance covering safe commit checks, message format, and per-file simplification recommendations.
* **Chores**
  * Introduced standardized developer "skills" docs to unify commit/review practices.
* **New Features**
  * CLI: added a prompt-only mode, clarified/renamed flags and messages, enforced branch-safety (rejects main in certain flows), and fetches remote branch data before computing change ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->