### PR TITLE
MNT: Add cuda12 extra, update URLs to Project-MONAI, fix capitalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
 
-    - name: Install PyTorch (CPU)
-      run: |
-        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-
     - name: Install package with test dependencies
       run: |
         pip install -e ".[test]"
@@ -196,10 +192,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
 
-    - name: Install PyTorch (CPU)
-      run: |
-        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-
     - name: Install package with test dependencies
       run: |
         pip install -e ".[test]"
@@ -235,7 +227,7 @@ jobs:
 
     - name: Run all integration tests
       run: |
-        pytest tests/ -v -m "not slow and not experiment"
+        pytest tests/ -v -m "not slow and not experiment and not requires_gpu"
       continue-on-error: true
 
     - name: Upload coverage to Codecov
@@ -254,7 +246,7 @@ jobs:
   # or by setting the 'run-gpu-tests' label on the PR.
   gpu-tests:
     name: GPU Tests (Python ${{ matrix.python-version }})
-    runs-on: [self-hosted, linux, gpu]
+    runs-on: [self-hosted, linux, gpu, cuda13]
     needs: unit-tests
     timeout-minutes: 30
     # Only run GPU tests on manual trigger or if 'run-gpu-tests' label is present
@@ -293,15 +285,12 @@ jobs:
 
     - name: Upgrade pip and build tools
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-
-    - name: Install PyTorch (CUDA 12.6)
-      run: |
-        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+        python -m pip install --upgrade pip setuptools wheel uv
 
     - name: Install package with test dependencies
+      # uv respects [tool.uv.sources], routing torch to pytorch-cu130 for cuda13
       run: |
-        pip install -e ".[test]"
+        uv pip install --system -e ".[test,cuda13]"
 
     - name: Verify GPU setup
       run: |
@@ -360,6 +349,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install ruff mypy
+        pip install -e ".[dev]"
 
     - name: Check formatting with Ruff
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,9 +52,7 @@ jobs:
         
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install uv
-        uv pip install --system torch torchvision --index-url https://download.pytorch.org/whl/cpu
+        python -m pip install --upgrade pip uv
         uv pip install --system -e ".[docs]"
 
     - name: Clear pip cache

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test-slow-gpu:
     name: Slow Tests on GPU
-    runs-on: [self-hosted, linux, gpu]
+    runs-on: [self-hosted, linux, gpu, cuda13]
     timeout-minutes: 60
     continue-on-error: true
 
@@ -40,17 +40,24 @@ jobs:
           ${{ runner.os }}-pip-gpu-
           ${{ runner.os }}-pip-
 
+    - name: Cache test data
+      uses: actions/cache@v4
+      with:
+        path: |
+          tests/data/
+          tests/results/
+        key: test-data-${{ hashFiles('tests/test_*.py') }}-v2
+        restore-keys: |
+          test-data-
+
     - name: Upgrade pip and build tools
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-
-    - name: Install PyTorch (CUDA 12.6)
-      run: |
-        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+        python -m pip install --upgrade pip setuptools wheel uv
 
     - name: Install package with test dependencies
+      # uv respects [tool.uv.sources], routing torch to pytorch-cu130 for cuda13
       run: |
-        pip install -e ".[test]"
+        uv pip install --system -e ".[test,cuda13]"
 
     - name: Run slow tests
       run: |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ PhysioMotion4D is a comprehensive medical imaging package that converts 4D CT sc
 ### Prerequisites
 
 - Python 3.10+ (Python 3.10, 3.11, or 3.12 recommended)
