### PR TITLE
ENH: Disable enablement - manually enable doc deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -121,8 +121,6 @@ jobs:
 
     - name: Setup Pages
       uses: actions/configure-pages@v4
-      with:
-        enablement: true
       
     - name: Upload artifact for Pages
       uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined documentation deployment configuration to optimize the Pages setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->