### PR TITLE
ENH: Add nightly health dashboard and fix Windows GPU runner labels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - gpu

--- a/.github/scripts/build_dashboard.py
+++ b/.github/scripts/build_dashboard.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""
+Build the nightly health dashboard for PhysioMotion4D.
+
+Reads JUnit XML test results and coverage JSON from --results-dir,
+generates an HTML dashboard (index.html), a shields.io-compatible
+endpoint (status.json), and a GitHub Actions step-summary (summary.md)
+in --output-dir.
+
+Usage (called from nightly-health.yml):
+    python .github/scripts/build_dashboard.py \\
+        --results-dir results/ \\
+        --output-dir dashboard/ \\
+        --run-url "https://github.com/Project-MONAI/physiomotion4d/actions/runs/123" \\
+        --timestamp "2026-03-31T07:05:42Z" \\
+        --health-outcome "success"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Parsers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def parse_junit(xml_path: Path) -> dict:
+    """Return a test-count summary from a JUnit XML file."""
+    if not xml_path.exists():
+        return {
+            "tests": 0,
+            "passed": 0,
+            "failed": 0,
+            "errors": 0,
+            "skipped": 0,
+            "available": False,
+        }
+
+    try:
+        tree = ET.parse(xml_path)  # noqa: S314
+        root = tree.getroot()
+
+        suites = root.findall("testsuite") if root.tag == "testsuites" else [root]
+
+        tests = sum(int(s.get("tests", 0)) for s in suites)
+        failures = sum(int(s.get("failures", 0)) for s in suites)
+        errors = sum(int(s.get("errors", 0)) for s in suites)
+        skipped = sum(int(s.get("skipped", 0)) for s in suites)
+        passed = max(0, tests - failures - errors - skipped)
+
+        return {
+            "tests": tests,
+            "passed": passed,
+            "failed": failures,
+            "errors": errors,
+            "skipped": skipped,
+            "available": True,
+        }
+    except Exception as exc:
+        return {
+            "tests": 0,
+            "passed": 0,
+            "failed": 0,
+            "errors": 0,
+            "skipped": 0,
+            "available": False,
+            "parse_error": str(exc),
+        }
+
+
+def parse_coverage(json_path: Path) -> dict:
+    """Return coverage percentage from a coverage.py JSON report."""
+    if not json_path.exists():
+        return {"percent": None, "available": False}
+
+    try:
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        totals = data.get("totals", {})
+        pct = totals.get("percent_covered_display") or totals.get("percent_covered")
+        if pct is not None:
+            return {"percent": float(pct), "available": True}
+        return {"percent": None, "available": False}
+    except Exception as exc:
+        return {"percent": None, "available": False, "parse_error": str(exc)}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# HTML dashboard
+# ──────────────────────────────────────────────────────────────────────────────
+
+_CSS = """\
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+     background:#0d1117;color:#c9d1d9;min-height:100vh;padding:32px 24px}
+h1{font-size:1.6rem;font-weight:600;margin-bottom:6px}
+.sub{color:#8b949e;font-size:.9rem;margin-bottom:36px}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));
+      gap:16px;margin-bottom:36px}
+.card{background:#161b22;border:1px solid #30363d;border-radius:8px;padding:20px}
+.card .label{font-size:.72rem;text-transform:uppercase;letter-spacing:.06em;
+             color:#8b949e;margin-bottom:10px}
+.card .value{font-size:2rem;font-weight:700}
+.pass{color:#3fb950}.fail{color:#f85149}.warn{color:#d29922}.muted{color:#8b949e}
+.badge{display:inline-block;padding:3px 10px;border-radius:12px;
+       font-size:.78rem;font-weight:600}
+.badge-pass{background:#1a3a2a;color:#3fb950;border:1px solid #2d5a3d}
+.badge-fail{background:#3a1a1a;color:#f85149;border:1px solid #5a2d2d}
+.badge-unknown{background:#2a2a1a;color:#d29922;border:1px solid #4a4a2a}
+.bar-bg{background:#21262d;border-radius:4px;height:8px;overflow:hidden;margin-top:10px}
+.bar-fill{height:100%;border-radius:4px}
+a{color:#58a6ff;text-decoration:none}a:hover{text-decoration:underline}
+footer{margin-top:48px;padding-top:16px;border-top:1px solid #21262d;
+       color:#8b949e;font-size:.8rem}
+"""
+
+
+def _cov_color(pct: float) -> str:
+    if pct >= 80:
+        return "#3fb950"
+    if pct >= 60:
+        return "#d29922"
+    return "#f85149"
+
+
+def build_html(data: dict) -> str:
+    junit = data["junit"]
+    cov = data["coverage"]
+    outcome = data["health_outcome"]
+    run_url = data["run_url"]
+    ts = data["timestamp"]
+
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        ts_display = dt.strftime("%Y-%m-%d %H:%M UTC")
+    except Exception:
+        ts_display = ts
+
+    # Determine overall badge
+    if not junit.get("available"):
+        badge_class, badge_label = "badge-unknown", "UNKNOWN"
+    elif (
+        outcome not in ("success", "skipped", "")
+        or (junit["failed"] + junit["errors"]) > 0
+    ):
+        badge_class, badge_label = "badge-fail", "FAILING"
+    else:
+        badge_class, badge_label = "badge-pass", "PASSING"
+
+    # Test card values
+    if junit.get("available"):
+        n_pass = junit["passed"]
+        n_fail = junit["failed"]
+        n_err = junit["errors"]
+        n_skip = junit["skipped"]
+        n_total = junit["tests"]
+        pass_cls = "pass" if (n_fail + n_err) == 0 else "fail"
+        fail_cls = "fail" if (n_fail + n_err) > 0 else "muted"
+        extra_err = (
+            f'<div class="label" style="margin-top:6px">+ {n_err} error(s)</div>'
+            if n_err > 0
+            else ""
+        )
+    else:
+        n_pass = n_fail = n_err = n_skip = n_total = "—"
+        pass_cls = fail_cls = "muted"
+        extra_err = ""
+
+    # Coverage card
+    if cov.get("available") and cov["percent"] is not None:
+        pct = cov["percent"]
+        cov_display = f"{pct:.1f}%"
+        cov_col = _cov_color(pct)
+        cov_bar = (
+            f'<div class="bar-bg">'
+            f'<div class="bar-fill" style="width:{pct:.1f}%;background:{cov_col}"></div>'
+            f"</div>"
+        )
+    else:
+        cov_display = "—"
+        cov_col = "#8b949e"
+        cov_bar = ""
+
+    return f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>PhysioMotion4D — Nightly Health</title>
+<style>{_CSS}</style>
+</head>
+<body>
+<h1>PhysioMotion4D &mdash; Nightly Health</h1>
+<p class="sub">
+  Last run: {ts_display}&nbsp;&middot;&nbsp;
+  <span class="badge {badge_class}">{badge_label}</span>&nbsp;&middot;&nbsp;
+  <a href="{run_url}" target="_blank" rel="noopener">View run &rarr;</a>
+</p>
+
+<div class="grid">
+  <div class="card">
+    <div class="label">Tests Passed</div>
+    <div class="value {pass_cls}">{n_pass}</div>
+    <div class="label" style="margin-top:6px">of {n_total} total</div>
+  </div>
+  <div class="card">
+    <div class="label">Tests Failed</div>
+    <div class="value {fail_cls}">{n_fail}</div>
+    {extra_err}
+  </div>
+  <div class="card">
+    <div class="label">Tests Skipped</div>
+    <div class="value muted">{n_skip}</div>
+  </div>
+  <div class="card">
+    <div class="label">Coverage</div>
+    <div class="value" style="color:{cov_col}">{cov_display}</div>
+    {cov_bar}
+  </div>
+</div>
+
+<footer>
+  Generated by the
+  <a href="https://github.com/Project-MONAI/physiomotion4d/actions/workflows/nightly-health.yml"
+     target="_blank" rel="noopener">nightly-health</a> workflow
+  &middot;
+  <a href="https://github.com/Project-MONAI/physiomotion4d"
+     target="_blank" rel="noopener">physiomotion4d</a>
+</footer>
+</body>
+</html>
+"""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# shields.io endpoint JSON
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def build_status_json(data: dict) -> dict:
+    """Return a shields.io dynamic endpoint object.
+
+    Usage in README:
+        ![Health](https://img.shields.io/endpoint?url=https://project-monai.github.io/physiomotion4d/status.json)
+    """
+    junit = data["junit"]
+    outcome = data["health_outcome"]
+
+    if not junit.get("available") or outcome not in ("success", "skipped", ""):
+        color, message = "critical", "unknown"
+    elif (junit["failed"] + junit["errors"]) > 0:
+        n_bad = junit["failed"] + junit["errors"]
+        color, message = "critical", f"{n_bad} failed"
+    else:
+        color, message = "brightgreen", f"{junit['passed']} passed"
+
+    return {
+        "schemaVersion": 1,
+        "label": "nightly health",
+        "message": message,
+        "color": color,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# GitHub Actions Markdown summary
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def build_summary_md(data: dict) -> str:
+    junit = data["junit"]
+    cov = data["coverage"]
+    outcome = data["health_outcome"]
+    run_url = data["run_url"]
+    ts = data["timestamp"]
+
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        ts_display = dt.strftime("%Y-%m-%d %H:%M UTC")
+    except Exception:
+        ts_display = ts
+
+    if not junit.get("available"):
+        status_icon = ":warning:"
+        status_text = "Unknown (no results)"
+    elif (
+        outcome not in ("success", "skipped", "")
+        or (junit["failed"] + junit["errors"]) > 0
+    ):
+        status_icon = ":x:"
+        status_text = "Failing"
+    else:
+        status_icon = ":white_check_mark:"
+        status_text = "Passing"
+
+    lines = [
+        f"# {status_icon} PhysioMotion4D Nightly Health — {ts_display}",
+        "",
+        f"**Status:** {status_text} &nbsp; | &nbsp; [View run]({run_url})",
+        "",
+        "## Test Results",
+        "",
+    ]
+
+    if junit.get("available"):
+        lines += [
+            "| | Count |",
+            "|---|---|",
+            f"| :white_check_mark: Passed | {junit['passed']} |",
+            f"| :x: Failed | {junit['failed']} |",
+            f"| :warning: Errors | {junit['errors']} |",
+            f"| :fast_forward: Skipped | {junit['skipped']} |",
+            f"| **Total** | **{junit['tests']}** |",
+            "",
+        ]
+    else:
+        lines += ["_Test results not available._", ""]
+
+    if cov.get("available") and cov["percent"] is not None:
+        pct = cov["percent"]
+        lines += [
+            "## Coverage",
+            "",
+            f"**{pct:.1f}%** line coverage",
+            "",
+        ]
+
+    return "\n".join(lines)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build PhysioMotion4D nightly health dashboard"
+    )
+    parser.add_argument(
+        "--results-dir",
+        default="results/",
+        help="Directory containing test-results.xml and coverage.json",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="dashboard/",
+        help="Output directory for dashboard files",
+    )
+    parser.add_argument("--run-url", default="#", help="URL of the GitHub Actions run")
+    parser.add_argument(
+        "--timestamp", default="", help="ISO 8601 UTC timestamp of the run"
+    )
+    parser.add_argument(
+        "--health-outcome",
+        default="",
+        help="Step outcome of the health tests (success/failure/...)",
+    )
+    args = parser.parse_args()
+
+    results_dir = Path(args.results_dir)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = args.timestamp or datetime.now(timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    data = {
+        "junit": parse_junit(results_dir / "test-results.xml"),
+        "coverage": parse_coverage(results_dir / "coverage.json"),
+        "run_url": args.run_url,
+        "timestamp": timestamp,
+        "health_outcome": args.health_outcome,
+    }
+
+    (output_dir / "index.html").write_text(build_html(data), encoding="utf-8")
+    (output_dir / "status.json").write_text(
+        json.dumps(build_status_json(data), indent=2), encoding="utf-8"
+    )
+    (output_dir / "summary.md").write_text(build_summary_md(data), encoding="utf-8")
+    (output_dir / ".nojekyll").write_text("", encoding="utf-8")
+
+    print(f"Dashboard written to {output_dir}/")
+    for name in ("index.html", "status.json", "summary.md", ".nojekyll"):
+        print(f"  {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/build_dashboard.py
+++ b/.github/scripts/build_dashboard.py
@@ -14,6 +14,19 @@ Usage (called from nightly-health.yml):
         --run-url "https://github.com/Project-MONAI/physiomotion4d/actions/runs/123" \\
         --timestamp "2026-03-31T07:05:42Z" \\
         --health-outcome "success"
+
+Artifact publishing:
+    ``status.json`` is uploaded by ``nightly-health.yml`` as a standalone
+    artifact named ``nightly-status-json`` (90-day retention).  ``docs.yml``
+    downloads that artifact during its ``deploy`` job and copies
+    ``status.json`` into the Pages output directory so that the file is
+    served at the live URL:
+
+        https://<pages-root>/status.json
+
+    The copy step uses ``continue-on-error: true`` so the first docs deploy
+    (before any nightly run has produced the artifact) succeeds without
+    ``status.json`` being present.
 """
 
 from __future__ import annotations

--- a/.github/scripts/build_dashboard.py
+++ b/.github/scripts/build_dashboard.py
@@ -250,9 +250,9 @@ def build_status_json(data: dict) -> dict:
         ![Health](https://img.shields.io/endpoint?url=https://project-monai.github.io/physiomotion4d/status.json)
     """
     junit = data["junit"]
-    outcome = data["health_outcome"]
 
-    if not junit.get("available") or outcome not in ("success", "skipped", ""):
+    if not junit.get("available"):
+        # JUnit XML missing or unparseable — step was cancelled or never ran.
         color, message = "critical", "unknown"
     elif (junit["failed"] + junit["errors"]) > 0:
         n_bad = junit["failed"] + junit["errors"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,16 +245,12 @@ jobs:
   # if no self-hosted runner is available. Enable manually via workflow_dispatch
   # or by setting the 'run-gpu-tests' label on the PR.
   gpu-tests:
-    name: GPU Tests (Python ${{ matrix.python-version }})
+    name: GPU Tests
     runs-on: [self-hosted, Windows, X64, gpu]
     needs: unit-tests
     timeout-minutes: 30
     # Only run GPU tests on manual trigger or if 'run-gpu-tests' label is present
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-gpu-tests')
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11"]
     continue-on-error: true
 
     steps:
@@ -263,10 +259,8 @@ jobs:
       with:
         lfs: true
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+    - name: Verify Python
+      run: python --version
 
     - name: Check GPU availability
       run: nvidia-smi
@@ -275,9 +269,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-pip-gpu-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+        key: ${{ runner.os }}-pip-gpu-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-pip-gpu-${{ matrix.python-version }}-
           ${{ runner.os }}-pip-gpu-
           ${{ runner.os }}-pip-
 
@@ -309,16 +302,14 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
-      if: matrix.python-version == '3.10'
       with:
         file: ./coverage.xml
         flags: gpu-tests
-        name: codecov-gpu-py${{ matrix.python-version }}
+        name: codecov-gpu
         fail_ci_if_error: false
 
     - name: Upload coverage artifacts
       uses: actions/upload-artifact@v4
-      if: matrix.python-version == '3.10'
       with:
         name: coverage-report-gpu
         path: htmlcov/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
 
     - name: Create venv in RUNNER_TEMP
       run: |
-        & "C:\Program Files\Python3.10\python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
+        & "C:\Program Files\Python310\python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
         echo "$env:RUNNER_TEMP\physiomotion4d-venv\Scripts" >> $env:GITHUB_PATH
 
     - name: Check GPU availability

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,8 +287,8 @@ jobs:
     - name: Assert CUDA is accessible
       run: |
         python -c "
-        import sys, torch
-        print(f'PyTorch {torch.__version__}  |  CUDA toolkit {torch.version.cuda}')
+        import sys, torch, cupy
+        print(f'PyTorch {torch.__version__}  |  CUDA toolkit {torch.version.cuda}  |  CuPy {cupy.__version__}')
         if not torch.cuda.is_available():
             print('ERROR: torch.cuda.is_available() returned False', file=sys.stderr)
             sys.exit(1)
@@ -296,7 +296,11 @@ jobs:
         if n == 0:
             print('ERROR: torch.cuda.device_count() == 0', file=sys.stderr)
             sys.exit(1)
-        print(f'OK: {n} GPU(s) visible')
+        cn = cupy.cuda.runtime.getDeviceCount()
+        if cn == 0:
+            print('ERROR: cupy.cuda.runtime.getDeviceCount() == 0', file=sys.stderr)
+            sys.exit(1)
+        print(f'OK: {n} GPU(s) visible to PyTorch and CuPy')
         "
 
     - name: List installed packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,8 +281,9 @@ jobs:
 
     - name: Install package with test dependencies
       # uv respects [tool.uv.sources], routing torch to pytorch-cu130 for cuda13
+      # Invoke via python -m uv so uv targets the active venv interpreter.
       run: |
-        uv pip install -e ".[test,cuda13]"
+        python -m uv pip install -e ".[test,cuda13]"
 
     - name: Assert CUDA is accessible
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,23 +259,21 @@ jobs:
       with:
         lfs: true
 
-    - name: Create / activate venv
+    - name: Create venv in RUNNER_TEMP
       run: |
-        if (-not (Test-Path "C:\actions-venvs\physiomotion4d")) {
-          & "C:\Program Files\Python3.10\python.exe" -m venv C:\actions-venvs\physiomotion4d
-        }
-        echo "C:\actions-venvs\physiomotion4d\Scripts" >> $env:GITHUB_PATH
+        & "C:\Program Files\Python3.10\python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
+        echo "$env:RUNNER_TEMP\physiomotion4d-venv\Scripts" >> $env:GITHUB_PATH
 
     - name: Check GPU availability
       run: nvidia-smi
 
-    - name: Cache venv packages
+    - name: Cache uv packages
       uses: actions/cache@v4
       with:
-        path: C:\actions-venvs\physiomotion4d
-        key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
+        path: ~\AppData\Local\uv\cache
+        key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-venv-
+          ${{ runner.os }}-uv-
 
     - name: Upgrade pip and build tools
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,12 +286,20 @@ jobs:
       run: |
         uv pip install -e ".[test,cuda13]"
 
-    - name: Verify GPU setup
+    - name: Assert CUDA is accessible
       run: |
-        python -c "import torch; print(f'PyTorch version: {torch.__version__}')"
-        python -c "import torch; print(f'CUDA available: {torch.cuda.is_available()}')"
-        python -c "import torch; print(f'CUDA version: {torch.version.cuda}')"
-        python -c "import torch; print(f'Number of GPUs: {torch.cuda.device_count()}')"
+        python -c "
+        import sys, torch
+        print(f'PyTorch {torch.__version__}  |  CUDA toolkit {torch.version.cuda}')
+        if not torch.cuda.is_available():
+            print('ERROR: torch.cuda.is_available() returned False', file=sys.stderr)
+            sys.exit(1)
+        n = torch.cuda.device_count()
+        if n == 0:
+            print('ERROR: torch.cuda.device_count() == 0', file=sys.stderr)
+            sys.exit(1)
+        print(f'OK: {n} GPU(s) visible')
+        "
 
     - name: List installed packages
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
   # or by setting the 'run-gpu-tests' label on the PR.
   gpu-tests:
     name: GPU Tests (Python ${{ matrix.python-version }})
-    runs-on: [self-hosted, linux, gpu, cuda13]
+    runs-on: [self-hosted, Windows, X64, gpu]
     needs: unit-tests
     timeout-minutes: 30
     # Only run GPU tests on manual trigger or if 'run-gpu-tests' label is present
@@ -269,14 +269,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Check GPU availability
-      run: |
-        nvidia-smi || echo "No GPU available"
-        python -c "import torch; print(f'PyTorch CUDA available: {torch.cuda.is_available()}')" || echo "PyTorch not installed yet"
+      run: nvidia-smi
 
     - name: Cache pip packages
       uses: actions/cache@v4
       with:
-        path: ~/.cache/pip
+        path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-gpu-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-pip-gpu-${{ matrix.python-version }}-
@@ -296,8 +294,8 @@ jobs:
       run: |
         python -c "import torch; print(f'PyTorch version: {torch.__version__}')"
         python -c "import torch; print(f'CUDA available: {torch.cuda.is_available()}')"
-        python -c "import torch; print(f'CUDA version: {torch.version.cuda}')" || echo "CUDA not available"
-        python -c "import torch; print(f'Number of GPUs: {torch.cuda.device_count()}')" || echo "No GPUs"
+        python -c "import torch; print(f'CUDA version: {torch.version.cuda}')"
+        python -c "import torch; print(f'Number of GPUs: {torch.cuda.device_count()}')"
 
     - name: List installed packages
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,20 +259,23 @@ jobs:
       with:
         lfs: true
 
-    - name: Verify Python
-      run: python --version
+    - name: Create / activate venv
+      run: |
+        if (-not (Test-Path "C:\actions-venvs\physiomotion4d")) {
+          & "C:\Program Files\Python3.10\python.exe" -m venv C:\actions-venvs\physiomotion4d
+        }
+        echo "C:\actions-venvs\physiomotion4d\Scripts" >> $env:GITHUB_PATH
 
     - name: Check GPU availability
       run: nvidia-smi
 
-    - name: Cache pip packages
+    - name: Cache venv packages
       uses: actions/cache@v4
       with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-pip-gpu-${{ hashFiles('pyproject.toml') }}
+        path: C:\actions-venvs\physiomotion4d
+        key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-pip-gpu-
-          ${{ runner.os }}-pip-
+          ${{ runner.os }}-venv-
 
     - name: Upgrade pip and build tools
       run: |
@@ -281,7 +284,7 @@ jobs:
     - name: Install package with test dependencies
       # uv respects [tool.uv.sources], routing torch to pytorch-cu130 for cuda13
       run: |
-        uv pip install --system -e ".[test,cuda13]"
+        uv pip install -e ".[test,cuda13]"
 
     - name: Verify GPU setup
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,6 +85,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:
@@ -98,16 +99,22 @@ jobs:
         name: documentation
         path: ./docs-html
 
-    - name: Download nightly status.json
-      uses: actions/download-artifact@v4
-      with:
-        name: nightly-status-json
-        path: results/
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-      continue-on-error: true
-
-    - name: Merge status.json into docs
-      run: cp results/status.json ./docs-html/status.json || true
+    - name: Fetch nightly status.json from nightly-status branch
+      # The nightly-health workflow maintains a single-file orphan branch
+      # (nightly-status) containing status.json.  Fetch it via the GitHub
+      # contents API so no checkout is required.  Silently omitted on the
+      # first docs deploy before any nightly run has pushed the branch.
+      run: |
+        if content=$(gh api \
+            "repos/${{ github.repository }}/contents/status.json?ref=nightly-status" \
+            --jq '.content' 2>/dev/null); then
+          printf '%s' "$content" | base64 -d > ./docs-html/status.json
+          echo "status.json merged into docs"
+        else
+          echo "No nightly-status branch yet; status.json omitted"
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Pages
       uses: actions/configure-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -97,7 +97,18 @@ jobs:
       with:
         name: documentation
         path: ./docs-html
-        
+
+    - name: Download nightly status.json
+      uses: actions/download-artifact@v4
+      with:
+        name: nightly-status-json
+        path: results/
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
+
+    - name: Merge status.json into docs
+      run: cp results/status.json ./docs-html/status.json || true
+
     - name: Setup Pages
       uses: actions/configure-pages@v4
       

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -42,7 +42,7 @@ jobs:
   health-tests:
     name: Health Tests (GPU)
     runs-on: [self-hosted, Windows, X64, gpu]
-    timeout-minutes: 90
+    timeout-minutes: 360
 
     outputs:
       # Captures the pytest step's actual outcome (success / failure / skipped)
@@ -99,7 +99,7 @@ jobs:
         # The step outcome (success/failure) is still captured and passed downstream.
         continue-on-error: true
         run: |
-          pytest tests/ -v -m "not experiment" `
+          pytest tests/ -v --run-experiments `
             --cov=physiomotion4d `
             --cov-report=xml `
             --cov-report=json `

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -86,10 +86,20 @@ jobs:
           python -m pip install --upgrade pip uv
           uv pip install -e ".[test,cuda13]"
 
-      - name: Verify GPU setup
+      - name: Assert CUDA is accessible
         run: |
-          python -c "import torch; print(f'PyTorch {torch.__version__}, CUDA={torch.cuda.is_available()}, GPUs={torch.cuda.device_count()}')"
-          python -c "import cupy; print(f'CuPy {cupy.__version__}')"
+          python -c "
+          import sys, torch, cupy
+          print(f'PyTorch {torch.__version__}  |  CUDA toolkit {torch.version.cuda}  |  CuPy {cupy.__version__}')
+          if not torch.cuda.is_available():
+              print('ERROR: torch.cuda.is_available() returned False', file=sys.stderr)
+              sys.exit(1)
+          n = torch.cuda.device_count()
+          if n == 0:
+              print('ERROR: torch.cuda.device_count() == 0', file=sys.stderr)
+              sys.exit(1)
+          print(f'OK: {n} GPU(s) visible')
+          "
 
       - name: Run health test suite
         id: run-tests

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -170,3 +170,10 @@ jobs:
           name: health-dashboard
           path: dashboard/
           retention-days: 90
+
+      - name: Upload status.json as standalone artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-status-json
+          path: dashboard/status.json
+          retention-days: 90

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -98,7 +98,11 @@ jobs:
           if n == 0:
               print('ERROR: torch.cuda.device_count() == 0', file=sys.stderr)
               sys.exit(1)
-          print(f'OK: {n} GPU(s) visible')
+          cn = cupy.cuda.runtime.getDeviceCount()
+          if cn == 0:
+              print('ERROR: cupy.cuda.runtime.getDeviceCount() == 0', file=sys.stderr)
+              sys.exit(1)
+          print(f'OK: {n} GPU(s) visible to PyTorch and CuPy')
           "
 
       - name: Run health test suite

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -59,10 +59,8 @@ jobs:
       - name: Check GPU availability
         run: nvidia-smi
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+      - name: Verify Python
+        run: python --version
 
       - name: Cache pip packages
         uses: actions/cache@v4

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -78,9 +78,10 @@ jobs:
             test-data-
 
       - name: Install uv and package
+        # Invoke via python -m uv so uv targets the active venv interpreter.
         run: |
           python -m pip install --upgrade pip uv
-          uv pip install -e ".[test,cuda13]"
+          python -m uv pip install -e ".[test,cuda13]"
 
       - name: Assert CUDA is accessible
         run: |

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -1,21 +1,19 @@
 name: Nightly Health
 
-# Run the full test suite on the GPU runner every night and publish a
-# one-page health dashboard to GitHub Pages.
+# Run the full test suite (including experiments) on the GPU runner every night.
 #
 # Schedule: 07:00 UTC daily ≈ 02:00 EST / 03:00 EDT
 #
-# Pages note: this workflow deploys the health dashboard to the same
-# github-pages environment used by docs.yml. The last deployment wins,
-# so pushing to main (which triggers docs.yml) will temporarily replace
-# the health page until the next nightly run. The README badge below is
-# independent of Pages and always reflects the latest run status.
+# Outputs:
+#   - GitHub Actions job summary (visible in the Actions UI after each run)
+#   - Artifact "health-dashboard": index.html + status.json (90-day retention)
+#   - Artifact "health-test-results": JUnit XML + coverage reports (90-day retention)
 #
-# README badge (workflow status — always current):
+# The dashboard is NOT deployed to GitHub Pages to avoid overwriting the
+# documentation site published by docs.yml.  Use the workflow status badge
+# for a live pass/fail indicator in README:
+#
 #   [![Nightly Health](https://github.com/Project-MONAI/physiomotion4d/actions/workflows/nightly-health.yml/badge.svg)](https://github.com/Project-MONAI/physiomotion4d/actions/workflows/nightly-health.yml)
-#
-# README badge (shields.io endpoint — reflects last Pages deploy):
-#   [![Health](https://img.shields.io/endpoint?url=https://project-monai.github.io/physiomotion4d/status.json)](https://project-monai.github.io/physiomotion4d/)
 
 on:
   schedule:
@@ -31,7 +29,6 @@ on:
         required: false
         default: 'main'
 
-# Minimal default permissions; deploy-pages job escalates its own permissions.
 permissions:
   contents: read
 
@@ -160,37 +157,3 @@ jobs:
           name: health-dashboard
           path: dashboard/
           retention-days: 90
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # 3. Deploy dashboard to GitHub Pages
-  # ──────────────────────────────────────────────────────────────────────────
-  deploy-pages:
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: build-dashboard
-    if: always()
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-
-    steps:
-      - name: Download dashboard artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: health-dashboard
-          path: dashboard/
-
-      - name: Setup GitHub Pages
-        uses: actions/configure-pages@v4
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dashboard/
-
-      - name: Deploy to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -56,20 +56,18 @@ jobs:
       - name: Check GPU availability
         run: nvidia-smi
 
-      - name: Create / activate venv
+      - name: Create venv in RUNNER_TEMP
         run: |
-          if (-not (Test-Path "C:\actions-venvs\physiomotion4d")) {
-            & "C:\Program Files\Python3.10\python.exe" -m venv C:\actions-venvs\physiomotion4d
-          }
-          echo "C:\actions-venvs\physiomotion4d\Scripts" >> $env:GITHUB_PATH
+          & "C:\Program Files\Python3.10\python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
+          echo "$env:RUNNER_TEMP\physiomotion4d-venv\Scripts" >> $env:GITHUB_PATH
 
-      - name: Cache venv packages
+      - name: Cache uv packages
         uses: actions/cache@v4
         with:
-          path: C:\actions-venvs\physiomotion4d
-          key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
+          path: ~\AppData\Local\uv\cache
+          key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-venv-
+            ${{ runner.os }}-uv-
 
       - name: Cache test data
         uses: actions/cache@v4

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -1,0 +1,198 @@
+name: Nightly Health
+
+# Run the full test suite on the GPU runner every night and publish a
+# one-page health dashboard to GitHub Pages.
+#
+# Schedule: 07:00 UTC daily ≈ 02:00 EST / 03:00 EDT
+#
+# Pages note: this workflow deploys the health dashboard to the same
+# github-pages environment used by docs.yml. The last deployment wins,
+# so pushing to main (which triggers docs.yml) will temporarily replace
+# the health page until the next nightly run. The README badge below is
+# independent of Pages and always reflects the latest run status.
+#
+# README badge (workflow status — always current):
+#   [![Nightly Health](https://github.com/Project-MONAI/physiomotion4d/actions/workflows/nightly-health.yml/badge.svg)](https://github.com/Project-MONAI/physiomotion4d/actions/workflows/nightly-health.yml)
+#
+# README badge (shields.io endpoint — reflects last Pages deploy):
+#   [![Health](https://img.shields.io/endpoint?url=https://project-monai.github.io/physiomotion4d/status.json)](https://project-monai.github.io/physiomotion4d/)
+
+on:
+  schedule:
+    - cron: '0 7 * * *'   # 07:00 UTC = ~02:00 EST / 03:00 EDT
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: false
+        default: 'Manual health check'
+      ref:
+        description: 'Git ref to check out (default: main)'
+        required: false
+        default: 'main'
+
+# Minimal default permissions; deploy-pages job escalates its own permissions.
+permissions:
+  contents: read
+
+jobs:
+  # ──────────────────────────────────────────────────────────────────────────
+  # 1. Run the full test suite on the GPU Windows runner
+  # ──────────────────────────────────────────────────────────────────────────
+  health-tests:
+    name: Health Tests (GPU)
+    runs-on: [self-hosted, Windows, X64, gpu]
+    timeout-minutes: 90
+
+    outputs:
+      # Captures the pytest step's actual outcome (success / failure / skipped)
+      # even though the job itself is not failed by a test failure.
+      test-outcome: ${{ steps.run-tests.outcome }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          ref: ${{ inputs.ref || 'main' }}
+
+      - name: Check GPU availability
+        run: nvidia-smi
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-health-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-health-
+            ${{ runner.os }}-pip-
+
+      - name: Cache test data
+        uses: actions/cache@v4
+        with:
+          path: |
+            tests/data/
+            tests/results/
+          key: test-data-${{ hashFiles('tests/test_*.py') }}-v2
+          restore-keys: |
+            test-data-
+
+      - name: Install uv and package
+        run: |
+          python -m pip install --upgrade pip uv
+          uv pip install --system -e ".[test,cuda13]"
+
+      - name: Verify GPU setup
+        run: |
+          python -c "import torch; print(f'PyTorch {torch.__version__}, CUDA={torch.cuda.is_available()}, GPUs={torch.cuda.device_count()}')"
+          python -c "import cupy; print(f'CuPy {cupy.__version__}')"
+
+      - name: Run health test suite
+        id: run-tests
+        # continue-on-error keeps the job running so artifacts are always uploaded.
+        # The step outcome (success/failure) is still captured and passed downstream.
+        continue-on-error: true
+        run: |
+          pytest tests/ -v -m "not experiment" `
+            --cov=physiomotion4d `
+            --cov-report=xml `
+            --cov-report=json `
+            --junitxml=test-results.xml
+        env:
+          CUDA_VISIBLE_DEVICES: 0
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: health-test-results
+          path: |
+            test-results.xml
+            coverage.xml
+            coverage.json
+          retention-days: 90
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # 2. Build the HTML dashboard from test results (runs even if tests failed)
+  # ──────────────────────────────────────────────────────────────────────────
+  build-dashboard:
+    name: Build Dashboard
+    runs-on: ubuntu-latest
+    needs: health-tests
+    if: always()
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download test results
+        uses: actions/download-artifact@v4
+        with:
+          name: health-test-results
+          path: results/
+        # Artifact may be absent if health-tests was cancelled before upload.
+        continue-on-error: true
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build dashboard
+        run: |
+          python .github/scripts/build_dashboard.py \
+            --results-dir results/ \
+            --output-dir dashboard/ \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --timestamp "$(python -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))')" \
+            --health-outcome "${{ needs.health-tests.outputs.test-outcome }}"
+
+      - name: Write GitHub Actions job summary
+        run: cat dashboard/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload dashboard artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: health-dashboard
+          path: dashboard/
+          retention-days: 90
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # 3. Deploy dashboard to GitHub Pages
+  # ──────────────────────────────────────────────────────────────────────────
+  deploy-pages:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build-dashboard
+    if: always()
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - name: Download dashboard artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: health-dashboard
+          path: dashboard/
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dashboard/
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create venv in RUNNER_TEMP
         run: |
-          & "C:\Program Files\Python3.10\python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
+          & "C:\Program Files\Python310\python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
           echo "$env:RUNNER_TEMP\physiomotion4d-venv\Scripts" >> $env:GITHUB_PATH
 
       - name: Cache uv packages

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -24,10 +24,9 @@ on:
         description: 'Reason for manual trigger'
         required: false
         default: 'Manual health check'
-      ref:
-        description: 'Git ref to check out (default: main)'
-        required: false
-        default: 'main'
+        # Branch selection is handled by the standard GitHub UI branch picker —
+        # no free-text ref input, so arbitrary non-default refs cannot be used
+        # to produce a misleading public artifact or dashboard.
 
 permissions:
   contents: read
@@ -51,7 +50,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          ref: ${{ inputs.ref || 'main' }}
 
       - name: Check GPU availability
         run: nvidia-smi

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -56,17 +56,20 @@ jobs:
       - name: Check GPU availability
         run: nvidia-smi
 
-      - name: Verify Python
-        run: python --version
+      - name: Create / activate venv
+        run: |
+          if (-not (Test-Path "C:\actions-venvs\physiomotion4d")) {
+            & "C:\Program Files\Python3.10\python.exe" -m venv C:\actions-venvs\physiomotion4d
+          }
+          echo "C:\actions-venvs\physiomotion4d\Scripts" >> $env:GITHUB_PATH
 
-      - name: Cache pip packages
+      - name: Cache venv packages
         uses: actions/cache@v4
         with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-health-${{ hashFiles('pyproject.toml') }}
+          path: C:\actions-venvs\physiomotion4d
+          key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-pip-health-
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-venv-
 
       - name: Cache test data
         uses: actions/cache@v4
@@ -81,7 +84,7 @@ jobs:
       - name: Install uv and package
         run: |
           python -m pip install --upgrade pip uv
-          uv pip install --system -e ".[test,cuda13]"
+          uv pip install -e ".[test,cuda13]"
 
       - name: Verify GPU setup
         run: |

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -135,6 +135,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: health-tests
     if: always()
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -172,9 +174,18 @@ jobs:
           path: dashboard/
           retention-days: 90
 
-      - name: Upload status.json as standalone artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: nightly-status-json
-          path: dashboard/status.json
-          retention-days: 90
+      - name: Push status.json to nightly-status branch
+        # Force-push a single-file orphan branch so docs.yml can fetch
+        # status.json via the GitHub API and include it in the Pages bundle.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          cp dashboard/status.json /tmp/status.json
+          git checkout --orphan nightly-status-tmp
+          git rm -rf . --quiet || true
+          cp /tmp/status.json status.json
+          git add status.json
+          git commit -m "chore: update nightly status [skip ci]"
+          git push origin HEAD:nightly-status --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test-slow-gpu:
     name: Slow Tests on GPU
-    runs-on: [self-hosted, linux, gpu, cuda13]
+    runs-on: [self-hosted, Windows, X64, gpu]
     timeout-minutes: 60
     continue-on-error: true
 
@@ -33,7 +33,7 @@ jobs:
     - name: Cache pip packages
       uses: actions/cache@v4
       with:
-        path: ~/.cache/pip
+        path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-slow-gpu-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-pip-slow-gpu-

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Create venv in RUNNER_TEMP
       run: |
-        & "C:\Program Files\Python3.10\python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
+        & "C:\Program Files\Python310\python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
         echo "$env:RUNNER_TEMP\physiomotion4d-venv\Scripts" >> $env:GITHUB_PATH
 
     - name: Check GPU availability

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -20,15 +20,11 @@ jobs:
       with:
         lfs: true
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
+    - name: Verify Python
+      run: python --version
 
     - name: Check GPU availability
-      run: |
-        nvidia-smi
-        python -c "import torch; print(f'PyTorch CUDA available: {torch.cuda.is_available()}')" || echo "PyTorch not installed yet"
+      run: nvidia-smi
 
     - name: Cache pip packages
       uses: actions/cache@v4

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -20,23 +20,21 @@ jobs:
       with:
         lfs: true
 
-    - name: Create / activate venv
+    - name: Create venv in RUNNER_TEMP
       run: |
-        if (-not (Test-Path "C:\actions-venvs\physiomotion4d")) {
-          & "C:\Program Files\Python3.10\python.exe" -m venv C:\actions-venvs\physiomotion4d
-        }
-        echo "C:\actions-venvs\physiomotion4d\Scripts" >> $env:GITHUB_PATH
+        & "C:\Program Files\Python3.10\python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
+        echo "$env:RUNNER_TEMP\physiomotion4d-venv\Scripts" >> $env:GITHUB_PATH
 
     - name: Check GPU availability
       run: nvidia-smi
 
-    - name: Cache venv packages
+    - name: Cache uv packages
       uses: actions/cache@v4
       with:
-        path: C:\actions-venvs\physiomotion4d
-        key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
+        path: ~\AppData\Local\uv\cache
+        key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-venv-
+          ${{ runner.os }}-uv-
 
     - name: Cache test data
       uses: actions/cache@v4

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -20,21 +20,23 @@ jobs:
       with:
         lfs: true
 
-    - name: Verify Python
-      run: python --version
+    - name: Create / activate venv
+      run: |
+        if (-not (Test-Path "C:\actions-venvs\physiomotion4d")) {
+          & "C:\Program Files\Python3.10\python.exe" -m venv C:\actions-venvs\physiomotion4d
+        }
+        echo "C:\actions-venvs\physiomotion4d\Scripts" >> $env:GITHUB_PATH
 
     - name: Check GPU availability
       run: nvidia-smi
 
-    - name: Cache pip packages
+    - name: Cache venv packages
       uses: actions/cache@v4
       with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-pip-slow-gpu-${{ hashFiles('pyproject.toml') }}
+        path: C:\actions-venvs\physiomotion4d
+        key: ${{ runner.os }}-venv-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-pip-slow-gpu-
-          ${{ runner.os }}-pip-gpu-
-          ${{ runner.os }}-pip-
+          ${{ runner.os }}-venv-
 
     - name: Cache test data
       uses: actions/cache@v4
@@ -53,7 +55,7 @@ jobs:
     - name: Install package with test dependencies
       # uv respects [tool.uv.sources], routing torch to pytorch-cu130 for cuda13
       run: |
-        uv pip install --system -e ".[test,cuda13]"
+        uv pip install -e ".[test,cuda13]"
 
     - name: Run slow tests
       run: |

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -57,6 +57,21 @@ jobs:
       run: |
         uv pip install -e ".[test,cuda13]"
 
+    - name: Assert CUDA is accessible
+      run: |
+        python -c "
+        import sys, torch
+        print(f'PyTorch {torch.__version__}  |  CUDA toolkit {torch.version.cuda}')
+        if not torch.cuda.is_available():
+            print('ERROR: torch.cuda.is_available() returned False', file=sys.stderr)
+            sys.exit(1)
+        n = torch.cuda.device_count()
+        if n == 0:
+            print('ERROR: torch.cuda.device_count() == 0', file=sys.stderr)
+            sys.exit(1)
+        print(f'OK: {n} GPU(s) visible')
+        "
+
     - name: Run slow tests
       run: |
         pytest tests/ -v -m "slow and not experiment" --cov=physiomotion4d --cov-report=xml --cov-report=term

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -52,8 +52,9 @@ jobs:
 
     - name: Install package with test dependencies
       # uv respects [tool.uv.sources], routing torch to pytorch-cu130 for cuda13
+      # Invoke via python -m uv so uv targets the active venv interpreter.
       run: |
-        uv pip install -e ".[test,cuda13]"
+        python -m uv pip install -e ".[test,cuda13]"
 
     - name: Assert CUDA is accessible
       run: |

--- a/docs/API_MAP.md
+++ b/docs/API_MAP.md
@@ -792,12 +792,12 @@ _Re-run `py utils/generate_api_map.py` whenever public APIs change._
 - `def get_repo_slug(repo_root)` (line 95): Derive owner/repo from the git remote URL (upstream, falling back to origin).
 - `def parse_github_datetime(iso_str)` (line 120): Parse GitHub API timestamps (may end with Z).
 - `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 136): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
-- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 176): Keep inline comments with created_at > cutoff and reviews with
+- `def filter_since_cutoff(thread_comments, reviews, cutoff)` (line 176): Keep thread comments with created_at > cutoff and reviews with
 - `def fetch_review_threads(pr_number, repo)` (line 390): Return all review threads for a PR via GraphQL, paginating both the
 - `def fetch_pr_data(pr_number, repo)` (line 449)
 - `def fetch_reviews(pr_number, repo)` (line 455)
 - `def resolve_review_threads(thread_ids, repo)` (line 460): Mark each thread in *thread_ids* as resolved via the GitHub GraphQL API.
-- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 549)
+- `def build_prompt(pr_number, pr_data, reviews, thread_comments, summary_filename)` (line 549)
 - `def invoke_claude(prompt, repo_root)` (line 666): Invoke Claude Code non-interactively via stdin.
 - `def parse_args()` (line 714)
 - `def main()` (line 779)

--- a/docs/API_MAP.md
+++ b/docs/API_MAP.md
@@ -787,19 +787,20 @@ _Re-run `py utils/generate_api_map.py` whenever public APIs change._
 
 ## utils/claude_github_reviews.py
 
-- `def git_fetch(repo_root, remote, branch)` (line 51): Run ``git fetch <remote> <branch>``, printing progress.
-- `def get_repo_root()` (line 65)
-- `def get_repo_slug(repo_root)` (line 79): Derive owner/repo from the git remote URL (upstream, falling back to origin).
-- `def parse_github_datetime(iso_str)` (line 104): Parse GitHub API timestamps (may end with Z).
-- `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 120): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
-- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 160): Keep inline comments with created_at > cutoff and reviews with
-- `def fetch_pr_data(pr_number, repo)` (line 238)
-- `def fetch_inline_comments(pr_number, repo)` (line 244)
-- `def fetch_reviews(pr_number, repo)` (line 249)
-- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 322)
-- `def invoke_claude(prompt, repo_root)` (line 439): Invoke Claude Code non-interactively via stdin.
-- `def parse_args()` (line 487)
-- `def main()` (line 533)
+- `def git_fetch(repo_root, remote, branch)` (line 64): Run ``git fetch <remote> <branch>``, printing progress.
+- `def get_repo_root()` (line 78)
+- `def get_repo_slug(repo_root)` (line 92): Derive owner/repo from the git remote URL (upstream, falling back to origin).
+- `def parse_github_datetime(iso_str)` (line 117): Parse GitHub API timestamps (may end with Z).
+- `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 133): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
+- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 173): Keep inline comments with created_at > cutoff and reviews with
+- `def fetch_review_threads(pr_number, repo)` (line 324): Return all review threads for a PR via GraphQL.
+- `def fetch_pr_data(pr_number, repo)` (line 376)
+- `def fetch_reviews(pr_number, repo)` (line 382)
+- `def resolve_review_threads(thread_ids, repo)` (line 387): Mark each thread in *thread_ids* as resolved via the GitHub GraphQL API.
+- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 476)
+- `def invoke_claude(prompt, repo_root)` (line 593): Invoke Claude Code non-interactively via stdin.
+- `def parse_args()` (line 641)
+- `def main()` (line 707)
 
 ## utils/generate_api_map.py
 

--- a/docs/API_MAP.md
+++ b/docs/API_MAP.md
@@ -793,14 +793,14 @@ _Re-run `py utils/generate_api_map.py` whenever public APIs change._
 - `def parse_github_datetime(iso_str)` (line 117): Parse GitHub API timestamps (may end with Z).
 - `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 133): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
 - `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 173): Keep inline comments with created_at > cutoff and reviews with
-- `def fetch_review_threads(pr_number, repo)` (line 324): Return all review threads for a PR via GraphQL.
-- `def fetch_pr_data(pr_number, repo)` (line 376)
-- `def fetch_reviews(pr_number, repo)` (line 382)
-- `def resolve_review_threads(thread_ids, repo)` (line 387): Mark each thread in *thread_ids* as resolved via the GitHub GraphQL API.
-- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 476)
-- `def invoke_claude(prompt, repo_root)` (line 593): Invoke Claude Code non-interactively via stdin.
-- `def parse_args()` (line 641)
-- `def main()` (line 707)
+- `def fetch_review_threads(pr_number, repo)` (line 387): Return all review threads for a PR via GraphQL, paginating both the
+- `def fetch_pr_data(pr_number, repo)` (line 446)
+- `def fetch_reviews(pr_number, repo)` (line 452)
+- `def resolve_review_threads(thread_ids, repo)` (line 457): Mark each thread in *thread_ids* as resolved via the GitHub GraphQL API.
+- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 546)
+- `def invoke_claude(prompt, repo_root)` (line 663): Invoke Claude Code non-interactively via stdin.
+- `def parse_args()` (line 711)
+- `def main()` (line 777)
 
 ## utils/generate_api_map.py
 

--- a/docs/API_MAP.md
+++ b/docs/API_MAP.md
@@ -787,20 +787,20 @@ _Re-run `py utils/generate_api_map.py` whenever public APIs change._
 
 ## utils/claude_github_reviews.py
 
-- `def git_fetch(repo_root, remote, branch)` (line 64): Run ``git fetch <remote> <branch>``, printing progress.
-- `def get_repo_root()` (line 78)
-- `def get_repo_slug(repo_root)` (line 92): Derive owner/repo from the git remote URL (upstream, falling back to origin).
-- `def parse_github_datetime(iso_str)` (line 117): Parse GitHub API timestamps (may end with Z).
-- `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 133): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
-- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 173): Keep inline comments with created_at > cutoff and reviews with
-- `def fetch_review_threads(pr_number, repo)` (line 387): Return all review threads for a PR via GraphQL, paginating both the
-- `def fetch_pr_data(pr_number, repo)` (line 446)
-- `def fetch_reviews(pr_number, repo)` (line 452)
-- `def resolve_review_threads(thread_ids, repo)` (line 457): Mark each thread in *thread_ids* as resolved via the GitHub GraphQL API.
-- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 546)
-- `def invoke_claude(prompt, repo_root)` (line 663): Invoke Claude Code non-interactively via stdin.
-- `def parse_args()` (line 711)
-- `def main()` (line 777)
+- `def git_fetch(repo_root, remote, branch)` (line 67): Run ``git fetch <remote> <branch>``, printing progress.
+- `def get_repo_root()` (line 81)
+- `def get_repo_slug(repo_root)` (line 95): Derive owner/repo from the git remote URL (upstream, falling back to origin).
+- `def parse_github_datetime(iso_str)` (line 120): Parse GitHub API timestamps (may end with Z).
+- `def get_remote_reflog_cutoff(repo_root, remote, head_ref)` (line 136): Latest reflog time for refs/remotes/<remote>/<head_ref> (when the ref last
+- `def filter_since_cutoff(inline_comments, reviews, cutoff)` (line 176): Keep inline comments with created_at > cutoff and reviews with
+- `def fetch_review_threads(pr_number, repo)` (line 390): Return all review threads for a PR via GraphQL, paginating both the
+- `def fetch_pr_data(pr_number, repo)` (line 449)
+- `def fetch_reviews(pr_number, repo)` (line 455)
+- `def resolve_review_threads(thread_ids, repo)` (line 460): Mark each thread in *thread_ids* as resolved via the GitHub GraphQL API.
+- `def build_prompt(pr_number, pr_data, reviews, inline_comments, summary_filename)` (line 549)
+- `def invoke_claude(prompt, repo_root)` (line 666): Invoke Claude Code non-interactively via stdin.
+- `def parse_args()` (line 714)
+- `def main()` (line 779)
 
 ## utils/generate_api_map.py
 

--- a/utils/claude_github_reviews.py
+++ b/utils/claude_github_reviews.py
@@ -836,13 +836,27 @@ def main() -> None:
             for r in reviews
             if r.get("body", "").strip() and r.get("state") not in ("PENDING", "")
         ]
-        # Re-derive thread IDs from comments that survived the time filter.
-        thread_ids = list(
-            {c["_thread_id"] for c in thread_comments if "_thread_id" in c}
-        )
+        # Only resolve threads where every comment survived the cutoff filter.
+        # A thread with pre-cutoff comments was not fully represented in the
+        # prompt, so resolving it would be premature.
+        surviving_thread_ids = {
+            c["_thread_id"] for c in thread_comments if "_thread_id" in c
+        }
+        thread_ids = [
+            t["id"]
+            for t in unresolved_threads
+            if t["id"] in surviving_thread_ids
+            and t["comments"]
+            and all(
+                parse_github_datetime(c.get("created_at", "1970-01-01T00:00:00Z"))
+                > cutoff
+                for c in t["comments"]
+            )
+        ]
         print(
             f"    After filter: {len(thread_comments)} thread comment(s), "
-            f"{len(review_bodies)} review(s) with body text"
+            f"{len(review_bodies)} review(s) with body text, "
+            f"{len(thread_ids)} thread(s) eligible for auto-resolve"
         )
 
     total = len(thread_comments) + len(review_bodies)

--- a/utils/claude_github_reviews.py
+++ b/utils/claude_github_reviews.py
@@ -282,18 +282,22 @@ def _gh_graphql(query: str, variables: dict) -> dict:
     return result
 
 
-# GraphQL query — fetches all review threads with resolution status and
-# the first 50 comments per thread.  Covers up to 100 threads per PR;
-# PRs with more than 100 threads will silently miss the remainder.
+# GraphQL query — fetches one page of review threads (up to 100) with the
+# first 50 comments per thread.  Both connections include pageInfo so the
+# caller can paginate until exhausted.
 _REVIEW_THREADS_QUERY = """
-query GetPRReviewThreads($owner: String!, $name: String!, $number: Int!) {
+query GetPRReviewThreads(
+  $owner: String!, $name: String!, $number: Int!, $after: String
+) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           isResolved
           comments(first: 50) {
+            pageInfo { hasNextPage endCursor }
             nodes {
               databaseId
               path
@@ -312,6 +316,29 @@ query GetPRReviewThreads($owner: String!, $name: String!, $number: Int!) {
 }
 """
 
+# Used when a thread's comment list was truncated in the main query.
+_THREAD_COMMENTS_QUERY = """
+query GetThreadComments($threadId: ID!, $after: String) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 50, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          databaseId
+          path
+          line
+          originalLine
+          body
+          createdAt
+          diffHunk
+          author { login }
+        }
+      }
+    }
+  }
+}
+"""
+
 _RESOLVE_THREAD_MUTATION = """
 mutation ResolveReviewThread($threadId: ID!) {
   resolveReviewThread(input: {threadId: $threadId}) {
@@ -321,55 +348,98 @@ mutation ResolveReviewThread($threadId: ID!) {
 """
 
 
+def _parse_comment(c: dict, thread_id: str) -> dict:
+    """Normalise a GraphQL comment node into the shape the rest of the code expects."""
+    return {
+        "id": c.get("databaseId"),
+        "path": c.get("path", ""),
+        "line": c.get("line"),
+        "original_line": c.get("originalLine"),
+        "body": c.get("body", ""),
+        "created_at": c.get("createdAt", ""),
+        "diff_hunk": c.get("diffHunk", ""),
+        "user": {"login": (c.get("author") or {}).get("login", "unknown")},
+        "_thread_id": thread_id,
+    }
+
+
+def _fetch_remaining_comments(thread_id: str, after: str) -> list[dict]:
+    """
+    Fetch comment pages for *thread_id* starting after *after* cursor.
+
+    Called only when the comments connection returned by the main threads
+    query reports ``hasNextPage = true``.
+    """
+    comments: list[dict] = []
+    cursor: str | None = after
+    while cursor:
+        result = _gh_graphql(
+            _THREAD_COMMENTS_QUERY, {"threadId": thread_id, "after": cursor}
+        )
+        conn = (result.get("data", {}).get("node") or {}).get("comments", {})
+        for c in conn.get("nodes", []):
+            comments.append(_parse_comment(c, thread_id))
+        page_info = conn.get("pageInfo", {})
+        cursor = page_info.get("endCursor") if page_info.get("hasNextPage") else None
+    return comments
+
+
 def fetch_review_threads(pr_number: int, repo: str) -> list[dict]:
     """
-    Return all review threads for a PR via GraphQL.
+    Return all review threads for a PR via GraphQL, paginating both the
+    thread list and per-thread comments until exhausted.
 
     Each entry has:
       ``id``         — GraphQL node ID (used for resolution mutation)
       ``isResolved`` — bool
-      ``comments``   — list of comment dicts shaped like the REST API response
-                       (keys: path, line, original_line, diff_hunk, body,
-                        created_at, user.login) plus ``_thread_id``
+      ``comments``   — list of comment dicts (keys: path, line, original_line,
+                       diff_hunk, body, created_at, user.login, _thread_id)
     """
     owner, name = repo.split("/", 1)
-    result = _gh_graphql(
-        _REVIEW_THREADS_QUERY,
-        {"owner": owner, "name": name, "number": pr_number},
-    )
-    raw_threads = (
-        result.get("data", {})
-        .get("repository", {})
-        .get("pullRequest", {})
-        .get("reviewThreads", {})
-        .get("nodes", [])
-    )
-
     threads: list[dict] = []
-    for t in raw_threads:
-        thread_id: str = t["id"]
-        comments: list[dict] = []
-        for c in t.get("comments", {}).get("nodes", []):
-            comments.append(
+    thread_cursor: str | None = None
+
+    while True:
+        result = _gh_graphql(
+            _REVIEW_THREADS_QUERY,
+            {"owner": owner, "name": name, "number": pr_number, "after": thread_cursor},
+        )
+        threads_conn = (
+            result.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+        )
+
+        for t in threads_conn.get("nodes", []):
+            thread_id: str = t["id"]
+            comments_conn = t.get("comments", {})
+
+            comments = [
+                _parse_comment(c, thread_id) for c in comments_conn.get("nodes", [])
+            ]
+
+            # Paginate comments if the first page was truncated.
+            if comments_conn.get("pageInfo", {}).get("hasNextPage"):
+                comments.extend(
+                    _fetch_remaining_comments(
+                        thread_id, comments_conn["pageInfo"]["endCursor"]
+                    )
+                )
+
+            threads.append(
                 {
-                    "id": c.get("databaseId"),
-                    "path": c.get("path", ""),
-                    "line": c.get("line"),
-                    "original_line": c.get("originalLine"),
-                    "body": c.get("body", ""),
-                    "created_at": c.get("createdAt", ""),
-                    "diff_hunk": c.get("diffHunk", ""),
-                    "user": {"login": (c.get("author") or {}).get("login", "unknown")},
-                    "_thread_id": thread_id,
+                    "id": thread_id,
+                    "isResolved": t.get("isResolved", False),
+                    "comments": comments,
                 }
             )
-        threads.append(
-            {
-                "id": thread_id,
-                "isResolved": t.get("isResolved", False),
-                "comments": comments,
-            }
-        )
+
+        page_info = threads_conn.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        thread_cursor = page_info["endCursor"]
+
     return threads
 
 

--- a/utils/claude_github_reviews.py
+++ b/utils/claude_github_reviews.py
@@ -23,6 +23,7 @@ Usage:
   py utils/claude_github_reviews.py --pr 42 --since-last-push --prompt-only
   py utils/claude_github_reviews.py --pr 42 --no-resolve
   py utils/claude_github_reviews.py --pr 42 --prompt-only --mark-resolved
+  # --no-resolve and --mark-resolved are mutually exclusive
 
   With --since-last-push, only inline comments and PR-level reviews created after
   the latest reflog time for refs/remotes/<remote>/<PR_head_branch> are included.
@@ -35,6 +36,8 @@ Usage:
   With --mark-resolved, threads are marked as resolved even when --prompt-only is
   set (no Claude invocation).  Useful for bulk-dismissing comments you have
   already handled manually.
+
+  --no-resolve and --mark-resolved are mutually exclusive; passing both is an error.
 
 Requirements:
   - gh CLI (GitHub CLI) — not a Python package; install separately:
@@ -754,15 +757,14 @@ def parse_args() -> argparse.Namespace:
         default="origin",
         help="Git remote name for fetch/reflog (default: origin; used with --since-last-push)",
     )
-    parser.add_argument(
+    resolve_group = parser.add_mutually_exclusive_group()
+    resolve_group.add_argument(
         "--no-resolve",
         dest="no_resolve",
         action="store_true",
-        help=(
-            "Do not mark inline-comment threads as resolved after Claude processes them"
-        ),
+        help="Do not mark inline-comment threads as resolved after Claude processes them",
     )
-    parser.add_argument(
+    resolve_group.add_argument(
         "--mark-resolved",
         dest="mark_resolved",
         action="store_true",

--- a/utils/claude_github_reviews.py
+++ b/utils/claude_github_reviews.py
@@ -3,25 +3,38 @@
 claude_github_reviews.py — Screen GitHub PR review comments with Claude.
 
 Workflow:
-  1. Fetch all inline review comments and PR-level review bodies via gh CLI.
+  1. Fetch all inline review threads and PR-level review bodies via gh CLI
+     (GraphQL for threads, REST for PR-level reviews).  Threads already marked
+     as resolved are skipped automatically.
   2. Build a structured prompt that includes file paths, line numbers, diff
      hunks, and suggestion blocks for every comment.
   3. Invoke Claude Code non-interactively; Claude reads CLAUDE.md and AGENTS.md,
      reads the referenced source files for context, and for each comment decides
      APPLY / REVISE / REJECT with explicit reasoning against project conventions.
   4. Accepted edits are applied as pending working-tree changes (not committed).
-  5. A Markdown summary tagged by PR number is written to the repo root.
+  5. Each processed inline-comment thread is marked as resolved on GitHub
+     (unless --no-resolve is passed).
+  6. A Markdown summary tagged by PR number is written to the repo root.
 
 Usage:
   py utils/claude_github_reviews.py --pr 42
   py utils/claude_github_reviews.py --pr 42 --repo owner/repo
   py utils/claude_github_reviews.py --pr 42 --prompt-only
   py utils/claude_github_reviews.py --pr 42 --since-last-push --prompt-only
+  py utils/claude_github_reviews.py --pr 42 --no-resolve
+  py utils/claude_github_reviews.py --pr 42 --prompt-only --mark-resolved
 
   With --since-last-push, only inline comments and PR-level reviews created after
   the latest reflog time for refs/remotes/<remote>/<PR_head_branch> are included.
   That time is when this clone last saw the remote ref move (push or fetch), not
   necessarily the exact server push timestamp.
+
+  With --no-resolve, inline-comment threads are NOT marked as resolved after
+  Claude processes them (useful for dry-runs or re-processing).
+
+  With --mark-resolved, threads are marked as resolved even when --prompt-only is
+  set (no Claude invocation).  Useful for bulk-dismissing comments you have
+  already handled manually.
 
 Requirements:
   - gh CLI (GitHub CLI) — not a Python package; install separately:
@@ -235,20 +248,161 @@ def _gh_api(endpoint: str, *, paginate: bool = False) -> list | dict:
     return json.loads(raw)
 
 
+def _gh_graphql(query: str, variables: dict) -> dict:
+    """
+    Execute a GitHub GraphQL query/mutation via ``gh api graphql --input -``.
+
+    Sends the query as a JSON body on stdin to avoid shell escaping and
+    Windows command-line length limits.  Exits on network or GraphQL errors.
+    """
+    payload = json.dumps({"query": query, "variables": variables})
+    try:
+        out = subprocess.run(
+            ["gh", "api", "graphql", "--input", "-"],
+            input=payload,
+            check=True,
+            text=True,
+            capture_output=True,
+            encoding="utf-8",
+        )
+    except FileNotFoundError:
+        print('[ERROR] "gh" CLI not found. Install from https://cli.github.com')
+        sys.exit(1)
+    except subprocess.CalledProcessError as exc:
+        msg = exc.stderr.strip() if exc.stderr else ""
+        print("[ERROR] gh api graphql failed.")
+        if msg:
+            print(f"        {msg}")
+        sys.exit(exc.returncode)
+
+    result: dict = json.loads(out.stdout.strip())
+    if "errors" in result:
+        print(f"[ERROR] GraphQL errors: {result['errors']}")
+        sys.exit(1)
+    return result
+
+
+# GraphQL query — fetches all review threads with resolution status and
+# the first 50 comments per thread.  Covers up to 100 threads per PR;
+# PRs with more than 100 threads will silently miss the remainder.
+_REVIEW_THREADS_QUERY = """
+query GetPRReviewThreads($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 50) {
+            nodes {
+              databaseId
+              path
+              line
+              originalLine
+              body
+              createdAt
+              diffHunk
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_RESOLVE_THREAD_MUTATION = """
+mutation ResolveReviewThread($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { id isResolved }
+  }
+}
+"""
+
+
+def fetch_review_threads(pr_number: int, repo: str) -> list[dict]:
+    """
+    Return all review threads for a PR via GraphQL.
+
+    Each entry has:
+      ``id``         — GraphQL node ID (used for resolution mutation)
+      ``isResolved`` — bool
+      ``comments``   — list of comment dicts shaped like the REST API response
+                       (keys: path, line, original_line, diff_hunk, body,
+                        created_at, user.login) plus ``_thread_id``
+    """
+    owner, name = repo.split("/", 1)
+    result = _gh_graphql(
+        _REVIEW_THREADS_QUERY,
+        {"owner": owner, "name": name, "number": pr_number},
+    )
+    raw_threads = (
+        result.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+        .get("nodes", [])
+    )
+
+    threads: list[dict] = []
+    for t in raw_threads:
+        thread_id: str = t["id"]
+        comments: list[dict] = []
+        for c in t.get("comments", {}).get("nodes", []):
+            comments.append(
+                {
+                    "id": c.get("databaseId"),
+                    "path": c.get("path", ""),
+                    "line": c.get("line"),
+                    "original_line": c.get("originalLine"),
+                    "body": c.get("body", ""),
+                    "created_at": c.get("createdAt", ""),
+                    "diff_hunk": c.get("diffHunk", ""),
+                    "user": {"login": (c.get("author") or {}).get("login", "unknown")},
+                    "_thread_id": thread_id,
+                }
+            )
+        threads.append(
+            {
+                "id": thread_id,
+                "isResolved": t.get("isResolved", False),
+                "comments": comments,
+            }
+        )
+    return threads
+
+
 def fetch_pr_data(pr_number: int, repo: str) -> dict:
     result = _gh_api(f"repos/{repo}/pulls/{pr_number}")
     assert isinstance(result, dict)
     return result
 
 
-def fetch_inline_comments(pr_number: int, repo: str) -> list[dict]:
-    result = _gh_api(f"repos/{repo}/pulls/{pr_number}/comments", paginate=True)
-    return result if isinstance(result, list) else []
-
-
 def fetch_reviews(pr_number: int, repo: str) -> list[dict]:
     result = _gh_api(f"repos/{repo}/pulls/{pr_number}/reviews", paginate=True)
     return result if isinstance(result, list) else []
+
+
+def resolve_review_threads(thread_ids: list[str], repo: str) -> None:
+    """
+    Mark each thread in *thread_ids* as resolved via the GitHub GraphQL API.
+
+    Resolution failures print a warning but do not abort; other threads are
+    still attempted.  PR-level reviews have no resolution concept and are not
+    handled here.
+    """
+    if not thread_ids:
+        return
+    print(f"[*] Resolving {len(thread_ids)} inline-comment thread(s)...")
+    owner, name = repo.split("/", 1)  # noqa: F841 — kept for future use
+    for tid in thread_ids:
+        try:
+            _gh_graphql(_RESOLVE_THREAD_MUTATION, {"threadId": tid})
+            print(f"    Resolved thread {tid}")
+        except SystemExit:
+            # _gh_graphql calls sys.exit on error; catch so we can continue.
+            print(f"    [WARNING] Could not resolve thread {tid} — skipping.")
 
 
 # ---------------------------------------------------------------------------
@@ -503,7 +657,10 @@ def parse_args() -> argparse.Namespace:
         "--repo",
         metavar="OWNER/REPO",
         default=None,
-        help="GitHub repo slug (default: inferred from git remote upstream, falling back to origin)",
+        help=(
+            "GitHub repo slug "
+            "(default: inferred from git remote upstream, falling back to origin)"
+        ),
     )
     parser.add_argument(
         "--prompt-only",
@@ -527,6 +684,23 @@ def parse_args() -> argparse.Namespace:
         default="origin",
         help="Git remote name for fetch/reflog (default: origin; used with --since-last-push)",
     )
+    parser.add_argument(
+        "--no-resolve",
+        dest="no_resolve",
+        action="store_true",
+        help=(
+            "Do not mark inline-comment threads as resolved after Claude processes them"
+        ),
+    )
+    parser.add_argument(
+        "--mark-resolved",
+        dest="mark_resolved",
+        action="store_true",
+        help=(
+            "Mark threads as resolved even when --prompt-only is set "
+            "(no Claude invocation required)"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -546,9 +720,17 @@ def main() -> None:
     pr_data = fetch_pr_data(pr_number, repo)
     print(f'    "{pr_data.get("title", "")}"')
 
-    print("[*] Fetching inline review comments...")
-    inline_comments = fetch_inline_comments(pr_number, repo)
-    print(f"    {len(inline_comments)} inline comment(s)")
+    print("[*] Fetching inline review threads (unresolved only)...")
+    threads = fetch_review_threads(pr_number, repo)
+    unresolved_threads = [t for t in threads if not t["isResolved"]]
+    resolved_count = len(threads) - len(unresolved_threads)
+    # Flatten to a comment list; each comment carries _thread_id for later resolution.
+    inline_comments: list[dict] = [c for t in unresolved_threads for c in t["comments"]]
+    thread_ids: list[str] = [t["id"] for t in unresolved_threads if t["comments"]]
+    print(
+        f"    {len(inline_comments)} comment(s) in {len(unresolved_threads)} "
+        f"unresolved thread(s) ({resolved_count} already resolved, skipped)"
+    )
 
     print("[*] Fetching PR-level reviews...")
     reviews = fetch_reviews(pr_number, repo)
@@ -582,6 +764,10 @@ def main() -> None:
             for r in reviews
             if r.get("body", "").strip() and r.get("state") not in ("PENDING", "")
         ]
+        # Re-derive thread IDs from comments that survived the time filter.
+        thread_ids = list(
+            {c["_thread_id"] for c in inline_comments if "_thread_id" in c}
+        )
         print(
             f"    After filter: {len(inline_comments)} inline comment(s), "
             f"{len(review_bodies)} review(s) with body text"
@@ -589,7 +775,7 @@ def main() -> None:
 
     total = len(inline_comments) + len(review_bodies)
     if total == 0:
-        print("\n[*] No review comments found. Nothing to do.")
+        print("\n[*] No unresolved review comments found. Nothing to do.")
         sys.exit(0)
 
     print(f"\n[*] Building prompt for {total} comment(s)...")
@@ -616,9 +802,16 @@ def main() -> None:
         print(separator)
         print("\n[prompt-only] No files changed.")
         print(f"[prompt-only] Summary would be written to: {summary_filename}")
+        if args.mark_resolved and thread_ids:
+            resolve_review_threads(thread_ids, repo)
         sys.exit(0)
 
     invoke_claude(prompt, repo_root)
+
+    if not args.no_resolve and thread_ids:
+        resolve_review_threads(thread_ids, repo)
+    elif args.no_resolve:
+        print(f"[*] --no-resolve: skipped resolving {len(thread_ids)} thread(s).")
 
     print()
     summary_path = repo_root / summary_filename

--- a/utils/claude_github_reviews.py
+++ b/utils/claude_github_reviews.py
@@ -174,16 +174,16 @@ def get_remote_reflog_cutoff(repo_root: Path, remote: str, head_ref: str) -> dat
 
 
 def filter_since_cutoff(
-    inline_comments: list[dict],
+    thread_comments: list[dict],
     reviews: list[dict],
     cutoff: datetime,
 ) -> tuple[list[dict], list[dict]]:
     """
-    Keep inline comments with created_at > cutoff and reviews with
+    Keep thread comments with created_at > cutoff and reviews with
     submitted_at > cutoff (submitted_at required).
     """
     filtered_inline: list[dict] = []
-    for c in inline_comments:
+    for c in thread_comments:
         created = c.get("created_at")
         if not created:
             continue
@@ -550,7 +550,7 @@ def build_prompt(
     pr_number: int,
     pr_data: dict,
     reviews: list[dict],
-    inline_comments: list[dict],
+    thread_comments: list[dict],
     summary_filename: str,
 ) -> str:
     title = pr_data.get("title", f"PR #{pr_number}")
@@ -562,14 +562,14 @@ def build_prompt(
         for r in reviews
         if r.get("body", "").strip() and r.get("state") not in ("PENDING", "")
     ]
-    total = len(inline_comments) + len(review_bodies)
+    total = len(thread_comments) + len(review_bodies)
 
     comments_block = "\n".join(
         filter(
             None,
             [
                 _format_review_bodies(reviews),
-                _format_inline_comments(inline_comments),
+                _format_inline_comments(thread_comments),
             ],
         )
     )
@@ -797,10 +797,10 @@ def main() -> None:
     unresolved_threads = [t for t in threads if not t["isResolved"]]
     resolved_count = len(threads) - len(unresolved_threads)
     # Flatten to a comment list; each comment carries _thread_id for later resolution.
-    inline_comments: list[dict] = [c for t in unresolved_threads for c in t["comments"]]
+    thread_comments: list[dict] = [c for t in unresolved_threads for c in t["comments"]]
     thread_ids: list[str] = [t["id"] for t in unresolved_threads if t["comments"]]
     print(
-        f"    {len(inline_comments)} comment(s) in {len(unresolved_threads)} "
+        f"    {len(thread_comments)} comment(s) in {len(unresolved_threads)} "
         f"unresolved thread(s) ({resolved_count} already resolved, skipped)"
     )
 
@@ -830,7 +830,7 @@ def main() -> None:
         print("[*] --since-last-push")
         print(f"    Remote ref : {remote_ref}")
         print(f"    Cutoff     : {cutoff.isoformat()}")
-        inline_comments, reviews = filter_since_cutoff(inline_comments, reviews, cutoff)
+        thread_comments, reviews = filter_since_cutoff(thread_comments, reviews, cutoff)
         review_bodies = [
             r
             for r in reviews
@@ -838,14 +838,14 @@ def main() -> None:
         ]
         # Re-derive thread IDs from comments that survived the time filter.
         thread_ids = list(
-            {c["_thread_id"] for c in inline_comments if "_thread_id" in c}
+            {c["_thread_id"] for c in thread_comments if "_thread_id" in c}
         )
         print(
-            f"    After filter: {len(inline_comments)} inline comment(s), "
+            f"    After filter: {len(thread_comments)} thread comment(s), "
             f"{len(review_bodies)} review(s) with body text"
         )
 
-    total = len(inline_comments) + len(review_bodies)
+    total = len(thread_comments) + len(review_bodies)
     if total == 0:
         print("\n[*] No unresolved review comments found. Nothing to do.")
         sys.exit(0)
@@ -855,7 +855,7 @@ def main() -> None:
         pr_number=pr_number,
         pr_data=pr_data,
         reviews=reviews,
-        inline_comments=inline_comments,
+        thread_comments=thread_comments,
         summary_filename=summary_filename,
     )
 


### PR DESCRIPTION
Adds nightly-health.yml: full test suite on the Windows GPU runner at 07:00 UTC (including experiment tests via --run-experiments), HTML dashboard uploaded as a GitHub Actions artifact, and a Markdown job summary written to the Actions UI. The dashboard is **not** deployed to GitHub Pages (to avoid overwriting the Sphinx docs site published by docs.yml); use the workflow status badge for a live pass/fail indicator. Also corrects self-hosted runner labels from [linux, gpu, cuda13] to [Windows, X64, gpu] in ci.yml and test-slow.yml, adds throwaway per-job venvs under $RUNNER_TEMP with uv wheel caching, adds hard CUDA+CuPy assertions before pytest runs, and fixes several bugs in utils/claude_github_reviews.py (GraphQL pagination, mutually exclusive flags, variable rename).