-- NVIDIA GPU with CUDA 13 (default) or CUDA 12 — CPU-only installation is not supported
+- NVIDIA GPU with CUDA 13 (default) or CUDA 12 — recommended for production use; CPU-only installation is supported but slow
 - 16GB+ RAM (32GB+ recommended for large datasets)
 - NVIDIA Omniverse (for USD visualization)
 - **Git LFS** (required for running tests: baseline files in `tests/baselines/` are stored with Git LFS; install from [git-lfs.github.com](https://git-lfs.github.com), then run `git lfs install` and `git lfs pull` after cloning)
@@ -34,12 +34,20 @@ PhysioMotion4D is a comprehensive medical imaging package that converts 4D CT sc
 ### Installation from PyPI
 
 ```bash
-# CUDA 13 install (recommended)
+# CPU-only install — works out of the box; a runtime warning points to the GPU extras
+pip install physiomotion4d
+
+# CUDA 13 install (recommended for production)
 uv pip install "physiomotion4d[cuda13]"
 
 # CUDA 12 install
 uv pip install "physiomotion4d[cuda12]"
 ```
+
+The `[cuda13]` and `[cuda12]` extras install both CuPy and the matching
+CUDA-built PyTorch wheel in one step — there is no need to install PyTorch
+separately. PyTorch is listed in the extras so that uv's dependency resolver
+fetches the GPU wheel from the PyTorch index instead of the CPU wheel from PyPI.
 
 For development with NVIDIA NIM cloud services:
 ```bash
@@ -69,7 +77,10 @@ pip install physiomotion4d[nim]
 
 4. **Install PhysioMotion4D**:
    ```bash
-   # CUDA 13
+   # CPU-only (evaluation / no GPU)
+   uv pip install -e "."
+
+   # CUDA 13 (recommended for production)
    uv pip install -e ".[cuda13]"
 
    # CUDA 12

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ PhysioMotion4D is a comprehensive medical imaging package that converts 4D CT sc
 ### Installation from PyPI
 
 ```bash
-# Default install — requires CUDA 13
-uv pip install physiomotion4d
+# CUDA 13 install (recommended)
+uv pip install "physiomotion4d[cuda13]"
 
 # CUDA 12 install
 uv pip install "physiomotion4d[cuda12]"
@@ -69,8 +69,8 @@ pip install physiomotion4d[nim]
 
 4. **Install PhysioMotion4D**:
    ```bash
-   # CUDA 13 (default)
-   uv pip install -e .
+   # CUDA 13
+   uv pip install -e ".[cuda13]"
 
    # CUDA 12
    uv pip install -e ".[cuda12]"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ PhysioMotion4D is a comprehensive medical imaging package that converts 4D CT sc
 ### Prerequisites
 
 - Python 3.10+ (Python 3.10, 3.11, or 3.12 recommended)
-- NVIDIA GPU with CUDA 12.6+ (for AI models and registration)
+- NVIDIA GPU with CUDA 13 (default) or CUDA 12 — CPU-only installation is not supported
 - 16GB+ RAM (32GB+ recommended for large datasets)
 - NVIDIA Omniverse (for USD visualization)
 - **Git LFS** (required for running tests: baseline files in `tests/baselines/` are stored with Git LFS; install from [git-lfs.github.com](https://git-lfs.github.com), then run `git lfs install` and `git lfs pull` after cloning)
@@ -34,7 +34,11 @@ PhysioMotion4D is a comprehensive medical imaging package that converts 4D CT sc
 ### Installation from PyPI
 
 ```bash
-pip install physiomotion4d
+# Default install — requires CUDA 13
+uv pip install physiomotion4d
+
+# CUDA 12 install
+uv pip install "physiomotion4d[cuda12]"
 ```
 
 For development with NVIDIA NIM cloud services:
@@ -65,12 +69,11 @@ pip install physiomotion4d[nim]
 
 4. **Install PhysioMotion4D**:
    ```bash
+   # CUDA 13 (default)
    uv pip install -e .
-   ```
 
-   Or with pip:
-   ```bash
-   pip install -e .
+   # CUDA 12
+   uv pip install -e ".[cuda12]"
    ```
 
 ### Verify Installation
@@ -125,7 +128,7 @@ print(f"PhysioMotion4D version: {physiomotion4d.__version__}")
 ### Key Dependencies
 
 - **Medical Imaging**: ITK, TubeTK, MONAI, nibabel, PyVista
-- **AI/ML**: PyTorch (CUDA 12.6), transformers, MONAI
+- **AI/ML**: PyTorch, CuPy (CUDA 13 default; CUDA 12 via `[cuda12]` extra), transformers, MONAI
 - **Registration**: icon-registration, unigradicon
 - **Visualization**: USD-core, PyVista
 - **Segmentation**: TotalSegmentator, VISTA-3D models

--- a/docs/API_MAP.md
+++ b/docs/API_MAP.md
@@ -326,23 +326,23 @@ _Re-run `py utils/generate_api_map.py` whenever public APIs change._
 
 ## src/physiomotion4d/transform_tools.py
 
-- **class TransformTools** (line 33): Utilities for transforming and manipulating ITK transforms.
-  - `def __init__(self, log_level=logging.INFO)` (line 66): Initialize the TransformTools class.
-  - `def combine_displacement_field_transforms(self, tfm1, tfm2, reference_image, tfm1_weight=1.0, tfm2_weight=1.0, mode='compose', tfm1_blur_sigma=0.0, tfm2_blur_sigma=0.0)` (line 74): Compose two displacement field transforms.
-  - `def convert_transform_to_displacement_field(self, tfm, reference_image, np_component_type=np.float64, use_reference_image_as_mask=False)` (line 158): Generate a dense deformation field from an ITK transform.
-  - `def convert_transform_to_displacement_field_transform(self, tfm, reference_image)` (line 246): Convert an ITK transform to a displacement field transform.
-  - `def invert_displacement_field_transform(self, tfm)` (line 263): Invert a displacement field transform.
-  - `def transform_pvcontour(self, contour, tfm, with_deformation_magnitude=False)` (line 285): Transform PyVista contour meshes using an ITK transform.
-  - `def transform_image(self, img, tfm, reference_image, interpolation_method='linear')` (line 348): Transform an ITK image using a specified transform and interpolation.
-  - `def convert_vtk_matrix_to_itk_transform(self, vtk_mat)` (line 425): Convert a VTK matrix to an ITK transform.
-  - `def smooth_transform(self, tfm, sigma, reference_image)` (line 460): Smooth a transform using Gaussian filtering to reduce noise.
-  - `def combine_transforms_with_masks(self, transform1, transform2, mask1, mask2, reference_image, max_iter=10, jacobian_threshold=0.1)` (line 519): Combine two transforms using spatial masks with folding correction.
-  - `def compute_jacobian_determinant_from_field(self, field)` (line 609): Compute Jacobian determinant of a displacement field.
-  - `def detect_folding_in_field(self, jacobian_det, threshold=0.1)` (line 638): Detect spatial folding in a transform.
-  - `def reduce_folding_in_field(self, field, jacobian_det, reduction_factor=0.8, threshold=0.1)` (line 662): Reduce folding by scaling displacement field in problematic regions.
-  - `def generate_grid_image(self, reference_image, grid_size=60, line_width=3)` (line 701): Generate a grid image.
-  - `def convert_field_to_grid_visualization(self, tfm, reference_image, grid_size=60, line_width=3)` (line 734): Generate a visual deformation grid for transform visualization.
-  - `def convert_itk_transform_to_usd_visualization(self, tfm, reference_image, output_filename, visualization_type='arrows', subsample_factor=4, arrow_scale=1.0, magnitude_threshold=0.0)` (line 770): Convert an ITK transform to a USD visualization for NVIDIA Omniverse.
+- **class TransformTools** (line 36): Utilities for transforming and manipulating ITK transforms.
+  - `def __init__(self, log_level=logging.INFO)` (line 69): Initialize the TransformTools class.
+  - `def combine_displacement_field_transforms(self, tfm1, tfm2, reference_image, tfm1_weight=1.0, tfm2_weight=1.0, mode='compose', tfm1_blur_sigma=0.0, tfm2_blur_sigma=0.0)` (line 77): Compose two displacement field transforms.
+  - `def convert_transform_to_displacement_field(self, tfm, reference_image, np_component_type=np.float64, use_reference_image_as_mask=False)` (line 161): Generate a dense deformation field from an ITK transform.
+  - `def convert_transform_to_displacement_field_transform(self, tfm, reference_image)` (line 249): Convert an ITK transform to a displacement field transform.
+  - `def invert_displacement_field_transform(self, tfm)` (line 266): Invert a displacement field transform.
+  - `def transform_pvcontour(self, contour, tfm, with_deformation_magnitude=False)` (line 288): Transform PyVista contour meshes using an ITK transform.
+  - `def transform_image(self, img, tfm, reference_image, interpolation_method='linear')` (line 356): Transform an ITK image using a specified transform and interpolation.
+  - `def convert_vtk_matrix_to_itk_transform(self, vtk_mat)` (line 433): Convert a VTK matrix to an ITK transform.
+  - `def smooth_transform(self, tfm, sigma, reference_image)` (line 468): Smooth a transform using Gaussian filtering to reduce noise.
+  - `def combine_transforms_with_masks(self, transform1, transform2, mask1, mask2, reference_image, max_iter=10, jacobian_threshold=0.1)` (line 527): Combine two transforms using spatial masks with folding correction.
+  - `def compute_jacobian_determinant_from_field(self, field)` (line 617): Compute Jacobian determinant of a displacement field.
+  - `def detect_folding_in_field(self, jacobian_det, threshold=0.1)` (line 646): Detect spatial folding in a transform.
+  - `def reduce_folding_in_field(self, field, jacobian_det, reduction_factor=0.8, threshold=0.1)` (line 670): Reduce folding by scaling displacement field in problematic regions.
+  - `def generate_grid_image(self, reference_image, grid_size=60, line_width=3)` (line 709): Generate a grid image.
+  - `def convert_field_to_grid_visualization(self, tfm, reference_image, grid_size=60, line_width=3)` (line 742): Generate a visual deformation grid for transform visualization.
+  - `def convert_itk_transform_to_usd_visualization(self, tfm, reference_image, output_filename, visualization_type='arrows', subsample_factor=4, arrow_scale=1.0, magnitude_threshold=0.0)` (line 778): Convert an ITK transform to a USD visualization for NVIDIA Omniverse.
 
 ## src/physiomotion4d/usd_anatomy_tools.py
 

--- a/docs/API_MAP.md
+++ b/docs/API_MAP.md
@@ -5,9 +5,9 @@ _Re-run `py utils/generate_api_map.py` whenever public APIs change._
 
 ## docs/conf.py
 
-- **class Mock** (line 16)
-- `def autodoc_skip_member(app, what, name, obj, skip, options)` (line 211): Custom function to skip certain members during autodoc processing.
-- `def setup(app)` (line 219): Custom setup function for Sphinx.
+- **class Mock** (line 20)
+- `def autodoc_skip_member(app, what, name, obj, skip, options)` (line 215): Custom function to skip certain members during autodoc processing.
+- `def setup(app)` (line 223): Custom setup function for Sphinx.
 
 ## experiments/Lung-GatedCT_To_USD/data_dirlab_4d_ct.py
 

--- a/docs/API_MAP.md
+++ b/docs/API_MAP.md
@@ -326,23 +326,23 @@ _Re-run `py utils/generate_api_map.py` whenever public APIs change._
 
 ## src/physiomotion4d/transform_tools.py
 
-- **class TransformTools** (line 36): Utilities for transforming and manipulating ITK transforms.
-  - `def __init__(self, log_level=logging.INFO)` (line 69): Initialize the TransformTools class.
-  - `def combine_displacement_field_transforms(self, tfm1, tfm2, reference_image, tfm1_weight=1.0, tfm2_weight=1.0, mode='compose', tfm1_blur_sigma=0.0, tfm2_blur_sigma=0.0)` (line 77): Compose two displacement field transforms.
-  - `def convert_transform_to_displacement_field(self, tfm, reference_image, np_component_type=np.float64, use_reference_image_as_mask=False)` (line 161): Generate a dense deformation field from an ITK transform.
-  - `def convert_transform_to_displacement_field_transform(self, tfm, reference_image)` (line 249): Convert an ITK transform to a displacement field transform.
-  - `def invert_displacement_field_transform(self, tfm)` (line 266): Invert a displacement field transform.
-  - `def transform_pvcontour(self, contour, tfm, with_deformation_magnitude=False)` (line 288): Transform PyVista contour meshes using an ITK transform.
-  - `def transform_image(self, img, tfm, reference_image, interpolation_method='linear')` (line 356): Transform an ITK image using a specified transform and interpolation.
-  - `def convert_vtk_matrix_to_itk_transform(self, vtk_mat)` (line 433): Convert a VTK matrix to an ITK transform.
-  - `def smooth_transform(self, tfm, sigma, reference_image)` (line 468): Smooth a transform using Gaussian filtering to reduce noise.
-  - `def combine_transforms_with_masks(self, transform1, transform2, mask1, mask2, reference_image, max_iter=10, jacobian_threshold=0.1)` (line 527): Combine two transforms using spatial masks with folding correction.
-  - `def compute_jacobian_determinant_from_field(self, field)` (line 617): Compute Jacobian determinant of a displacement field.
-  - `def detect_folding_in_field(self, jacobian_det, threshold=0.1)` (line 646): Detect spatial folding in a transform.
-  - `def reduce_folding_in_field(self, field, jacobian_det, reduction_factor=0.8, threshold=0.1)` (line 670): Reduce folding by scaling displacement field in problematic regions.
-  - `def generate_grid_image(self, reference_image, grid_size=60, line_width=3)` (line 709): Generate a grid image.
-  - `def convert_field_to_grid_visualization(self, tfm, reference_image, grid_size=60, line_width=3)` (line 742): Generate a visual deformation grid for transform visualization.
-  - `def convert_itk_transform_to_usd_visualization(self, tfm, reference_image, output_filename, visualization_type='arrows', subsample_factor=4, arrow_scale=1.0, magnitude_threshold=0.0)` (line 778): Convert an ITK transform to a USD visualization for NVIDIA Omniverse.
+- **class TransformTools** (line 39): Utilities for transforming and manipulating ITK transforms.
+  - `def __init__(self, log_level=logging.INFO)` (line 72): Initialize the TransformTools class.
+  - `def combine_displacement_field_transforms(self, tfm1, tfm2, reference_image, tfm1_weight=1.0, tfm2_weight=1.0, mode='compose', tfm1_blur_sigma=0.0, tfm2_blur_sigma=0.0)` (line 80): Compose two displacement field transforms.
+  - `def convert_transform_to_displacement_field(self, tfm, reference_image, np_component_type=np.float64, use_reference_image_as_mask=False)` (line 164): Generate a dense deformation field from an ITK transform.
+  - `def convert_transform_to_displacement_field_transform(self, tfm, reference_image)` (line 252): Convert an ITK transform to a displacement field transform.
+  - `def invert_displacement_field_transform(self, tfm)` (line 269): Invert a displacement field transform.
+  - `def transform_pvcontour(self, contour, tfm, with_deformation_magnitude=False)` (line 291): Transform PyVista contour meshes using an ITK transform.
+  - `def transform_image(self, img, tfm, reference_image, interpolation_method='linear')` (line 359): Transform an ITK image using a specified transform and interpolation.
+  - `def convert_vtk_matrix_to_itk_transform(self, vtk_mat)` (line 436): Convert a VTK matrix to an ITK transform.
+  - `def smooth_transform(self, tfm, sigma, reference_image)` (line 471): Smooth a transform using Gaussian filtering to reduce noise.
+  - `def combine_transforms_with_masks(self, transform1, transform2, mask1, mask2, reference_image, max_iter=10, jacobian_threshold=0.1)` (line 530): Combine two transforms using spatial masks with folding correction.
+  - `def compute_jacobian_determinant_from_field(self, field)` (line 620): Compute Jacobian determinant of a displacement field.
+  - `def detect_folding_in_field(self, jacobian_det, threshold=0.1)` (line 649): Detect spatial folding in a transform.
+  - `def reduce_folding_in_field(self, field, jacobian_det, reduction_factor=0.8, threshold=0.1)` (line 673): Reduce folding by scaling displacement field in problematic regions.
+  - `def generate_grid_image(self, reference_image, grid_size=60, line_width=3)` (line 712): Generate a grid image.
+  - `def convert_field_to_grid_visualization(self, tfm, reference_image, grid_size=60, line_width=3)` (line 745): Generate a visual deformation grid for transform visualization.
+  - `def convert_itk_transform_to_usd_visualization(self, tfm, reference_image, output_filename, visualization_type='arrows', subsample_factor=4, arrow_scale=1.0, magnitude_threshold=0.0)` (line 781): Convert an ITK transform to a USD visualization for NVIDIA Omniverse.
 
 ## src/physiomotion4d/usd_anatomy_tools.py
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,5 +18,5 @@ Features
 * USD export for Omniverse
 * Comprehensive documentation
 
-For detailed changelog, see `CHANGELOG.md <https://github.com/aylward/PhysioMotion4d/blob/main/CHANGELOG.md>`_.
+For detailed changelog, see `CHANGELOG.md <https://github.com/Project-MONAI/physiomotion4d/blob/main/CHANGELOG.md>`_.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,8 +98,8 @@ html_show_sphinx = True
 
 html_context = {
     "display_github": True,
-    "github_user": "aylward",
-    "github_repo": "PhysioMotion4d",
+    "github_user": "Project-MONAI",
+    "github_repo": "physiomotion4d",
     "github_version": "main",
     "conf_py_path": "/docs/",
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 sys.path.insert(0, os.path.abspath("../src"))
 
 # Suppress the ImportWarning emitted when cupy is absent (CPU-only docs build)
-warnings.filterwarnings("ignore", category=ImportWarning, module="physiomotion4d")
+warnings.filterwarnings("ignore", category=UserWarning, message="CuPy is not installed")
 
 
 # Create a more robust mock for complex packages

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,12 +4,16 @@
 
 import os
 import sys
+import warnings
 from datetime import datetime
 from unittest.mock import MagicMock
 
 
 # Add the source directory to the path
 sys.path.insert(0, os.path.abspath("../src"))
+
+# Suppress the ImportWarning emitted when cupy is absent (CPU-only docs build)
+warnings.filterwarnings("ignore", category=ImportWarning, module="physiomotion4d")
 
 
 # Create a more robust mock for complex packages

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -448,4 +448,4 @@ See Also
 
 * :doc:`architecture` - System architecture
 * :doc:`testing` - Testing guide
-* `GitHub Repository <https://github.com/aylward/PhysioMotion4d>`_
+* `GitHub Repository <https://github.com/Project-MONAI/physiomotion4d>`_

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -34,8 +34,21 @@ Installation Questions
 Do I need a GPU?
 ----------------
 
-* **Recommended**: NVIDIA GPU with CUDA 12.6+ for fast processing
-* **Optional**: CPU-only mode available (slower)
+Yes. An NVIDIA GPU is required; CPU-only installation is not supported.
+
+Which CUDA version is required?
+--------------------------------
+
+CUDA 13 is the default. If your system has CUDA 12, install the ``[cuda12]`` extra
+instead:
+
+.. code-block:: bash
+
+   uv pip install "physiomotion4d[cuda12]"
+
+The ``[cuda12]`` extra provides ``cupy-cuda12x>=12.0.0`` and sources PyTorch,
+torchvision, and torchaudio from ``https://download.pytorch.org/whl/cu128``.
+The default install provides ``cupy-cuda13x>=13.6.0``.
 
 What Python version is required?
 ---------------------------------
@@ -83,5 +96,5 @@ More Questions?
 
 * Check the :doc:`cli_scripts/heart_gated_ct`
 * Browse :doc:`examples`
-* Open an issue on `GitHub <https://github.com/aylward/PhysioMotion4d/issues>`_
+* Open an issue on `GitHub <https://github.com/Project-MONAI/physiomotion4d/issues>`_
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -34,12 +34,23 @@ Installation Questions
 Do I need a GPU?
 ----------------
 
-Yes. An NVIDIA GPU is required; CPU-only installation is not supported.
+No. A plain ``pip install physiomotion4d`` works without a GPU. At runtime you
+will see an ``ImportWarning``:
+
+.. code-block:: text
+
+   CuPy is not installed — GPU acceleration is unavailable and processing will be
+   slow. Install CuPy matching your CUDA version: pip install
+   'physiomotion4d[cuda13]' or 'physiomotion4d[cuda12]'
+
+CPU-only mode is suitable for evaluation and small datasets. For production
+workloads an NVIDIA GPU is strongly recommended.
 
 Which CUDA version is required?
 --------------------------------
 
-CUDA 13 and CUDA 12 are both supported. Install the extra that matches your system:
+CUDA 13 and CUDA 12 are both supported. Install the extra that matches your
+system CUDA version:
 
 .. code-block:: bash
 
@@ -49,10 +60,14 @@ CUDA 13 and CUDA 12 are both supported. Install the extra that matches your syst
    # CUDA 12
    uv pip install "physiomotion4d[cuda12]"
 
-The ``[cuda13]`` extra provides ``cupy-cuda13x>=13.6.0`` and sources PyTorch from
+Each extra installs both CuPy and a CUDA-built PyTorch wheel in one step —
+there is no need to install PyTorch separately. The ``[cuda13]`` extra provides
+``cupy-cuda13x>=13.6.0`` and sources PyTorch, torchvision, and torchaudio from
 ``https://download.pytorch.org/whl/cu130``. The ``[cuda12]`` extra provides
-``cupy-cuda12x>=12.0.0`` and sources PyTorch from
-``https://download.pytorch.org/whl/cu128``. Install exactly one of these extras.
+``cupy-cuda12x>=12.0.0`` and sources them from
+``https://download.pytorch.org/whl/cu128``. PyTorch is listed in both extras
+so that uv's dependency resolver fetches the GPU wheel instead of the CPU wheel
+from PyPI.
 
 What Python version is required?
 ---------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -39,16 +39,20 @@ Yes. An NVIDIA GPU is required; CPU-only installation is not supported.
 Which CUDA version is required?
 --------------------------------
 
-CUDA 13 is the default. If your system has CUDA 12, install the ``[cuda12]`` extra
-instead:
+CUDA 13 and CUDA 12 are both supported. Install the extra that matches your system:
 
 .. code-block:: bash
 
+   # CUDA 13 (recommended)
+   uv pip install "physiomotion4d[cuda13]"
+
+   # CUDA 12
    uv pip install "physiomotion4d[cuda12]"
 
-The ``[cuda12]`` extra provides ``cupy-cuda12x>=12.0.0`` and sources PyTorch,
-torchvision, and torchaudio from ``https://download.pytorch.org/whl/cu128``.
-The default install provides ``cupy-cuda13x>=13.6.0``.
+The ``[cuda13]`` extra provides ``cupy-cuda13x>=13.6.0`` and sources PyTorch from
+``https://download.pytorch.org/whl/cu130``. The ``[cuda12]`` extra provides
+``cupy-cuda12x>=12.0.0`` and sources PyTorch from
+``https://download.pytorch.org/whl/cu128``. Install exactly one of these extras.
 
 What Python version is required?
 ---------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -34,14 +34,16 @@ Installation Questions
 Do I need a GPU?
 ----------------
 
-No. A plain ``pip install physiomotion4d`` works without a GPU. At runtime you
-will see an ``ImportWarning``:
+No. A plain ``pip install physiomotion4d`` works without a GPU. At import time
+a ``UserWarning`` is emitted (visible by default in all standard Python runs):
 
 .. code-block:: text
 
    CuPy is not installed — GPU acceleration is unavailable and processing will be
-   slow. Install CuPy matching your CUDA version: pip install
-   'physiomotion4d[cuda13]' or 'physiomotion4d[cuda12]'
+   slow. Re-install with uv to get CuPy and CUDA-enabled PyTorch in one step
+   (pip alone will not select the correct CUDA wheel):
+     uv pip install 'physiomotion4d[cuda13]'  # CUDA 13
+     uv pip install 'physiomotion4d[cuda12]'  # CUDA 12
 
 CPU-only mode is suitable for evaluation and small datasets. For production
 workloads an NVIDIA GPU is strongly recommended.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,19 +17,19 @@ PhysioMotion4D is a comprehensive medical imaging package that converts 3D and 4
    :alt: Python Versions
 
 .. image:: https://img.shields.io/badge/license-Apache%202.0-blue.svg
-   :target: https://github.com/aylward/PhysioMotion4d/blob/main/LICENSE
+   :target: https://github.com/Project-MONAI/physiomotion4d/blob/main/LICENSE
    :alt: License
 
-.. image:: https://img.shields.io/github/actions/workflow/status/aylward/PhysioMotion4d/ci.yml?branch=main&label=CI%20Tests
-   :target: https://github.com/aylward/PhysioMotion4d/actions/workflows/ci.yml
+.. image:: https://img.shields.io/github/actions/workflow/status/Project-MONAI/physiomotion4d/ci.yml?branch=main&label=CI%20Tests
+   :target: https://github.com/Project-MONAI/physiomotion4d/actions/workflows/ci.yml
    :alt: CI Tests
 
 .. image:: https://img.shields.io/badge/tests-Windows%20%7C%20Linux%20%7C%20Python%203.10--3.12-blue
-   :target: https://github.com/aylward/PhysioMotion4d/actions/workflows/ci.yml
+   :target: https://github.com/Project-MONAI/physiomotion4d/actions/workflows/ci.yml
    :alt: Test Matrix: Windows, Linux, Python 3.10-3.12
 
-.. image:: https://codecov.io/gh/aylward/PhysioMotion4d/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/aylward/PhysioMotion4d
+.. image:: https://codecov.io/gh/Project-MONAI/physiomotion4d/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/Project-MONAI/physiomotion4d
    :alt: Test Coverage
 
 🚀 Key Features

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,11 +35,11 @@ Method 1: Install from PyPI (Recommended)
 
 The simplest way to install PhysioMotion4D is from PyPI.
 
-Default install (CUDA 13):
+CUDA 13 install (recommended):
 
 .. code-block:: bash
 
-   uv pip install physiomotion4d
+   uv pip install "physiomotion4d[cuda13]"
 
 CUDA 12 install:
 
@@ -63,7 +63,7 @@ For development or to get the latest features:
 .. code-block:: bash
 
    git clone https://github.com/Project-MONAI/physiomotion4d.git
-   cd PhysioMotion4D
+   cd physiomotion4d
 
 **Step 2: Create virtual environment**
 
@@ -91,11 +91,11 @@ For development or to get the latest features:
 
 **Step 4: Install PhysioMotion4D**
 
-With uv (CUDA 13, default):
+With uv (CUDA 13):
 
 .. code-block:: bash
 
-   uv pip install -e .
+   uv pip install -e ".[cuda13]"
 
 With uv (CUDA 12):
 
@@ -182,8 +182,8 @@ CUDA Installation
 
 PhysioMotion4D requires an NVIDIA GPU. Two CUDA versions are supported:
 
-* **CUDA 13** — default; installed when you run ``uv pip install physiomotion4d``
-* **CUDA 12** — optional; installed when you add the ``[cuda12]`` extra
+* **CUDA 13** — installed when you use the ``[cuda13]`` extra (recommended)
+* **CUDA 12** — installed when you use the ``[cuda12]`` extra
 
 CPU-only installation is not supported.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ System Requirements
 -------------------
 
 * **Python**: 3.10, 3.11, or 3.12
-* **GPU**: NVIDIA GPU with CUDA 13 (default) or CUDA 12 — CPU-only installation is not supported
+* **GPU**: NVIDIA GPU with CUDA 13 (default) or CUDA 12 — recommended for production use; CPU-only installation is supported but will be slow and will emit a runtime warning
 * **RAM**: 16GB minimum (32GB+ recommended for large datasets)
 * **Storage**: 10GB+ for package and model weights
 * **Visualization**: NVIDIA Omniverse (optional, for USD visualization)
@@ -35,7 +35,22 @@ Method 1: Install from PyPI (Recommended)
 
 The simplest way to install PhysioMotion4D is from PyPI.
 
-CUDA 13 install (recommended):
+CPU-only install (evaluation / no GPU):
+
+.. code-block:: bash
+
+   pip install physiomotion4d
+
+This works immediately. CuPy is absent, so an ``ImportWarning`` is emitted at
+runtime:
+
+.. code-block:: text
+
+   CuPy is not installed — GPU acceleration is unavailable and processing will be
+   slow. Install CuPy matching your CUDA version: pip install
+   'physiomotion4d[cuda13]' or 'physiomotion4d[cuda12]'
+
+CUDA 13 install (recommended for production):
 
 .. code-block:: bash
 
@@ -46,6 +61,12 @@ CUDA 12 install:
 .. code-block:: bash
 
    uv pip install "physiomotion4d[cuda12]"
+
+The ``[cuda13]`` and ``[cuda12]`` extras install both CuPy and the correct
+CUDA-built PyTorch wheel in one step. PyTorch is listed inside the extras so
+that uv's dependency resolver fetches the GPU wheel from the PyTorch index
+rather than the CPU wheel from PyPI. There is no need to install PyTorch
+separately.
 
 For development with NVIDIA NIM cloud services:
 
@@ -91,7 +112,13 @@ For development or to get the latest features:
 
 **Step 4: Install PhysioMotion4D**
 
-With uv (CUDA 13):
+CPU-only (evaluation / no GPU):
+
+.. code-block:: bash
+
+   uv pip install -e "."
+
+With uv (CUDA 13, recommended for production):
 
 .. code-block:: bash
 
@@ -180,12 +207,15 @@ GPU Setup
 CUDA Installation
 -----------------
 
-PhysioMotion4D requires an NVIDIA GPU. Two CUDA versions are supported:
+An NVIDIA GPU is strongly recommended. Two CUDA versions are supported via
+optional extras:
 
 * **CUDA 13** — installed when you use the ``[cuda13]`` extra (recommended)
 * **CUDA 12** — installed when you use the ``[cuda12]`` extra
 
-CPU-only installation is not supported.
+A plain ``pip install physiomotion4d`` installs a CPU-only build. It runs
+without error but emits an ``ImportWarning`` at startup and will be
+significantly slower than a GPU-enabled install.
 
 If CUDA is not yet installed, download the CUDA Toolkit from
 `NVIDIA's website <https://developer.nvidia.com/cuda-downloads>`_, then verify:
@@ -198,9 +228,11 @@ If CUDA is not yet installed, download the CUDA Toolkit from
 PyTorch with CUDA
 -----------------
 
-The default install pulls PyTorch built against CUDA 13. The ``[cuda12]`` extra
-sources PyTorch, torchvision, and torchaudio from
-``https://download.pytorch.org/whl/cu128``. To verify the active version:
+A plain install pulls a CPU-only PyTorch wheel from PyPI. The ``[cuda13]``
+extra sources PyTorch, torchvision, and torchaudio from the
+``https://download.pytorch.org/whl/cu130`` index. The ``[cuda12]`` extra
+sources them from ``https://download.pytorch.org/whl/cu128``. To verify the
+active version:
 
 .. code-block:: python
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ System Requirements
 -------------------
 
 * **Python**: 3.10, 3.11, or 3.12
-* **GPU**: NVIDIA GPU with CUDA 12.6+ (for AI models and registration)
+* **GPU**: NVIDIA GPU with CUDA 13 (default) or CUDA 12 — CPU-only installation is not supported
 * **RAM**: 16GB minimum (32GB+ recommended for large datasets)
 * **Storage**: 10GB+ for package and model weights
 * **Visualization**: NVIDIA Omniverse (optional, for USD visualization)
@@ -22,7 +22,7 @@ Software Dependencies
 PhysioMotion4D relies on several key packages:
 
 * **Medical Imaging**: ITK, TubeTK, MONAI, nibabel, PyVista
-* **AI/ML**: PyTorch (CUDA 12.6), transformers, MONAI
+* **AI/ML**: PyTorch, CuPy (CUDA 13 default; CUDA 12 via ``[cuda12]`` extra), transformers, MONAI
 * **Registration**: icon-registration, unigradicon
 * **Visualization**: USD-core, PyVista
 * **Segmentation**: TotalSegmentator, VISTA-3D models
@@ -33,11 +33,19 @@ Installation Methods
 Method 1: Install from PyPI (Recommended)
 ------------------------------------------
 
-The simplest way to install PhysioMotion4D is from PyPI:
+The simplest way to install PhysioMotion4D is from PyPI.
+
+Default install (CUDA 13):
 
 .. code-block:: bash
 
-   pip install physiomotion4d
+   uv pip install physiomotion4d
+
+CUDA 12 install:
+
+.. code-block:: bash
+
+   uv pip install "physiomotion4d[cuda12]"
 
 For development with NVIDIA NIM cloud services:
 
@@ -54,7 +62,7 @@ For development or to get the latest features:
 
 .. code-block:: bash
 
-   git clone https://github.com/aylward/PhysioMotion4d.git
+   git clone https://github.com/Project-MONAI/physiomotion4d.git
    cd PhysioMotion4D
 
 **Step 2: Create virtual environment**
@@ -83,17 +91,17 @@ For development or to get the latest features:
 
 **Step 4: Install PhysioMotion4D**
 
-With uv:
+With uv (CUDA 13, default):
 
 .. code-block:: bash
 
    uv pip install -e .
 
-Or with pip:
+With uv (CUDA 12):
 
 .. code-block:: bash
 
-   pip install -e .
+   uv pip install -e ".[cuda12]"
 
 Optional Dependencies
 =====================
@@ -172,10 +180,15 @@ GPU Setup
 CUDA Installation
 -----------------
 
-PhysioMotion4D requires CUDA 12.6+ for GPU acceleration. If you don't have CUDA installed:
+PhysioMotion4D requires an NVIDIA GPU. Two CUDA versions are supported:
 
-1. Download and install CUDA Toolkit from `NVIDIA's website <https://developer.nvidia.com/cuda-downloads>`_
-2. Verify CUDA installation:
+* **CUDA 13** — default; installed when you run ``uv pip install physiomotion4d``
+* **CUDA 12** — optional; installed when you add the ``[cuda12]`` extra
+
+CPU-only installation is not supported.
+
+If CUDA is not yet installed, download the CUDA Toolkit from
+`NVIDIA's website <https://developer.nvidia.com/cuda-downloads>`_, then verify:
 
 .. code-block:: bash
 
@@ -185,7 +198,9 @@ PhysioMotion4D requires CUDA 12.6+ for GPU acceleration. If you don't have CUDA 
 PyTorch with CUDA
 -----------------
 
-The package automatically installs PyTorch with CUDA 12.6 support. To verify:
+The default install pulls PyTorch built against CUDA 13. The ``[cuda12]`` extra
+sources PyTorch, torchvision, and torchaudio from
+``https://download.pytorch.org/whl/cu128``. To verify the active version:
 
 .. code-block:: python
 
@@ -193,14 +208,6 @@ The package automatically installs PyTorch with CUDA 12.6 support. To verify:
    print(f"PyTorch version: {torch.__version__}")
    print(f"CUDA available: {torch.cuda.is_available()}")
    print(f"CUDA version: {torch.version.cuda}")
-
-Expected output:
-
-.. code-block:: text
-
-   PyTorch version: 2.x.x+cu126
-   CUDA available: True
-   CUDA version: 12.6
 
 Troubleshooting
 ===============
@@ -243,7 +250,7 @@ Getting Help
 If you encounter issues:
 
 1. Check the :doc:`troubleshooting` guide
-2. Search `GitHub Issues <https://github.com/aylward/PhysioMotion4d/issues>`_
+2. Search `GitHub Issues <https://github.com/Project-MONAI/physiomotion4d/issues>`_
 3. Open a new issue with:
 
    * Python version

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,14 +41,16 @@ CPU-only install (evaluation / no GPU):
 
    pip install physiomotion4d
 
-This works immediately. CuPy is absent, so an ``ImportWarning`` is emitted at
-runtime:
+This works immediately. CuPy is absent, so a ``UserWarning`` is emitted at
+import time (visible by default in all standard Python runs):
 
 .. code-block:: text
 
    CuPy is not installed — GPU acceleration is unavailable and processing will be
-   slow. Install CuPy matching your CUDA version: pip install
-   'physiomotion4d[cuda13]' or 'physiomotion4d[cuda12]'
+   slow. Re-install with uv to get CuPy and CUDA-enabled PyTorch in one step
+   (pip alone will not select the correct CUDA wheel):
+     uv pip install 'physiomotion4d[cuda13]'  # CUDA 13
+     uv pip install 'physiomotion4d[cuda12]'  # CUDA 12
 
 CUDA 13 install (recommended for production):
 
@@ -214,7 +216,7 @@ optional extras:
 * **CUDA 12** — installed when you use the ``[cuda12]`` extra
 
 A plain ``pip install physiomotion4d`` installs a CPU-only build. It runs
-without error but emits an ``ImportWarning`` at startup and will be
+without error but emits a ``UserWarning`` at import time and will be
 significantly slower than a GPU-enabled install.
 
 If CUDA is not yet installed, download the CUDA Toolkit from

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,7 +10,7 @@ Prerequisites
 Before starting, ensure you have:
 
 * PhysioMotion4D installed (see :doc:`installation`)
-* NVIDIA GPU with CUDA 13 (default) or CUDA 12 — see :doc:`installation` for the ``[cuda12]`` extra
+* NVIDIA GPU with CUDA 13 (default) or CUDA 12 — recommended for production performance; see :doc:`installation` for the ``[cuda13]`` and ``[cuda12]`` extras. A CPU-only install works for evaluation but is slow.
 * 4D cardiac CT data or access to sample datasets
 
 Basic Workflow

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,7 +10,7 @@ Prerequisites
 Before starting, ensure you have:
 
 * PhysioMotion4D installed (see :doc:`installation`)
-* NVIDIA GPU with CUDA 12.6+
+* NVIDIA GPU with CUDA 13 (default) or CUDA 12 — see :doc:`installation` for the ``[cuda12]`` extra
 * 4D cardiac CT data or access to sample datasets
 
 Basic Workflow

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -16,7 +16,7 @@ If you use PhysioMotion4D in your research, please cite:
      title = {PhysioMotion4D: Medical Imaging to Omniverse},
      year = {2025},
      publisher = {GitHub},
-     url = {https://github.com/aylward/PhysioMotion4d}
+     url = {https://github.com/Project-MONAI/physiomotion4d}
    }
 
 Related Publications

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -46,8 +46,8 @@ version than the one present on the system.
 
 .. code-block:: bash
 
-   # CUDA 13 (default)
-   uv pip install physiomotion4d
+   # CUDA 13
+   uv pip install "physiomotion4d[cuda13]"
 
    # CUDA 12
    uv pip install "physiomotion4d[cuda12]"
@@ -59,7 +59,10 @@ Verify the active CUDA version before reinstalling:
    nvidia-smi   # shows driver and CUDA version
 
 .. note::
-   CPU-only installation is not supported. A CUDA-capable NVIDIA GPU is required.
+   CPU-only *installation* is not supported — a CUDA-capable NVIDIA GPU and either
+   the ``[cuda13]`` or ``[cuda12]`` extra is required. CPU *execution* of individual
+   operations (e.g. ``processor.set_registration_device('cpu')``) is possible after
+   a CUDA-enabled install.
 
 Import Errors
 -------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -62,7 +62,7 @@ Verify the active CUDA version before reinstalling:
 
 .. note::
    If you have no NVIDIA GPU, a plain ``pip install physiomotion4d`` installs a
-   CPU-only build. CuPy is absent and an ``ImportWarning`` is emitted at startup.
+   CPU-only build. CuPy is absent and a ``UserWarning`` is emitted at import time.
    CPU execution of all operations is supported but will be significantly slower
    than a GPU-enabled install.
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -52,6 +52,8 @@ version than the one present on the system.
    # CUDA 12
    uv pip install "physiomotion4d[cuda12]"
 
+Each extra installs both CuPy and the correct CUDA-built PyTorch wheel.
+
 Verify the active CUDA version before reinstalling:
 
 .. code-block:: bash
@@ -59,10 +61,10 @@ Verify the active CUDA version before reinstalling:
    nvidia-smi   # shows driver and CUDA version
 
 .. note::
-   CPU-only *installation* is not supported — a CUDA-capable NVIDIA GPU and either
-   the ``[cuda13]`` or ``[cuda12]`` extra is required. CPU *execution* of individual
-   operations (e.g. ``processor.set_registration_device('cpu')``) is possible after
-   a CUDA-enabled install.
+   If you have no NVIDIA GPU, a plain ``pip install physiomotion4d`` installs a
+   CPU-only build. CuPy is absent and an ``ImportWarning`` is emitted at startup.
+   CPU execution of all operations is supported but will be significantly slower
+   than a GPU-enabled install.
 
 Import Errors
 -------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -33,6 +33,34 @@ CUDA Out of Memory
 
       processor.set_batch_size(1)
 
+CUDA Version Mismatch
+---------------------
+
+**Problem**: Errors such as ``cupy`` failing to import, ``torch.cuda.is_available()``
+returning ``False``, or runtime messages indicating a CUDA library version conflict.
+
+**Cause**: The installed ``cupy`` or PyTorch wheel was built for a different CUDA
+version than the one present on the system.
+
+**Solution**: Install the extra that matches your system CUDA version:
+
+.. code-block:: bash
+
+   # CUDA 13 (default)
+   uv pip install physiomotion4d
+
+   # CUDA 12
+   uv pip install "physiomotion4d[cuda12]"
+
+Verify the active CUDA version before reinstalling:
+
+.. code-block:: bash
+
+   nvidia-smi   # shows driver and CUDA version
+
+.. note::
+   CPU-only installation is not supported. A CUDA-capable NVIDIA GPU is required.
+
 Import Errors
 -------------
 
@@ -179,7 +207,7 @@ Getting Help
 If you still have issues:
 
 1. Check :doc:`faq`
-2. Search `GitHub Issues <https://github.com/aylward/PhysioMotion4d/issues>`_
+2. Search `GitHub Issues <https://github.com/Project-MONAI/physiomotion4d/issues>`_
 3. Open a new issue with:
 
    * Python version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,9 @@ explicit = true
 [project.optional-dependencies]
 cuda12 = [
     "cupy-cuda12x>=12.0.0",
+    "torch>=2.0.0,<3.0.0",
+    "torchvision",
+    "torchaudio",
 ]
 nim = [
     # Cloud and data handling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,18 +88,22 @@ dependencies = [
 [tool.uv]
 link-mode = "copy"
 
+# torch/torchvision/torchaudio appear in both core deps (CPU fallback) and in
+# the cuda13/cuda12 extras. The extras listing is required by uv: it is what
+# triggers the CUDA-specific wheel index (cu130 / cu128) instead of PyPI.
+# Without it, uv would install CPU-only torch even when a CUDA extra is active.
 [tool.uv.sources]
 torch = [
+  { index = "pytorch-cu130", extra = "cuda13" },
   { index = "pytorch-cu128", extra = "cuda12" },
-  { index = "pytorch-cu130" },
 ]
 torchvision = [
+  { index = "pytorch-cu130", extra = "cuda13" },
   { index = "pytorch-cu128", extra = "cuda12" },
-  { index = "pytorch-cu130" },
 ]
 torchaudio = [
+  { index = "pytorch-cu130", extra = "cuda13" },
   { index = "pytorch-cu128", extra = "cuda12" },
-  { index = "pytorch-cu130" },
 ]
 
 [[tool.uv.index]]
@@ -115,6 +119,9 @@ explicit = true
 [project.optional-dependencies]
 cuda13 = [
     "cupy-cuda13x>=13.6.0",
+    "torch>=2.0.0,<3.0.0",
+    "torchvision",
+    "torchaudio",
 ]
 cuda12 = [
     "cupy-cuda12x>=12.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ dependencies = [
 
     # Utilities
     "matplotlib>=3.5.0",
-    "jupyterlab>=4.0.0",
     "typing-extensions>=4.0.0",
     "cupy-cuda13x>=13.6.0",
 
@@ -92,13 +91,16 @@ link-mode = "copy"
 
 [tool.uv.sources]
 torch = [
-  { index = "pytorch-cu130" }
+  { index = "pytorch-cu128", extra = "cuda12" },
+  { index = "pytorch-cu130" },
 ]
 torchvision = [
-  { index = "pytorch-cu130" }
+  { index = "pytorch-cu128", extra = "cuda12" },
+  { index = "pytorch-cu130" },
 ]
 torchaudio = [
-  { index = "pytorch-cu130" }
+  { index = "pytorch-cu128", extra = "cuda12" },
+  { index = "pytorch-cu130" },
 ]
 
 [[tool.uv.index]]
@@ -106,7 +108,15 @@ name = "pytorch-cu130"
 url = "https://download.pytorch.org/whl/cu130"
 explicit = true
 
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
 [project.optional-dependencies]
+cuda12 = [
+    "cupy-cuda12x>=12.0.0",
+]
 nim = [
     # Cloud and data handling
     "google-auth>=2.0.0",
@@ -155,11 +165,11 @@ test = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/aylward/PhysioMotion4d"
-Documentation = "https://github.com/aylward/PhysioMotion4d/blob/main/README.md"
-Repository = "https://github.com/aylward/PhysioMotion4d.git"
-"Bug Tracker" = "https://github.com/aylward/PhysioMotion4d/issues"
-Changelog = "https://github.com/aylward/PhysioMotion4d/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/Project-MONAI/physiomotion4d"
+Documentation = "https://github.com/Project-MONAI/physiomotion4d/blob/main/README.md"
+Repository = "https://github.com/Project-MONAI/physiomotion4d.git"
+"Bug Tracker" = "https://github.com/Project-MONAI/physiomotion4d/issues"
+Changelog = "https://github.com/Project-MONAI/physiomotion4d/blob/main/CHANGELOG.md"
 "Author LinkedIn" = "https://www.linkedin.com/in/stephenaylward"
 "Author Google Scholar" = "https://scholar.google.com/citations?user=u1UdL4oAAAAJ&hl"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ dependencies = [
     # Utilities
     "matplotlib>=3.5.0",
     "typing-extensions>=4.0.0",
-    "cupy-cuda13x>=13.6.0",
 
 ]
 
@@ -114,6 +113,9 @@ url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [project.optional-dependencies]
+cuda13 = [
+    "cupy-cuda13x>=13.6.0",
+]
 cuda12 = [
     "cupy-cuda12x>=12.0.0",
     "torch>=2.0.0,<3.0.0",

--- a/src/physiomotion4d/__init__.py
+++ b/src/physiomotion4d/__init__.py
@@ -19,16 +19,19 @@ Main Components:
 
 __version__ = "2025.05.0"
 
+import warnings as _warnings
+
 try:
     import cupy as _cupy  # noqa: F401
-except ImportError as _err:
-    raise ImportError(
-        "PhysioMotion4D requires CuPy with a matching CUDA toolkit. "
-        "Re-install with the extra that matches your system:\n\n"
-        "  uv pip install 'physiomotion4d[cuda13]'  # CUDA 13 (recommended)\n"
-        "  uv pip install 'physiomotion4d[cuda12]'  # CUDA 12\n\n"
-        "CPU-only installation is not supported."
-    ) from _err
+except ImportError:
+    _warnings.warn(
+        "CuPy is not installed — GPU acceleration is unavailable and processing "
+        "will be slow. Install CuPy matching your CUDA version:\n"
+        "  pip install 'physiomotion4d[cuda13]'  # CUDA 13\n"
+        "  pip install 'physiomotion4d[cuda12]'  # CUDA 12",
+        ImportWarning,
+        stacklevel=2,
+    )
 
 # VTK to USD library
 # VTK to USD library (new modular implementation)

--- a/src/physiomotion4d/__init__.py
+++ b/src/physiomotion4d/__init__.py
@@ -19,6 +19,17 @@ Main Components:
 
 __version__ = "2025.05.0"
 
+try:
+    import cupy as _cupy  # noqa: F401
+except ImportError as _err:
+    raise ImportError(
+        "PhysioMotion4D requires CuPy with a matching CUDA toolkit. "
+        "Re-install with the extra that matches your system:\n\n"
+        "  uv pip install 'physiomotion4d[cuda13]'  # CUDA 13 (recommended)\n"
+        "  uv pip install 'physiomotion4d[cuda12]'  # CUDA 12\n\n"
+        "CPU-only installation is not supported."
+    ) from _err
+
 # VTK to USD library
 # VTK to USD library (new modular implementation)
 from . import vtk_to_usd

--- a/src/physiomotion4d/__init__.py
+++ b/src/physiomotion4d/__init__.py
@@ -26,10 +26,11 @@ try:
 except ImportError:
     _warnings.warn(
         "CuPy is not installed — GPU acceleration is unavailable and processing "
-        "will be slow. Install CuPy matching your CUDA version:\n"
-        "  pip install 'physiomotion4d[cuda13]'  # CUDA 13\n"
-        "  pip install 'physiomotion4d[cuda12]'  # CUDA 12",
-        ImportWarning,
+        "will be slow. Re-install with uv to get CuPy and CUDA-enabled PyTorch "
+        "in one step (pip alone will not select the correct CUDA wheel):\n"
+        "  uv pip install 'physiomotion4d[cuda13]'  # CUDA 13\n"
+        "  uv pip install 'physiomotion4d[cuda12]'  # CUDA 12",
+        UserWarning,
         stacklevel=2,
     )
 

--- a/src/physiomotion4d/transform_tools.py
+++ b/src/physiomotion4d/transform_tools.py
@@ -15,7 +15,10 @@ import logging
 from collections.abc import Sequence
 from typing import TypeAlias
 
-import cupy as cp
+try:
+    import cupy as cp  # optional (GPU)
+except ModuleNotFoundError:  # CPU-only environments (e.g., CI unit-tests)
+    cp = None
 import itk
 import numpy as np
 import pyvista as pv
@@ -336,12 +339,17 @@ class TransformTools(PhysioMotion4DBase):
         ]
         new_contour.points = np.asarray(new_pnts, dtype=float)
 
-        new_pnts = cp.array(new_pnts)
-        pnts = cp.array(pnts)
         if with_deformation_magnitude:
-            new_contour.point_data["DeformationMagnitude"] = cp.linalg.norm(
-                new_pnts - pnts, axis=1
-            ).get()
+            if cp is not None:
+                new_pnts_cp = cp.array(new_pnts)
+                pnts_cp = cp.array(pnts)
+                new_contour.point_data["DeformationMagnitude"] = cp.linalg.norm(
+                    new_pnts_cp - pnts_cp, axis=1
+                ).get()
+            else:
+                new_contour.point_data["DeformationMagnitude"] = np.linalg.norm(
+                    np.asarray(new_pnts) - np.asarray(pnts), axis=1
+                )
 
         return new_contour
 

--- a/src/physiomotion4d/transform_tools.py
+++ b/src/physiomotion4d/transform_tools.py
@@ -17,7 +17,10 @@ from typing import TypeAlias
 
 try:
     import cupy as cp  # optional (GPU)
-except ModuleNotFoundError:  # CPU-only environments (e.g., CI unit-tests)
+except (ImportError, OSError):
+    # ImportError: cupy not installed or CUDA libraries missing/mismatched.
+    # OSError: driver/library load failure on some platforms.
+    # In all cases fall back to CPU (NumPy) paths.
     cp = None
 import itk
 import numpy as np


### PR DESCRIPTION
Adds a cuda12 optional extra (cupy-cuda12x, pytorch cu128) so users on CUDA 12 systems can install without source-building cupy. Makes CUDA 13 the default install. Updates all GitHub URLs from aylward/PhysioMotion4d to Project-MONAI/physiomotion4d and fixes the lone PhysioMotion4d capitalisation violation in docs/conf.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * CUDA 13 is now the default; CUDA 12 remains available via new optional extras.
  * Clarified that plain pip installs are CPU-only (supported but slower) and added CUDA-specific install examples and guidance.
  * Updated troubleshooting and all repo/docs links to the new project location.

* **Chores**
  * Removed JupyterLab from core deps and introduced extras/index entries to support CUDA12/CUDA13 installs.

* **Behavior**
  * Package now warns at import when GPU libraries are missing and falls back to CPU computation when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->