### PR TITLE
FIX: Converting mm to voxels wrong for dilation in registration

### DIFF
--- a/src/physiomotion4d/register_images_base.py
+++ b/src/physiomotion4d/register_images_base.py
@@ -187,7 +187,7 @@ class RegisterImagesBase(PhysioMotion4DBase):
         if self.mask_dilation_mm > 0:
             imMath = ttk.ImageMath.New(self.fixed_mask)
             imMath.Dilate(
-                int(self.fixed_image.GetSpacing()[0] / self.mask_dilation_mm), 1, 0
+                int(self.mask_dilation_mm / self.fixed_image.GetSpacing()[0]), 1, 0
             )
             self.fixed_mask = imMath.GetOutputUChar()
 
@@ -320,7 +320,7 @@ class RegisterImagesBase(PhysioMotion4DBase):
             if self.mask_dilation_mm > 0:
                 imMath = ttk.ImageMath.New(new_moving_mask)
                 imMath.Dilate(
-                    int(moving_image.GetSpacing()[0] / self.mask_dilation_mm), 1, 0
+                    int(self.mask_dilation_mm / moving_image.GetSpacing()[0]), 1, 0
                 )
                 new_moving_mask = imMath.GetOutputUChar()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mask dilation distance calculations in image registration to ensure proper spatial correspondence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->