### PR TITLE
ENH: accept registration/segmentation method instances in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         lfs: true
 
@@ -58,7 +58,7 @@ jobs:
         df -h
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -129,7 +129,7 @@ jobs:
         fail_ci_if_error: false
 
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       with:
         name: coverage-report-unit-tests
@@ -147,7 +147,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         lfs: true
 
@@ -164,7 +164,7 @@ jobs:
         df -h
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -277,7 +277,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         lfs: true
 
@@ -354,7 +354,7 @@ jobs:
         fail_ci_if_error: false
 
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: coverage-report-gpu
         path: htmlcov/
@@ -369,12 +369,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         lfs: true
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
         cache: 'pip'

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: true
 
@@ -121,7 +121,7 @@ jobs:
           CUDA_VISIBLE_DEVICES: 0
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: health-test-results
@@ -144,10 +144,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: health-test-results
           path: results/
@@ -155,7 +155,7 @@ jobs:
         continue-on-error: true
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -172,7 +172,7 @@ jobs:
         run: cat dashboard/summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload dashboard artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: health-dashboard
           path: dashboard/

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -58,7 +58,7 @@ jobs:
         # Python 3.11 is required because the [physicsnemo] extra pulls in
         # nvidia-physicsnemo, which requires Python >= 3.11.
         run: |
-          & "C:\Users\saylward\AppData\Local\Programs\Python\Python311/python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
+          & "C:\Users\saylward\AppData\Local\Programs\Python\Python311\python.exe" -m venv "$env:RUNNER_TEMP\physiomotion4d-venv"
           echo "$env:RUNNER_TEMP\physiomotion4d-venv\Scripts" >> $env:GITHUB_PATH
 
       - name: Cache uv packages

--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         lfs: true
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,6 @@ Version bumping: `bumpver update --patch`, `--minor`, or `--major`.
   changes.
 - Keep diffs small and reviewable.
 - Prefer editing existing modules over creating new ones.
-- Call out breaking changes explicitly.
 - No backward-compatibility shims: just change the code.
 
 ## Testing Role

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,7 @@ Before editing any code:
 7. Follow the behavior guidelines given above.
 8. Implement in small, reviewable diffs.
 9. Update docstrings and tests for every changed public method.
-10. Call out breaking changes explicitly.
-11. Do not commit changes or make pull requests unless specifically told to do so.
+10. Do not commit changes or make pull requests unless specifically told to do so.
 
 Breaking changes are acceptable. Backward-compatibility shims are not.
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ print(WorkflowConvertImageToUSD.__name__)
 
 ## Getting Started: Tutorials
 
-The `tutorials/` directory contains nine end-to-end Python scripts, one for each
-major workflow. They are the recommended starting point for new users.
+The `tutorials/` directory contains eleven end-to-end Python scripts covering
+nine major workflows (Tutorials 9 and 10 each have MeshGraphNet and MLP
+variants). They are the recommended starting point for new users.
 
 | # | Script | Workflow | Dataset |
 |---|--------|----------|---------|
@@ -291,7 +292,7 @@ For implementation details and advanced usage, see the CLI modules in `src/physi
 ### Python API - Basic Heart-Gated CT Processing
 
 ```python
-from physiomotion4d import WorkflowConvertImageToUSD
+from physiomotion4d import RegisterImagesICON, WorkflowConvertImageToUSD
 
 # Initialize processor
 processor = WorkflowConvertImageToUSD(
@@ -299,7 +300,7 @@ processor = WorkflowConvertImageToUSD(
     contrast_enhanced=True,
     output_directory="./results",
     project_name="cardiac_model",
-    registration_method='ICON'  # or 'ANTS'
+    registration_method=RegisterImagesICON(),  # or RegisterImagesANTS()
 )
 
 # Run complete workflow
@@ -371,12 +372,15 @@ registerer.set_fixed_image(itk.imread("reference_frame.mha"))
 results = registerer.register(itk.imread("target_frame.mha"))
 
 # Option 3: Time series registration for 4D CT
-time_series_reg = RegisterTimeSeriesImages(
-    reference_index=0,
-    registration_method='ICON'  # or 'ANTS'
-)
+time_series_reg = RegisterTimeSeriesImages(registration_method=RegisterImagesICON())
+time_series_reg.set_fixed_image(itk.imread("time00.mha"))
 transforms = time_series_reg.register_time_series(
-    image_filenames=["time00.mha", "time01.mha", "time02.mha"]
+    moving_images=[
+        itk.imread("time00.mha"),
+        itk.imread("time01.mha"),
+        itk.imread("time02.mha"),
+    ],
+    reference_frame=0,
 )
 
 # Get forward and inverse displacement fields

--- a/docs/api/registration/time_series.rst
+++ b/docs/api/registration/time_series.rst
@@ -6,7 +6,9 @@ Time-Series Registration
 .. currentmodule:: physiomotion4d
 
 ``RegisterTimeSeriesImages`` registers ordered 3D image phases to a reference
-frame using Greedy, ICON, or combined ``Greedy_ICON`` methods.
+frame using a caller-supplied :class:`RegisterImagesBase` backend (e.g.
+:class:`RegisterImagesGreedy`, :class:`RegisterImagesICON`, or
+:class:`RegisterImagesGreedyICON` for combined Greedy-then-ICON refinement).
 
 Class Reference
 ===============
@@ -24,11 +26,11 @@ Basic Usage
 
    import itk
 
-   from physiomotion4d import RegisterTimeSeriesImages
+   from physiomotion4d import RegisterImagesGreedy, RegisterTimeSeriesImages
 
    images = [itk.imread(f"phase_{idx:02d}.mha") for idx in range(10)]
 
-   registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+   registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
    registrar.set_fixed_image(images[0])
 
    result = registrar.register_time_series(

--- a/docs/api/workflows.rst
+++ b/docs/api/workflows.rst
@@ -48,15 +48,19 @@ Convert Image to USD
 
 .. code-block:: python
 
-   from physiomotion4d import WorkflowConvertImageToUSD
+   from physiomotion4d import (
+       RegisterImagesICON,
+       SegmentChestTotalSegmentator,
+       WorkflowConvertImageToUSD,
+   )
 
    workflow = WorkflowConvertImageToUSD(
        input_filenames=["cardiac_4d.nrrd"],
        contrast_enhanced=True,
        output_directory="./results",
        project_name="patient_001",
-       segmentation_method="ChestTotalSegmentator",
-       registration_method="ICON",
+       segmentation_method=SegmentChestTotalSegmentator(),
+       registration_method=RegisterImagesICON(),
    )
 
    final_usd = workflow.process()
@@ -73,10 +77,12 @@ Image to VTK
 
    import itk
 
-   from physiomotion4d import WorkflowConvertImageToVTK
+   from physiomotion4d import SegmentChestTotalSegmentator, WorkflowConvertImageToVTK
 
    image = itk.imread("chest_ct.nii.gz")
-   workflow = WorkflowConvertImageToVTK(segmentation_method="ChestTotalSegmentator")
+   workflow = WorkflowConvertImageToVTK(
+       segmentation_method=SegmentChestTotalSegmentator()
+   )
    result = workflow.run_workflow(
        input_image=image,
        contrast_enhanced_study=True,
@@ -150,14 +156,14 @@ High-Resolution 4D CT Reconstruction
 
    import itk
 
-   from physiomotion4d import WorkflowReconstructHighres4DCT
+   from physiomotion4d import RegisterImagesGreedyICON, WorkflowReconstructHighres4DCT
 
    time_series_images = [itk.imread(f"phase_{idx:02d}.mha") for idx in range(10)]
    workflow = WorkflowReconstructHighres4DCT(
        time_series_images=time_series_images,
        fixed_image=time_series_images[0],
        reference_frame=0,
-       registration_method="Greedy_ICON",
+       registration_method=RegisterImagesGreedyICON(),
    )
 
    result = workflow.run_workflow(upsample_to_fixed_resolution=True)

--- a/docs/developer/registration_images.rst
+++ b/docs/developer/registration_images.rst
@@ -38,17 +38,43 @@ Time Series
 
    import itk
 
-   from physiomotion4d import RegisterTimeSeriesImages
+   from physiomotion4d import RegisterImagesGreedy, RegisterTimeSeriesImages
 
    images = [itk.imread(f"phase_{idx:02d}.mha") for idx in range(10)]
 
-   registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+   registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
    registrar.set_fixed_image(images[0])
    result = registrar.register_time_series(
        moving_images=images,
        reference_frame=0,
        register_reference=False,
    )
+
+Combining Registrars
+=====================
+
+Workflows that accept a ``registration_method`` (e.g.
+:class:`WorkflowConvertImageToUSD`, :class:`RegisterTimeSeriesImages`) take
+any :class:`RegisterImagesBase` instance, including a composite chain that
+runs multiple backends in sequence. :class:`RegisterImagesChain` runs an
+ordered list of registrars, feeding each stage's ``forward_transform`` as the
+next stage's ``initial_forward_transform``. :class:`RegisterImagesGreedyICON`
+is a named 2-stage convenience class for the common case of a fast Greedy
+registration followed by ICON refinement:
+
+.. code-block:: python
+
+   from physiomotion4d import RegisterImagesChain, RegisterImagesGreedy, RegisterImagesICON
+
+   # Arbitrary N-stage chain
+   registrar = RegisterImagesChain([RegisterImagesGreedy(), RegisterImagesICON()])
+
+   # Or, for the common Greedy-then-ICON case:
+   from physiomotion4d import RegisterImagesGreedyICON
+
+   registrar = RegisterImagesGreedyICON()
+   registrar.greedy.set_number_of_iterations([30, 15, 7, 3])
+   registrar.icon.set_number_of_iterations(20)
 
 Development Notes
 =================

--- a/docs/developer/workflows.rst
+++ b/docs/developer/workflows.rst
@@ -32,14 +32,14 @@ Workflow Example
 
 .. code-block:: python
 
-   from physiomotion4d import WorkflowConvertImageToUSD
+   from physiomotion4d import RegisterImagesICON, WorkflowConvertImageToUSD
 
    workflow = WorkflowConvertImageToUSD(
        input_filenames=["cardiac_4d.nrrd"],
        contrast_enhanced=True,
        output_directory="./results",
        project_name="patient_001",
-       registration_method="ICON",
+       registration_method=RegisterImagesICON(),
    )
 
    final_usd = workflow.process()

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -27,7 +27,7 @@ Complete end-to-end cardiac CT processing:
 
 .. code-block:: python
 
-   from physiomotion4d import WorkflowConvertImageToUSD
+   from physiomotion4d import RegisterImagesICON, WorkflowConvertImageToUSD
 
    # Initialize workflow
    workflow = WorkflowConvertImageToUSD(
@@ -35,7 +35,7 @@ Complete end-to-end cardiac CT processing:
        contrast_enhanced=True,
        output_directory="./results",
        project_name="patient_001",
-       registration_method="ICON",
+       registration_method=RegisterImagesICON(),
    )
 
    # Run complete workflow
@@ -54,7 +54,7 @@ phase images:
 
    import itk
 
-   from physiomotion4d import WorkflowReconstructHighres4DCT
+   from physiomotion4d import RegisterImagesGreedyICON, WorkflowReconstructHighres4DCT
 
    # DirLab-4DCT data is manual-only. Place phase images under ./data/DirLab.
    phase_dir = Path("./data/DirLab/case1")
@@ -66,7 +66,7 @@ phase images:
        time_series_images=time_series_images,
        fixed_image=fixed_image,
        reference_frame=0,
-       registration_method="Greedy_ICON",
+       registration_method=RegisterImagesGreedyICON(),
    )
 
    result = workflow.run_workflow(upsample_to_fixed_resolution=True)
@@ -390,7 +390,7 @@ Batch process multiple datasets:
 
 .. code-block:: python
 
-   from physiomotion4d import WorkflowConvertImageToUSD
+   from physiomotion4d import RegisterImagesICON, WorkflowConvertImageToUSD
    import glob
    import os
 
@@ -411,7 +411,7 @@ Batch process multiple datasets:
            contrast_enhanced=True,
            output_directory=f"results/{patient_id}",
            project_name=patient_id,
-           registration_method="ICON",
+           registration_method=RegisterImagesICON(),
        )
 
        try:
@@ -474,14 +474,14 @@ Run the supported end-to-end workflow API:
 
 .. code-block:: python
 
-   from physiomotion4d import WorkflowConvertImageToUSD
+   from physiomotion4d import RegisterImagesICON, WorkflowConvertImageToUSD
 
    workflow = WorkflowConvertImageToUSD(
        input_filenames=["cardiac_4d.nrrd"],
        contrast_enhanced=True,
        output_directory="./results",
        project_name="cardiac_model",
-       registration_method="ICON",
+       registration_method=RegisterImagesICON(),
    )
 
    final_usd = workflow.process()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,24 @@
        <p>Register respiratory CT phases and reconstruct a higher-resolution 4D volume series.</p>
        <span class="pm4d-card__meta">DirLab-4DCT</span>
      </a>
+     <a class="pm4d-card" href="tutorials.html#tutorial-8-fit-the-cardiac-ssm-and-propagate-through-gated-phases">
+       <span class="pm4d-card__number">08</span>
+       <h2>Fit the Cardiac SSM and Propagate Through Gated Phases</h2>
+       <p>Fit a PCA heart model to the reference phase and propagate it to every gated phase with ICON registration.</p>
+       <span class="pm4d-card__meta">Bring your own cardiac data</span>
+     </a>
+     <a class="pm4d-card" href="tutorials.html#tutorial-9a-9b-train-a-physicsnemo-cardiac-stage-model">
+       <span class="pm4d-card__number">09</span>
+       <h2>Train a PhysicsNeMo Cardiac Stage Model</h2>
+       <p>Train a PhysicsNeMo MeshGraphNet (9a) or MLP (9b) to predict cardiac meshes at requested stages.</p>
+       <span class="pm4d-card__meta">Tutorial 8 output</span>
+     </a>
+     <a class="pm4d-card" href="tutorials.html#tutorial-10a-10b-predict-and-evaluate-cardiac-surfaces">
+       <span class="pm4d-card__number">10</span>
+       <h2>Predict and Evaluate Cardiac Surfaces</h2>
+       <p>Load a Tutorial 9 checkpoint and predict cardiac surfaces at gated phases or caller-specified stages.</p>
+       <span class="pm4d-card__meta">Tutorial 9a / 9b output</span>
+     </a>
    </section>
 
    <section class="pm4d-topic-section" aria-label="Documentation topics">

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,8 +16,9 @@ This guide will help you get started with PhysioMotion4D quickly.
 Tutorials
 =========
 
-The ``tutorials/`` directory contains nine end-to-end scripts, one per major
-workflow. Each script is a ``# %%`` percent-cell Python script that exercises
+The ``tutorials/`` directory contains eleven end-to-end scripts covering nine
+major workflows (Tutorials 9 and 10 each have MeshGraphNet and MLP variants).
+Each script is a ``# %%`` percent-cell Python script that exercises
 the workflow classes directly. Run as a regular file
 (``python tutorials/tutorial_01_...py``) or cell-by-cell in VS Code or Cursor.
 
@@ -44,9 +45,12 @@ Recommended run order:
 3. Tutorial 3 after downloading KCL-Heart-Model.
 4. Tutorial 4 after Tutorial 3 because it can consume Tutorial 3 output.
 5. Tutorial 6 after downloading DirLab-4DCT.
-6. Tutorial 7 after downloading DirLab-4DCT.
-7. Tutorial 8 after Tutorial 7 because it consumes the fitted PCA meshes.
-8. Tutorial 9 after Tutorial 8 because it trains from propagated meshes.
+6. Tutorial 8 after preparing your own cardiac gated CT, labelmaps, KCL volume
+   PCA model, and ICON weights (bring-your-own-data).
+7. Tutorial 9a and/or 9b after Tutorial 8 because they train from its fitted
+   meshes.
+8. Tutorial 10a and/or 10b after Tutorial 9a / 9b because they evaluate the
+   trained checkpoints.
 
 Prerequisites
 =============
@@ -105,7 +109,7 @@ For more control, use the Python API:
 
 .. code-block:: python
 
-   from physiomotion4d import WorkflowConvertImageToUSD
+   from physiomotion4d import RegisterImagesICON, WorkflowConvertImageToUSD
 
 **Step 2: Initialize with your data**
 
@@ -116,7 +120,7 @@ For more control, use the Python API:
        contrast_enhanced=True,
        output_directory="./results",
        project_name="cardiac_model",
-       registration_method="ICON",
+       registration_method=RegisterImagesICON(),
    )
 
 **Step 3: Run the workflow**
@@ -143,7 +147,7 @@ For more control over individual steps:
 
 .. code-block:: python
 
-   from physiomotion4d import WorkflowConvertImageToUSD
+   from physiomotion4d import RegisterImagesICON, WorkflowConvertImageToUSD
 
    # Initialize workflow
    workflow = WorkflowConvertImageToUSD(
@@ -151,7 +155,7 @@ For more control over individual steps:
        contrast_enhanced=True,
        output_directory="./results",
        project_name="cardiac_model",
-       registration_method="ICON",
+       registration_method=RegisterImagesICON(),
    )
 
    final_usd = workflow.process()
@@ -246,8 +250,9 @@ Download Sample Cardiac CT Data
    assert DataDownloadTools.VerifySlicerHeartCTData("sample_data")
 
 DirLab-4DCT data is manual-only; see ``data/README.md`` before running the
-high-resolution 4D CT reconstruction, lung-lobe PCA model, or PCA time-series
-propagation tutorials. Tutorial 9 additionally requires the optional
+high-resolution 4D CT reconstruction tutorial. Tutorials 8-10 are
+bring-your-own-data cardiac tutorials; see :doc:`tutorials` for their dataset
+layout. Tutorials 9a/9b/10a/10b additionally require the optional
 ``physicsnemo`` extra (``pip install "physiomotion4d[physicsnemo]"``);
 PhysicsNeMo itself requires Python >= 3.11.
 

--- a/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_patient-CHOPValve.py
+++ b/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_patient-CHOPValve.py
@@ -12,6 +12,7 @@ import pyvista as pv
 
 # Import from PhysioMotion4D package
 from physiomotion4d import (
+    SegmentHeartSimplewareTrimmedBranches,
     WorkflowFitStatisticalModelToPatient,
 )
 from physiomotion4d.test_tools import TestTools
@@ -51,7 +52,7 @@ os.makedirs(output_dir, exist_ok=True)
 registrar = WorkflowFitStatisticalModelToPatient(
     template_model=template_model,
     patient_image=patient_image,
-    segmentation_method="HeartSimplewareTrimmedBranches",
+    segmentation_method=SegmentHeartSimplewareTrimmedBranches(),
 )
 
 registrar.set_use_pca_registration(

--- a/experiments/LongitudinalRegistration/3-eval_icon.py
+++ b/experiments/LongitudinalRegistration/3-eval_icon.py
@@ -22,10 +22,48 @@ from pathlib import Path
 import itk
 import numpy as np
 
-from physiomotion4d import RegisterTimeSeriesImages, SegmentHeartSimpleware
+from physiomotion4d import (
+    RegisterImagesBase,
+    RegisterImagesGreedy,
+    RegisterImagesGreedyICON,
+    RegisterImagesICON,
+    RegisterTimeSeriesImages,
+    SegmentHeartSimpleware,
+)
 from physiomotion4d.labelmap_tools import LabelmapTools
 from physiomotion4d.landmark_tools import LandmarkTools
 from physiomotion4d.transform_tools import TransformTools
+
+
+def _build_registrar(
+    reg_method: str,
+    greedy_iters,
+    icon_iterations,
+    weights_path,
+) -> RegisterImagesBase:
+    """Build a configured registrar instance for one of "Greedy", "ICON", or
+    "Greedy_ICON", matching this experiment's per-method config entries."""
+    if reg_method == "Greedy":
+        greedy = RegisterImagesGreedy()
+        if greedy_iters is not None:
+            greedy.set_number_of_iterations(greedy_iters)
+        return greedy
+    if reg_method == "ICON":
+        icon = RegisterImagesICON()
+        icon.set_number_of_iterations(icon_iterations)
+        if weights_path is not None:
+            icon.set_weights_path(str(weights_path))
+        return icon
+    if reg_method == "Greedy_ICON":
+        greedy_icon = RegisterImagesGreedyICON()
+        if greedy_iters is not None:
+            greedy_icon.greedy.set_number_of_iterations(greedy_iters)
+        greedy_icon.icon.set_number_of_iterations(icon_iterations)
+        if weights_path is not None:
+            greedy_icon.icon.set_weights_path(str(weights_path))
+        return greedy_icon
+    raise ValueError(f"Unknown registration method: {reg_method}")
+
 
 # %% [markdown]
 # ## 1. Hard-coded paths and configuration
@@ -218,17 +256,15 @@ for subject_id in test_subjects:
         greedy_iters = method_cfg["greedy_iters"]
 
         print(f"  Method: {method_name}")
-        registrar = RegisterTimeSeriesImages(registration_method=reg_method)
+        registrar = RegisterTimeSeriesImages(
+            registration_method=_build_registrar(
+                reg_method, greedy_iters, icon_iterations, weights_path
+            )
+        )
         registrar.set_modality("ct")
         registrar.set_fixed_image(fixed_image)
         if use_mask:
             registrar.set_fixed_mask(fixed_mask)
-        if greedy_iters is not None:
-            registrar.set_number_of_iterations_greedy(greedy_iters)
-        if reg_method in ("ICON", "Greedy_ICON"):
-            registrar.set_number_of_iterations_ICON(icon_iterations)
-            if weights_path is not None:
-                registrar.registrar_ICON.set_weights_path(str(weights_path))
 
         result = registrar.register_time_series(
             moving_images=moving_images,

--- a/experiments/LongitudinalRegistration/3-eval_icon.py
+++ b/experiments/LongitudinalRegistration/3-eval_icon.py
@@ -180,7 +180,6 @@ landmark_tools = LandmarkTools()
 labelmap_tools = LabelmapTools()
 transform_tools = TransformTools()
 segmenter = SegmentHeartSimpleware()
-segmenter.set_trim_branches(False)
 
 
 # %% [markdown]

--- a/experiments/Reconstruct4DCT/reconstruct_4d_ct_class.py
+++ b/experiments/Reconstruct4DCT/reconstruct_4d_ct_class.py
@@ -16,10 +16,44 @@ import os
 import itk
 import numpy as np
 
-from physiomotion4d import RegisterTimeSeriesImages, TransformTools
+from physiomotion4d import (
+    RegisterImagesBase,
+    RegisterImagesGreedy,
+    RegisterImagesGreedyICON,
+    RegisterImagesICON,
+    RegisterTimeSeriesImages,
+    TransformTools,
+)
 from physiomotion4d.test_tools import TestTools
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _build_registrar(method_name: str, iterations=None) -> RegisterImagesBase:
+    """Build a registrar instance for one of "Greedy", "ICON", or
+    "Greedy_ICON". When `iterations` is given, it matches this experiment's
+    `number_of_iterations_list` shape: a list for Greedy, an int for ICON,
+    or [greedy_list, icon_int] for Greedy_ICON. `iterations=None` builds an
+    unconfigured instance (used where only the transform-reconstruction
+    step is needed, which does not depend on iteration counts)."""
+    if method_name == "Greedy":
+        greedy = RegisterImagesGreedy()
+        if iterations is not None:
+            greedy.set_number_of_iterations(iterations)
+        return greedy
+    if method_name == "ICON":
+        icon = RegisterImagesICON()
+        if iterations is not None:
+            icon.set_number_of_iterations(iterations)
+        return icon
+    if method_name == "Greedy_ICON":
+        greedy_icon = RegisterImagesGreedyICON()
+        if iterations is not None:
+            greedy_icon.greedy.set_number_of_iterations(iterations[0])
+            greedy_icon.icon.set_number_of_iterations(iterations[1])
+        return greedy_icon
+    raise ValueError(f"Unknown registration method: {method_name}")
+
 
 # %% [markdown]
 # ## Load Data and Set Parameters
@@ -139,18 +173,11 @@ for method_idx, registration_method in enumerate(registration_methods):
     print(f"  Number of iterations: {number_of_iterations}")
 
     # Create registrar for this method
-    registrar = RegisterTimeSeriesImages(registration_method=registration_method)
+    registrar = RegisterTimeSeriesImages(
+        registration_method=_build_registrar(registration_method, number_of_iterations)
+    )
     registrar.set_modality("ct")
     registrar.set_fixed_image(fixed_image)
-
-    # Set iterations based on registration method
-    if registration_method == "Greedy":
-        registrar.set_number_of_iterations_greedy(number_of_iterations)
-    elif registration_method == "ICON":
-        registrar.set_number_of_iterations_ICON(number_of_iterations)
-    elif registration_method == "Greedy_ICON":
-        registrar.set_number_of_iterations_greedy(number_of_iterations[0])
-        registrar.set_number_of_iterations_ICON(number_of_iterations[1])
 
     # Perform registration
     result = registrar.register_time_series(
@@ -192,8 +219,11 @@ for registration_method in registration_methods:
     forward_transforms = result["forward_transforms"]
     inverse_transforms = result["inverse_transforms"]
 
-    # Get the registrar used for this method
-    registrar = RegisterTimeSeriesImages(registration_method=registration_method)
+    # Get the registrar used for this method (iterations are irrelevant here -
+    # reconstruct_time_series() only applies already-computed transforms)
+    registrar = RegisterTimeSeriesImages(
+        registration_method=_build_registrar(registration_method)
+    )
     registrar.set_fixed_image(fixed_image)
 
     print(f"Saving {registration_method.upper()} results...")
@@ -281,8 +311,11 @@ for registration_method in registration_methods:
     result = all_results[registration_method]
     inverse_transforms = result["inverse_transforms"]
 
-    # Get the registrar used for this method
-    registrar = RegisterTimeSeriesImages(registration_method=registration_method)
+    # Get the registrar used for this method (iterations are irrelevant here -
+    # reconstruct_time_series() only applies already-computed transforms)
+    registrar = RegisterTimeSeriesImages(
+        registration_method=_build_registrar(registration_method)
+    )
     registrar.set_fixed_image(fixed_image)
 
     print(f"\n{registration_method.upper()}: Reconstructing with upsampling...")

--- a/src/physiomotion4d/__init__.py
+++ b/src/physiomotion4d/__init__.py
@@ -52,6 +52,8 @@ from .register_images_greedy import RegisterImagesGreedy
 
 # Registration classes
 from .register_images_base import RegisterImagesBase
+from .register_images_chain import RegisterImagesChain
+from .register_images_greedy_icon import RegisterImagesGreedyICON
 from .register_images_icon import RegisterImagesICON
 from .register_models_distance_maps import RegisterModelsDistanceMaps
 from .register_models_icp import RegisterModelsICP
@@ -63,6 +65,9 @@ from .register_time_series_images import RegisterTimeSeriesImages
 from .segment_anatomy_base import SegmentAnatomyBase
 from .segment_chest_total_segmentator import SegmentChestTotalSegmentator
 from .segment_heart_simpleware import SegmentHeartSimpleware
+from .segment_heart_simpleware_trimmed_branches import (
+    SegmentHeartSimplewareTrimmedBranches,
+)
 from .test_tools import TestTools
 from .transform_tools import TransformTools
 from .usd_anatomy_tools import USDAnatomyTools
@@ -92,11 +97,14 @@ __all__ = [
     "SegmentAnatomyBase",
     "SegmentChestTotalSegmentator",
     "SegmentHeartSimpleware",
+    "SegmentHeartSimplewareTrimmedBranches",
     # Registration classes
     "RegisterImagesBase",
     "RegisterImagesICON",
     "RegisterImagesANTS",
     "RegisterImagesGreedy",
+    "RegisterImagesChain",
+    "RegisterImagesGreedyICON",
     "RegisterTimeSeriesImages",
     "RegisterModelsPCA",
     "RegisterModelsICP",

--- a/src/physiomotion4d/cli/_method_factories.py
+++ b/src/physiomotion4d/cli/_method_factories.py
@@ -1,0 +1,75 @@
+"""Shared string-to-instance factories for CLI segmentation/registration flags.
+
+CLI scripts expose segmentation/registration backends as string choices for
+usability, then build the corresponding instance via these factories before
+passing it to the library's instance-based workflow API.
+"""
+
+from physiomotion4d import (
+    RegisterImagesBase,
+    RegisterImagesGreedy,
+    RegisterImagesGreedyICON,
+    RegisterImagesICON,
+    SegmentAnatomyBase,
+    SegmentChestTotalSegmentator,
+    SegmentHeartSimpleware,
+    SegmentHeartSimplewareTrimmedBranches,
+)
+
+#: Segmentation backend string choices exposed by CLI flags.
+SEGMENTATION_METHODS: tuple[str, ...] = (
+    "ChestTotalSegmentator",
+    "HeartSimpleware",
+    "HeartSimplewareTrimmedBranches",
+)
+
+#: Registration backend string choices exposed by CLI flags.
+REGISTRATION_METHODS: tuple[str, ...] = ("Greedy", "ICON", "Greedy_ICON")
+
+
+def build_segmentation_method(name: str) -> SegmentAnatomyBase:
+    """Build a SegmentAnatomyBase instance for a CLI --segmentation-method choice.
+
+    Args:
+        name: One of SEGMENTATION_METHODS.
+
+    Returns:
+        A new, unconfigured segmentation backend instance.
+
+    Raises:
+        ValueError: If name is not one of SEGMENTATION_METHODS.
+    """
+    if name == "ChestTotalSegmentator":
+        return SegmentChestTotalSegmentator()
+    if name == "HeartSimpleware":
+        return SegmentHeartSimpleware()
+    if name == "HeartSimplewareTrimmedBranches":
+        return SegmentHeartSimplewareTrimmedBranches()
+    raise ValueError(
+        f"Unknown segmentation method: {name}. "
+        f"Must be one of: {', '.join(SEGMENTATION_METHODS)}."
+    )
+
+
+def build_registration_method(name: str) -> RegisterImagesBase:
+    """Build a RegisterImagesBase instance for a CLI --registration-method choice.
+
+    Args:
+        name: One of REGISTRATION_METHODS.
+
+    Returns:
+        A new, unconfigured registration backend instance.
+
+    Raises:
+        ValueError: If name is not one of REGISTRATION_METHODS.
+    """
+    if name == "Greedy":
+        return RegisterImagesGreedy()
+    if name == "ICON":
+        return RegisterImagesICON()
+    if name == "Greedy_ICON":
+        return RegisterImagesGreedyICON()
+    raise ValueError(
+        f"Unknown registration method: {name}. "
+        f"Must be one of: {', '.join(REGISTRATION_METHODS)}."
+    )

--- a/src/physiomotion4d/cli/convert_image_to_usd.py
+++ b/src/physiomotion4d/cli/convert_image_to_usd.py
@@ -10,6 +10,10 @@ import argparse
 import os
 import sys
 
+from ._method_factories import build_registration_method, build_segmentation_method
+from ..register_images_greedy import RegisterImagesGreedy
+from ..register_images_icon import RegisterImagesICON
+
 
 def main() -> int:
     """Command-line interface for the Image-to-USD workflow."""
@@ -112,15 +116,37 @@ Examples:
     try:
         from .. import WorkflowConvertImageToUSD
 
+        segmentation_method = build_segmentation_method(args.segmentation_method)
+        if args.segmentation_method == "ChestTotalSegmentator":
+            segmentation_method.contrast_threshold = 500
+        registration_method = build_registration_method(args.registration_method)
+        if (
+            args.registration_iterations is not None
+            and args.registration_iterations > 0
+        ):
+            if isinstance(registration_method, RegisterImagesGreedy):
+                registration_method.set_number_of_iterations(
+                    [
+                        args.registration_iterations,
+                        args.registration_iterations // 2,
+                        0,
+                    ]
+                )
+            elif isinstance(registration_method, RegisterImagesICON):
+                registration_method.set_number_of_iterations(
+                    args.registration_iterations
+                )
+        if isinstance(registration_method, RegisterImagesICON):
+            registration_method.set_mass_preservation(not args.contrast)
+
         processor = WorkflowConvertImageToUSD(
             input_filenames=args.input_files,
             contrast_enhanced=args.contrast,
             output_directory=args.output_dir,
             project_name=args.project_name,
             reference_image_filename=args.reference_image,
-            number_of_registration_iterations=args.registration_iterations,
-            segmentation_method=args.segmentation_method,
-            registration_method=args.registration_method,
+            segmentation_method=segmentation_method,
+            registration_method=registration_method,
             times_per_second=args.times_per_second,
         )
     except Exception as e:

--- a/src/physiomotion4d/cli/convert_image_to_vtk.py
+++ b/src/physiomotion4d/cli/convert_image_to_vtk.py
@@ -10,6 +10,8 @@ import os
 import sys
 import traceback
 
+from ._method_factories import SEGMENTATION_METHODS, build_segmentation_method
+
 ANATOMY_GROUPS = (
     "heart",
     "lung",
@@ -18,12 +20,6 @@ ANATOMY_GROUPS = (
     "soft_tissue",
     "other",
     "contrast",
-)
-
-SEGMENTATION_METHODS = (
-    "ChestTotalSegmentator",
-    "HeartSimpleware",
-    "HeartSimplewareTrimmedBranches",
 )
 
 
@@ -163,7 +159,7 @@ Examples
         from .. import WorkflowConvertImageToVTK
 
         workflow = WorkflowConvertImageToVTK(
-            segmentation_method=args.segmentation_method,
+            segmentation_method=build_segmentation_method(args.segmentation_method),
         )
         result = workflow.run_workflow(
             input_image=input_image,

--- a/src/physiomotion4d/cli/reconstruct_highres_4d_ct.py
+++ b/src/physiomotion4d/cli/reconstruct_highres_4d_ct.py
@@ -283,10 +283,8 @@ Examples:
         greedy_iterations = args.Greedy_iterations or [30, 15, 7, 3]
         if args.ICON_iterations is None or args.ICON_iterations > 0:
             icon_iterations = args.ICON_iterations
-        elif args.ICON_iterations <= 0:
-            icon_iterations = None
         else:
-            icon_iterations = 20
+            icon_iterations = None
         if isinstance(registration_method, RegisterImagesGreedyICON):
             registration_method.greedy.set_number_of_iterations(greedy_iterations)
             registration_method.icon.set_number_of_iterations(icon_iterations)

--- a/src/physiomotion4d/cli/reconstruct_highres_4d_ct.py
+++ b/src/physiomotion4d/cli/reconstruct_highres_4d_ct.py
@@ -13,6 +13,11 @@ import os
 import sys
 import traceback
 
+from ._method_factories import build_registration_method
+from ..register_images_greedy import RegisterImagesGreedy
+from ..register_images_greedy_icon import RegisterImagesGreedyICON
+from ..register_images_icon import RegisterImagesICON
+
 
 def main() -> int:
     """Command-line interface for high-resolution 4D CT reconstruction."""
@@ -271,12 +276,25 @@ Examples:
     try:
         from .. import WorkflowReconstructHighres4DCT
 
+        registration_method = build_registration_method(args.registration_method)
+
+        # Set number of iterations based on registration method and CLI arguments
+        greedy_iterations = args.Greedy_iterations or [30, 15, 7, 3]
+        icon_iterations = args.ICON_iterations if args.ICON_iterations else 20
+        if isinstance(registration_method, RegisterImagesGreedyICON):
+            registration_method.greedy.set_number_of_iterations(greedy_iterations)
+            registration_method.icon.set_number_of_iterations(icon_iterations)
+        elif isinstance(registration_method, RegisterImagesGreedy):
+            registration_method.set_number_of_iterations(greedy_iterations)
+        elif isinstance(registration_method, RegisterImagesICON):
+            registration_method.set_number_of_iterations(icon_iterations)
+
         workflow = WorkflowReconstructHighres4DCT(
             time_series_images=time_series_images,
             fixed_image=fixed_image,
             reference_frame=args.reference_frame,
             register_reference=args.register_reference,
-            registration_method=args.registration_method,
+            registration_method=registration_method,
         )
 
         # Configure registration parameters
@@ -289,17 +307,6 @@ Examples:
 
         if moving_masks is not None:
             workflow.set_moving_masks(moving_masks)
-
-        # Set number of iterations based on registration method and CLI arguments
-        if args.Greedy_iterations:
-            workflow.set_number_of_iterations_Greedy(args.Greedy_iterations)
-        else:
-            workflow.set_number_of_iterations_Greedy([30, 15, 7, 3])
-
-        if args.icon_iterations:
-            workflow.set_number_of_iterations_ICON(args.icon_iterations)
-        else:
-            workflow.set_number_of_iterations_ICON(20)
 
     except (ValueError, RuntimeError, OSError) as e:
         print(f"Error initializing workflow: {e}")

--- a/src/physiomotion4d/cli/reconstruct_highres_4d_ct.py
+++ b/src/physiomotion4d/cli/reconstruct_highres_4d_ct.py
@@ -13,10 +13,10 @@ import os
 import sys
 import traceback
 
-from ._method_factories import build_registration_method
 from ..register_images_greedy import RegisterImagesGreedy
 from ..register_images_greedy_icon import RegisterImagesGreedyICON
 from ..register_images_icon import RegisterImagesICON
+from ._method_factories import build_registration_method
 
 
 def main() -> int:
@@ -119,7 +119,8 @@ Examples:
     parser.add_argument(
         "--ICON-iterations",
         type=int,
-        help="ICON fine-tuning iterations. Default: 20",
+        default=None,
+        help="ICON fine-tuning iterations. Default: None",
     )
 
     # Reconstruction options
@@ -280,7 +281,12 @@ Examples:
 
         # Set number of iterations based on registration method and CLI arguments
         greedy_iterations = args.Greedy_iterations or [30, 15, 7, 3]
-        icon_iterations = args.ICON_iterations if args.ICON_iterations else 20
+        if args.ICON_iterations is None or args.ICON_iterations > 0:
+            icon_iterations = args.ICON_iterations
+        elif args.ICON_iterations <= 0:
+            icon_iterations = None
+        else:
+            icon_iterations = 20
         if isinstance(registration_method, RegisterImagesGreedyICON):
             registration_method.greedy.set_number_of_iterations(greedy_iterations)
             registration_method.icon.set_number_of_iterations(icon_iterations)

--- a/src/physiomotion4d/image_tools.py
+++ b/src/physiomotion4d/image_tools.py
@@ -6,7 +6,7 @@ and performing image processing operations.
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Union, overload
 
 import itk
 import numpy as np
@@ -273,6 +273,28 @@ class ImageTools(PhysioMotion4DBase):
         result.DisconnectPipeline()
         return result
 
+    @overload
+    def flip_image(
+        self,
+        in_image: itk.Image,
+        in_mask: None = None,
+        flip_x: bool = False,
+        flip_y: bool = False,
+        flip_z: bool = False,
+        flip_and_make_identity: bool = False,
+    ) -> itk.Image: ...
+
+    @overload
+    def flip_image(
+        self,
+        in_image: itk.Image,
+        in_mask: itk.Image,
+        flip_x: bool = False,
+        flip_y: bool = False,
+        flip_z: bool = False,
+        flip_and_make_identity: bool = False,
+    ) -> tuple[itk.Image, itk.Image]: ...
+
     def flip_image(
         self,
         in_image: itk.Image,
@@ -281,7 +303,7 @@ class ImageTools(PhysioMotion4DBase):
         flip_y: bool = False,
         flip_z: bool = False,
         flip_and_make_identity: bool = False,
-    ) -> Any | tuple[Any, Any]:
+    ) -> Union[itk.Image, tuple[itk.Image, itk.Image]]:
         """
         Flip the image and mask.
 

--- a/src/physiomotion4d/register_images_base.py
+++ b/src/physiomotion4d/register_images_base.py
@@ -16,7 +16,7 @@ the register() method with their specific algorithm (e.g., Icon, ANTs, etc.).
 """
 
 import logging
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import itk
 
@@ -69,6 +69,11 @@ class RegisterImagesBase(PhysioMotion4DBase):
         >>> result = registrar.register(moving_image)
         >>> forward_tfm = result['forward_transform']  # warps moving image -> fixed grid
         >>> inverse_tfm = result['inverse_transform']  # warps fixed image -> moving grid
+
+    See :class:`RegisterImagesChain` to combine multiple registrars into a
+    multi-stage pipeline (e.g. a fast coarse registrar followed by a
+    refinement stage), and :class:`RegisterImagesGreedyICON` for the common
+    Greedy-then-ICON case.
     """
 
     def __init__(self, log_level: int | str = logging.INFO) -> None:
@@ -349,6 +354,75 @@ class RegisterImagesBase(PhysioMotion4DBase):
             "inverse_transform": self.inverse_transform,
             "loss": self.loss,
         }
+
+    def _delegate_to(
+        self,
+        other: "RegisterImagesBase",
+        moving_image: itk.Image,
+        moving_mask: Optional[itk.Image],
+        moving_labelmap: Optional[itk.Image],
+    ) -> None:
+        """Prepare ``other`` to run a standalone ``registration_method()`` call.
+
+        Uses direct attribute assignment for fixed_image/fixed_mask/
+        fixed_labelmap (not the public setters), since ``self.fixed_mask``
+        is already the dilated/converted mask produced by
+        :meth:`set_fixed_mask` -- calling it again on ``other`` would
+        re-dilate it. ``moving_mask`` is similarly already converted by the
+        outer :meth:`register` call and is passed through unchanged, since
+        mask conversion is backend-independent.
+
+        ``fixed_image_pre``/``moving_image_pre`` are deliberately NOT copied
+        from this instance: unlike mask conversion, intensity preprocessing
+        is backend-specific (e.g. ``RegisterImagesICON.preprocess()`` runs
+        uniGradICON preprocessing; ``RegisterImagesGreedy`` does not), so a
+        "pre" value this instance computed with its own (possibly no-op)
+        ``preprocess()`` cannot be trusted for ``other``. Instead, ``other``
+        computes its own ``fixed_image_pre`` via its own ``preprocess()``
+        (cached, matching :meth:`register`'s own caching), and
+        ``moving_image_pre`` is left unset so ``other.registration_method()``
+        preprocesses the moving image itself.
+
+        Args:
+            other: The registrar to prepare for a delegated call.
+            moving_image: Raw moving image for the delegated call.
+            moving_mask: Already-converted moving mask, or None.
+            moving_labelmap: Moving labelmap, or None.
+        """
+        other.modality = self.modality
+        other.mask_dilation_mm = self.mask_dilation_mm
+        other.fixed_image = self.fixed_image
+        if other.fixed_image_pre is None:
+            other.fixed_image_pre = other.preprocess(
+                other.fixed_image, modality=other.modality
+            )
+        other.fixed_mask = self.fixed_mask
+        other.fixed_labelmap = self.fixed_labelmap
+        other.moving_image = moving_image
+        other.moving_image_pre = None
+        other.moving_mask = moving_mask
+        other.moving_labelmap = moving_labelmap
+
+    def _capture_delegate_result(
+        self,
+        other: "RegisterImagesBase",
+        result: dict[str, Union[itk.Transform, float]],
+    ) -> None:
+        """Mirror a delegate's registration result back onto it as state.
+
+        Matches what :meth:`register` would have set had it been called on
+        ``other`` directly, so ``other.get_registered_image()`` still works
+        afterward.
+
+        Args:
+            other: The registrar whose ``registration_method()`` produced
+                ``result``.
+            result: The dict returned by ``other.registration_method(...)``.
+        """
+        other.forward_transform = cast(itk.Transform, result["forward_transform"])
+        other.inverse_transform = cast(itk.Transform, result["inverse_transform"])
+        other.loss = cast(float, result["loss"])
+        other.moving_image_registered = None
 
     def get_registered_image(self) -> itk.Image:
         """Get the registered image.

--- a/src/physiomotion4d/register_images_base.py
+++ b/src/physiomotion4d/register_images_base.py
@@ -391,7 +391,14 @@ class RegisterImagesBase(PhysioMotion4DBase):
         """
         other.modality = self.modality
         other.mask_dilation_mm = self.mask_dilation_mm
-        other.fixed_image = self.fixed_image
+        # Recompute other.fixed_image_pre whenever the fixed image changes.
+        # The identity check preserves per-frame caching (many moving frames
+        # against one fixed image reuse the same pre) while preventing a stale
+        # pre from a previous, different fixed image - which would silently
+        # register against the wrong reference - when ``other`` is reused.
+        if other.fixed_image is not self.fixed_image:
+            other.fixed_image = self.fixed_image
+            other.fixed_image_pre = None
         if other.fixed_image_pre is None:
             other.fixed_image_pre = other.preprocess(
                 other.fixed_image, modality=other.modality

--- a/src/physiomotion4d/register_images_chain.py
+++ b/src/physiomotion4d/register_images_chain.py
@@ -1,0 +1,111 @@
+"""Composite registration: run multiple registrars in sequence.
+
+This module provides the RegisterImagesChain class, which combines an
+ordered list of RegisterImagesBase instances into a single multi-stage
+registration pipeline.
+"""
+
+import logging
+from typing import Optional, Union
+
+import itk
+
+from .register_images_base import RegisterImagesBase
+
+
+class RegisterImagesChain(RegisterImagesBase):
+    """Run an ordered list of registrars in sequence, feeding each stage's
+    forward_transform as the next stage's initial_forward_transform.
+
+    Use this to combine independent registration backends into a multi-stage
+    pipeline (e.g. a fast coarse registrar followed by a refinement stage).
+    Every element of ``registrars`` must be a :class:`RegisterImagesBase`
+    instance. ``registrars`` (plural, a list) is distinct from the singular
+    ``registrar`` attribute used by classes like
+    :class:`RegisterTimeSeriesImages`.
+
+    See :class:`RegisterImagesGreedyICON` for a named 2-stage convenience
+    subclass (Greedy followed by ICON refinement).
+
+    Example:
+        >>> chain = RegisterImagesChain([RegisterImagesGreedy(), RegisterImagesICON()])
+        >>> chain.set_fixed_image(fixed_image)
+        >>> result = chain.register(moving_image)
+    """
+
+    def __init__(
+        self, registrars: list[RegisterImagesBase], log_level: int | str = logging.INFO
+    ) -> None:
+        """Initialize the registration chain.
+
+        Args:
+            registrars: Ordered, non-empty list of RegisterImagesBase
+                instances to run in sequence.
+            log_level: Logging level (default: logging.INFO)
+
+        Raises:
+            ValueError: If registrars is empty.
+            TypeError: If any element of registrars is not a
+                RegisterImagesBase instance.
+        """
+        super().__init__(log_level=log_level)
+
+        if not registrars:
+            raise ValueError("registrars must not be empty")
+        for registrar in registrars:
+            if not isinstance(registrar, RegisterImagesBase):
+                raise TypeError(
+                    "Every element of registrars must be a RegisterImagesBase "
+                    f"instance, got {type(registrar).__name__}"
+                )
+
+        self.registrars = registrars
+
+    def registration_method(
+        self,
+        moving_image: itk.Image,
+        moving_mask: Optional[itk.Image] = None,
+        moving_labelmap: Optional[itk.Image] = None,
+        moving_image_pre: Optional[itk.Image] = None,
+        initial_forward_transform: Optional[itk.Transform] = None,
+    ) -> dict[str, Union[itk.Transform, float]]:
+        """Run each registrar in ``self.registrars`` in order.
+
+        Each stage's ``forward_transform`` becomes the next stage's
+        ``initial_forward_transform``.
+
+        Note:
+            ``moving_image_pre`` is ignored: each stage may need different
+            intensity preprocessing (e.g. ICON's uniGradICON preprocessing
+            vs. Greedy's no-op), so every stage computes its own
+            preprocessing from the raw ``moving_image`` rather than reuse a
+            value computed for a different backend.
+
+        Args:
+            moving_image (itk.image): The 3D image to be registered
+            moving_mask (itk.image, optional): Binary mask for moving image ROI
+            moving_labelmap (itk.image, optional): Multi-label segmentation
+                for the moving image
+            moving_image_pre (itk.image, optional): Ignored - see Note above
+            initial_forward_transform (itk.Transform, optional): Initial
+                transformation from moving to fixed, used to initialize the
+                first stage
+
+        Returns:
+            dict: The last stage's result dict (see :meth:`RegisterImagesBase.register`)
+        """
+        current_initial = initial_forward_transform
+        result: dict[str, Union[itk.Transform, float]] = {}
+        for registrar in self.registrars:
+            self._delegate_to(registrar, moving_image, moving_mask, moving_labelmap)
+            result = registrar.registration_method(
+                moving_image,
+                moving_mask=moving_mask,
+                moving_labelmap=moving_labelmap,
+                moving_image_pre=None,
+                initial_forward_transform=current_initial,
+            )
+            self._capture_delegate_result(registrar, result)
+            current_initial = result["forward_transform"]
+
+        return result

--- a/src/physiomotion4d/register_images_chain.py
+++ b/src/physiomotion4d/register_images_chain.py
@@ -6,7 +6,7 @@ registration pipeline.
 """
 
 import logging
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 import itk
 
@@ -106,6 +106,6 @@ class RegisterImagesChain(RegisterImagesBase):
                 initial_forward_transform=current_initial,
             )
             self._capture_delegate_result(registrar, result)
-            current_initial = result["forward_transform"]
+            current_initial = cast(itk.Transform, result["forward_transform"])
 
         return result

--- a/src/physiomotion4d/register_images_greedy_icon.py
+++ b/src/physiomotion4d/register_images_greedy_icon.py
@@ -1,0 +1,54 @@
+"""Composite registration: Greedy followed by ICON refinement.
+
+This module provides the RegisterImagesGreedyICON class, a named
+RegisterImagesChain of RegisterImagesGreedy followed by RegisterImagesICON.
+"""
+
+import logging
+
+from .register_images_chain import RegisterImagesChain
+from .register_images_greedy import RegisterImagesGreedy
+from .register_images_icon import RegisterImagesICON
+
+
+class RegisterImagesGreedyICON(RegisterImagesChain):
+    """Greedy registration followed by ICON refinement, using Greedy's
+    forward_transform to initialize ICON.
+
+    Access the two stages by name via ``.greedy``/``.icon`` (e.g.
+    ``RegisterImagesGreedyICON().greedy.set_number_of_iterations([30, 15, 7, 3])``)
+    rather than positional ``registrars[0]``/``registrars[1]`` indexing.
+
+    Example:
+        >>> registrar = RegisterImagesGreedyICON()
+        >>> registrar.greedy.set_number_of_iterations([30, 15, 7, 3])
+        >>> registrar.icon.set_number_of_iterations(20)
+        >>> registrar.set_fixed_image(fixed_image)
+        >>> result = registrar.register(moving_image)
+    """
+
+    def __init__(self, log_level: int | str = logging.INFO) -> None:
+        """Initialize the Greedy-then-ICON registration chain.
+
+        Args:
+            log_level: Logging level (default: logging.INFO)
+        """
+        super().__init__(
+            [
+                RegisterImagesGreedy(log_level=log_level),
+                RegisterImagesICON(log_level=log_level),
+            ],
+            log_level=log_level,
+        )
+
+    @property
+    def greedy(self) -> RegisterImagesGreedy:
+        """The Greedy stage of this chain."""
+        assert isinstance(self.registrars[0], RegisterImagesGreedy)
+        return self.registrars[0]
+
+    @property
+    def icon(self) -> RegisterImagesICON:
+        """The ICON stage of this chain."""
+        assert isinstance(self.registrars[1], RegisterImagesICON)
+        return self.registrars[1]

--- a/src/physiomotion4d/register_time_series_images.py
+++ b/src/physiomotion4d/register_time_series_images.py
@@ -1,8 +1,10 @@
 """Time series image registration implementation.
 
-This module provides the RegisterTimeSeriesImages class for registering an ordered
-sequence of images (time series) to a fixed image. It supports Greedy, ICON, and
-combined Greedy initialization followed by ICON refinement.
+This module provides the RegisterTimeSeriesImages class for registering an
+ordered sequence of images (time series) to a fixed image using a
+caller-supplied RegisterImagesBase backend (e.g. RegisterImagesGreedy,
+RegisterImagesICON, or RegisterImagesGreedyICON for Greedy-then-ICON
+refinement).
 
 The class is particularly useful for 4D medical imaging applications such as cardiac
 CT where sequential frames need to be registered to a common frame.
@@ -15,24 +17,16 @@ import itk
 
 from .register_images_base import RegisterImagesBase
 from .register_images_greedy import RegisterImagesGreedy
-from .register_images_icon import RegisterImagesICON
 from .transform_tools import TransformTools
-
-REGISTRATION_METHODS: list[str] = [
-    "Greedy",
-    "ICON",
-    "Greedy_ICON",
-]
 
 
 class RegisterTimeSeriesImages(RegisterImagesBase):
     """Register a time series of images to a fixed image.
 
-    This class extends RegisterImagesBase to provide sequential registration of
-    multiple images (time series) to a fixed image. It supports Greedy, ICON, and
-    combined Greedy initialization followed by ICON refinement.
-    It can propagate information from prior registrations to initialize
-    subsequent ones.
+    This class extends RegisterImagesBase to provide sequential registration
+    of multiple images (time series) to a fixed image, using a
+    caller-supplied registration backend. It can propagate information from
+    prior registrations to initialize subsequent ones.
 
     The registration proceeds in two passes from a reference frame:
     1. Forward pass: from reference_frame to the end of the series
@@ -43,25 +37,22 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
     Key features:
     - Sequential registration of ordered image lists
-    - Support for Greedy, ICON, and Greedy+ICON backends
+    - Supports any RegisterImagesBase backend, including RegisterImagesChain
+      / RegisterImagesGreedyICON for multi-stage registration
     - Optional use of prior transforms to initialize next registration
     - Configurable starting point in the time series
     - Returns all transforms and loss values for the entire series
 
     Attributes:
-        registration_method_name (str): Registration method in use ('Greedy',
-            'ICON', or 'Greedy_ICON').
-        registrar_greedy (RegisterImagesGreedy): Internal Greedy registrar.
-        registrar_ICON (RegisterImagesICON): Internal ICON registrar (also used
-            as the refinement stage for 'Greedy_ICON').
+        registrar (RegisterImagesBase): The registration backend in use.
         transform_tools (TransformTools): Utility for transform operations.
 
     Example:
         >>> # Register a cardiac CT time series
-        >>> registrar = RegisterTimeSeriesImages(registration_method='Greedy')
+        >>> greedy = RegisterImagesGreedy()
+        >>> registrar = RegisterTimeSeriesImages(registration_method=greedy)
         >>> registrar.set_modality('ct')
         >>> registrar.set_fixed_image(fixed_image)
-        >>> registrar.set_number_of_iterations_greedy([40, 20, 10])
         >>>
         >>> # Register all time points to fixed image
         >>> result = registrar.register_time_series(
@@ -84,59 +75,34 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
     """
 
     def __init__(
-        self, registration_method: str = "Greedy", log_level: int | str = logging.INFO
+        self,
+        registration_method: Optional[RegisterImagesBase] = None,
+        log_level: int | str = logging.INFO,
     ) -> None:
         """Initialize the time series image registration class.
 
         Args:
-            registration_method (str): Registration method to use.
-                Options: 'Greedy', 'ICON', or 'Greedy_ICON'. Default: 'Greedy'
+            registration_method: Registration backend instance to use.
+                Defaults to a new RegisterImagesGreedy() when None.
             log_level: Logging level (default: logging.INFO)
 
         Raises:
-            ValueError: If registration_method is not supported.
+            TypeError: If registration_method is neither None nor a
+                RegisterImagesBase instance.
         """
         super().__init__(log_level=log_level)
 
-        self.registration_method_name: str = registration_method
-
-        self.registrar_greedy = RegisterImagesGreedy(log_level=log_level)
-        self.registrar_ICON = RegisterImagesICON(log_level=log_level)
-
-        # Set default iterations based on registration method
-        self.number_of_iterations_greedy: list[int] = [40, 20, 10]
-        self.number_of_iterations_ICON: Optional[int] = 50
-
-        if self.registration_method_name not in REGISTRATION_METHODS:
-            raise ValueError(
-                "registration_method must be one of "
-                f"{REGISTRATION_METHODS}, got '{registration_method}'"
+        if registration_method is None:
+            registration_method = RegisterImagesGreedy(log_level=log_level)
+        elif not isinstance(registration_method, RegisterImagesBase):
+            raise TypeError(
+                "registration_method must be a RegisterImagesBase instance or None"
             )
+        self.registrar: RegisterImagesBase = registration_method
 
         self.transform_tools: TransformTools = TransformTools()
 
         self.smooth_prior_transform_sigma: float = 0.5
-
-    def set_number_of_iterations_ICON(
-        self, number_of_iterations_ICON: Optional[int]
-    ) -> None:
-        """Set the number of iterations for ICON registration.
-
-        Args:
-            number_of_iterations_ICON: Number of fine-tuning steps for ICON
-        """
-        self.number_of_iterations_ICON = number_of_iterations_ICON
-
-    def set_number_of_iterations_greedy(
-        self, number_of_iterations_greedy: list[int]
-    ) -> None:
-        """Set the number of iterations for Greedy registration.
-
-        Args:
-            number_of_iterations_greedy: List of iterations per Greedy
-                resolution level, for example ``[40, 20, 10]``.
-        """
-        self.number_of_iterations_greedy = number_of_iterations_greedy
 
     def set_smooth_prior_transform_sigma(
         self, smooth_prior_transform_sigma: float
@@ -265,12 +231,11 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             calling this method.
 
         Example:
-            >>> registrar = RegisterTimeSeriesImages(registration_method='Greedy')
+            >>> greedy = RegisterImagesGreedy()
+            >>> registrar = RegisterTimeSeriesImages(registration_method=greedy)
             >>> registrar.set_fixed_image(fixed_image)
             >>> registrar.set_fixed_mask(fixed_mask)  # Optional
-            >>> registrar.set_number_of_iterations_greedy([30, 15, 5])
             >>>
-            >>> # Use new intuitive parameter names
             >>> result = registrar.register_time_series(
             ...     moving_images=image_list,
             ...     moving_masks=mask_list,  # Optional
@@ -292,22 +257,11 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         if self.fixed_image is None:
             raise ValueError("Fixed image must be set before registering time series")
 
-        if self.registration_method_name in ["Greedy", "Greedy_ICON"]:
-            self.registrar_greedy.set_fixed_image(self.fixed_image)
-            self.registrar_greedy.set_modality(self.modality)
-            self.registrar_greedy.set_mask_dilation(self.mask_dilation_mm)
-            self.registrar_greedy.set_number_of_iterations(
-                self.number_of_iterations_greedy
-            )
-            self.registrar_greedy.set_fixed_mask(self.fixed_mask)
-            self.registrar_greedy.set_fixed_labelmap(self.fixed_labelmap)
-        if self.registration_method_name in ["ICON", "Greedy_ICON"]:
-            self.registrar_ICON.set_fixed_image(self.fixed_image)
-            self.registrar_ICON.set_modality(self.modality)
-            self.registrar_ICON.set_mask_dilation(self.mask_dilation_mm)
-            self.registrar_ICON.set_number_of_iterations(self.number_of_iterations_ICON)
-            self.registrar_ICON.set_fixed_mask(self.fixed_mask)
-            self.registrar_ICON.set_fixed_labelmap(self.fixed_labelmap)
+        self.registrar.set_fixed_image(self.fixed_image)
+        self.registrar.set_modality(self.modality)
+        self.registrar.set_mask_dilation(self.mask_dilation_mm)
+        self.registrar.set_fixed_mask(self.fixed_mask)
+        self.registrar.set_fixed_labelmap(self.fixed_labelmap)
 
         num_images = len(moving_images)
 
@@ -354,35 +308,11 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 if moving_labelmaps is not None
                 else None
             )
-            if self.registration_method_name == "Greedy":
-                result = self.registrar_greedy.register(
-                    moving_images[reference_frame],
-                    moving_mask=reference_mask,
-                    moving_labelmap=reference_labelmap,
-                )
-            elif self.registration_method_name == "ICON":
-                result = self.registrar_ICON.register(
-                    moving_images[reference_frame],
-                    moving_mask=reference_mask,
-                    moving_labelmap=reference_labelmap,
-                )
-            elif self.registration_method_name == "Greedy_ICON":
-                result = self.registrar_greedy.register(
-                    moving_images[reference_frame],
-                    moving_mask=reference_mask,
-                    moving_labelmap=reference_labelmap,
-                )
-                forward_initial = result["forward_transform"]
-                result = self.registrar_ICON.register(
-                    moving_images[reference_frame],
-                    moving_mask=reference_mask,
-                    moving_labelmap=reference_labelmap,
-                    initial_forward_transform=forward_initial,
-                )
-            else:
-                raise ValueError(
-                    f"Invalid registration method: {self.registration_method_name}"
-                )
+            result = self.registrar.register(
+                moving_images[reference_frame],
+                moving_mask=reference_mask,
+                moving_labelmap=reference_labelmap,
+            )
             forward_transform = result["forward_transform"]
             inverse_transform = result["inverse_transform"]
             loss = result["loss"]
@@ -429,35 +359,11 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 )
 
                 # Try registration with identity initialization
-                if self.registration_method_name == "Greedy":
-                    result_init_identity = self.registrar_greedy.register(
-                        moving_image=moving_image,
-                        moving_mask=moving_mask,
-                        moving_labelmap=moving_labelmap,
-                    )
-                elif self.registration_method_name == "ICON":
-                    result_init_identity = self.registrar_ICON.register(
-                        moving_image=moving_image,
-                        moving_mask=moving_mask,
-                        moving_labelmap=moving_labelmap,
-                    )
-                elif self.registration_method_name == "Greedy_ICON":
-                    result_init_identity = self.registrar_greedy.register(
-                        moving_image=moving_image,
-                        moving_mask=moving_mask,
-                        moving_labelmap=moving_labelmap,
-                    )
-                    forward_initial = result_init_identity["forward_transform"]
-                    result_init_identity = self.registrar_ICON.register(
-                        moving_image=moving_image,
-                        moving_mask=moving_mask,
-                        moving_labelmap=moving_labelmap,
-                        initial_forward_transform=forward_initial,
-                    )
-                else:
-                    raise ValueError(
-                        f"Invalid registration method: {self.registration_method_name}"
-                    )
+                result_init_identity = self.registrar.register(
+                    moving_image=moving_image,
+                    moving_mask=moving_mask,
+                    moving_labelmap=moving_labelmap,
+                )
                 forward_init_identity = result_init_identity["forward_transform"]
                 inverse_init_identity = result_init_identity["inverse_transform"]
                 loss_init_identity = result_init_identity["loss"]
@@ -465,38 +371,12 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 # Select best result based on prior usage
                 if prior_weight > 0.0:
                     # Try with prior transform initialization
-                    if self.registration_method_name == "Greedy":
-                        result_init_prior = self.registrar_greedy.register(
-                            moving_image=moving_image,
-                            moving_mask=moving_mask,
-                            moving_labelmap=moving_labelmap,
-                            initial_forward_transform=prior_forward,
-                        )
-                    elif self.registration_method_name == "ICON":
-                        result_init_prior = self.registrar_ICON.register(
-                            moving_image=moving_image,
-                            moving_mask=moving_mask,
-                            moving_labelmap=moving_labelmap,
-                            initial_forward_transform=prior_forward,
-                        )
-                    elif self.registration_method_name == "Greedy_ICON":
-                        result_init_prior = self.registrar_greedy.register(
-                            moving_image=moving_image,
-                            moving_mask=moving_mask,
-                            moving_labelmap=moving_labelmap,
-                            initial_forward_transform=prior_forward,
-                        )
-                        forward_initial = result_init_prior["forward_transform"]
-                        result_init_prior = self.registrar_ICON.register(
-                            moving_image=moving_image,
-                            moving_mask=moving_mask,
-                            moving_labelmap=moving_labelmap,
-                            initial_forward_transform=forward_initial,
-                        )
-                    else:
-                        raise ValueError(
-                            f"Invalid registration method: {self.registration_method_name}"
-                        )
+                    result_init_prior = self.registrar.register(
+                        moving_image=moving_image,
+                        moving_mask=moving_mask,
+                        moving_labelmap=moving_labelmap,
+                        initial_forward_transform=prior_forward,
+                    )
                     forward_init_prior = result_init_prior["forward_transform"]
                     inverse_init_prior = result_init_prior["inverse_transform"]
                     loss_init_prior = result_init_prior["loss"]
@@ -577,7 +457,8 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             ValueError: If lengths of moving_images and inverse_transforms don't match
 
         Example:
-            >>> registrar = RegisterTimeSeriesImages(registration_method='Greedy')
+            >>> greedy = RegisterImagesGreedy()
+            >>> registrar = RegisterTimeSeriesImages(registration_method=greedy)
             >>> registrar.set_fixed_image(fixed_image)
             >>>
             >>> result = registrar.register_time_series(
@@ -687,65 +568,32 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
     ) -> dict[str, Union[itk.Transform, float]]:
         """Registration method required by RegisterImagesBase.
 
-        This method is not typically called directly. Use register_time_series()
-        instead for time series registration.
+        Delegates to the configured ``registrar``. This method is not
+        typically called directly; use register_time_series() instead for
+        time series registration.
 
         Args:
             moving_image (itk.Image): Image to register
             moving_mask (itk.Image, optional): Binary mask
-            moving_image_pre (itk.Image, optional): Preprocessed image
+            moving_labelmap (itk.Image, optional): Multi-label segmentation
+            moving_image_pre (itk.Image, optional): Ignored - the registrar
+                computes its own preprocessing from the raw moving_image
             initial_forward_transform (itk.Transform, optional): Initial transform
 
         Returns:
             dict: Registration result with forward_transform, inverse_transform, and loss
         """
-        if self.registration_method_name == "Greedy":
-            res = self.registrar_greedy.registration_method(
-                moving_image=moving_image,
-                moving_mask=moving_mask,
-                moving_labelmap=moving_labelmap,
-                moving_image_pre=moving_image_pre,
-                initial_forward_transform=initial_forward_transform,
-            )
-            return {
-                "forward_transform": cast(itk.Transform, res["forward_transform"]),
-                "inverse_transform": cast(itk.Transform, res["inverse_transform"]),
-                "loss": float(cast(float, res["loss"])),
-            }
-        if self.registration_method_name == "ICON":
-            res = self.registrar_ICON.registration_method(
-                moving_image=moving_image,
-                moving_mask=moving_mask,
-                moving_labelmap=moving_labelmap,
-                moving_image_pre=moving_image_pre,
-                initial_forward_transform=initial_forward_transform,
-            )
-            return {
-                "forward_transform": cast(itk.Transform, res["forward_transform"]),
-                "inverse_transform": cast(itk.Transform, res["inverse_transform"]),
-                "loss": float(cast(float, res["loss"])),
-            }
-        if self.registration_method_name == "Greedy_ICON":
-            initial_res = self.registrar_greedy.registration_method(
-                moving_image=moving_image,
-                moving_mask=moving_mask,
-                moving_labelmap=moving_labelmap,
-                moving_image_pre=moving_image_pre,
-                initial_forward_transform=initial_forward_transform,
-            )
-            forward_initial = initial_res["forward_transform"]
-            icon_res = self.registrar_ICON.registration_method(
-                moving_image=moving_image,
-                moving_mask=moving_mask,
-                moving_labelmap=moving_labelmap,
-                moving_image_pre=moving_image_pre,
-                initial_forward_transform=forward_initial,
-            )
-            return {
-                "forward_transform": cast(itk.Transform, icon_res["forward_transform"]),
-                "inverse_transform": cast(itk.Transform, icon_res["inverse_transform"]),
-                "loss": float(cast(float, icon_res["loss"])),
-            }
-        raise ValueError(
-            f"Invalid registration method: {self.registration_method_name}"
+        self._delegate_to(self.registrar, moving_image, moving_mask, moving_labelmap)
+        result = self.registrar.registration_method(
+            moving_image=moving_image,
+            moving_mask=moving_mask,
+            moving_labelmap=moving_labelmap,
+            moving_image_pre=None,
+            initial_forward_transform=initial_forward_transform,
         )
+        self._capture_delegate_result(self.registrar, result)
+        return {
+            "forward_transform": cast(itk.Transform, result["forward_transform"]),
+            "inverse_transform": cast(itk.Transform, result["inverse_transform"]),
+            "loss": float(cast(float, result["loss"])),
+        }

--- a/src/physiomotion4d/segment_heart_simpleware.py
+++ b/src/physiomotion4d/segment_heart_simpleware.py
@@ -53,6 +53,9 @@ class SegmentHeartSimpleware(SegmentAnatomyBase):
         >>> result = segmenter.segment(ct_image, contrast_enhanced_study=True)
         >>> labelmap = result['labelmap']
         >>> heart_mask = result['heart']
+
+    See :class:`SegmentHeartSimplewareTrimmedBranches` for a variant that
+    additionally clips pulmonary/great-vessel branches to the cardiac region.
     """
 
     def __init__(self, log_level: int | str = logging.INFO):
@@ -101,8 +104,6 @@ class SegmentHeartSimpleware(SegmentAnatomyBase):
             for label_id, organ_name in organs.items():
                 self.taxonomy.add_organ(group_name, label_id, organ_name)
 
-        self._trim_branches = False
-
         self._finalize_other_group()
 
         # Path to Simpleware Medical console executable
@@ -114,21 +115,6 @@ class SegmentHeartSimpleware(SegmentAnatomyBase):
             "simpleware_medical",
             "SimplewareScript_heart_segmentation.py",
         )
-
-    def set_trim_branches(self, trim_branches: bool) -> None:
-        """Enable trimming of pulmonary and great-vessel branches.
-
-        When enabled, :meth:`trim_branches` is applied to the labelmap after
-        Simpleware segmentation, clipping the pulmonary veins and major great
-        vessels back to the cardiac region.  Trimming reduces inter-subject
-        variability in vessel extent, which simplifies AI-Ready and Sim-Ready
-        model fitting.  It is consistent with how vessels were trimmed in the
-        example KCL Heart dataset.
-
-        Args:
-            trim_branches (bool): Whether to trim branches to the cardiac region.
-        """
-        self._trim_branches = trim_branches
 
     def set_simpleware_executable_path(self, path: str) -> None:
         """Set the path to the Simpleware Medical console executable.
@@ -384,153 +370,8 @@ class SegmentHeartSimpleware(SegmentAnatomyBase):
             labelmap_image = itk.GetImageFromArray(labelmap_array.astype(np.uint8))
             labelmap_image.CopyInformation(preprocessed_image)
 
-            if self._trim_branches:
-                labelmap_image = self.trim_branches(labelmap_image)
-
         return labelmap_image
 
     def get_landmarks(self) -> dict[str, tuple[float, float, float]]:
         """Get the landmarks."""
         return self.landmarks
-
-    def trim_branches(self, labelmap_image: itk.image) -> itk.image:
-        """Trim pulmonary and great-vessel branches back to the cardiac region.
-
-        Clips pulmonary veins and the great vessels (aorta, pulmonary artery)
-        to the portions adjacent to the heart and keeps only the largest
-        connected component of the left and right atria.  Reduces inter-subject
-        variability in vessel extent, simplifying AI-Ready and Sim-Ready model
-        fitting.  Consistent with how vessels were trimmed in the example KCL
-        Heart dataset.
-        """
-
-        # Reference code for cropping aorta and pulmonary artery to
-        #    portions adjacent to the heart.
-        # Trim z-axis
-        # z = labelmap_array.shape[2] - 1
-        # z_classes = np.unique(labelmap_array[z, :, :])
-        # heart_count = np.sum((c in [1, 2, 3, 4, 5]) for c in z_classes)
-        # while heart_count < 3 and z > 0:
-        #     z -= 1
-        #     z_classes = np.unique(labelmap_array[z, :, :])
-        #     heart_count = np.sum((c in [1, 2, 3, 4, 5]) for c in z_classes)
-        # if z < labelmap_array.shape[2] - 3:
-        # labelmap_array[(z + 3) :, :, :] = 0
-
-        # In labelmap,
-        #  if pixel is in keep_mask, was left or right atrium, then keep as
-        #     left or right atrium
-
-        #  1) Erase Heart and Myo label
-        labelmap_arr = itk.array_from_image(labelmap_image)
-
-        heart_arr = itk.array_from_image(labelmap_image)
-        heart_arr[heart_arr == 6] = 0
-        heart_arr[heart_arr == 5] = 0
-
-        img = itk.image_from_array(heart_arr)
-        img.CopyInformation(labelmap_image)
-        imMath = tube.ImageMath.New(img)
-
-        #  2) Erode then Dilate Left Atrium label to clip vessels
-        spacing = labelmap_image.GetSpacing()
-        imMath.Erode(round(7 / spacing[0]), 3, 0)
-        imMath.Dilate(round(7 / spacing[0]), 3, 0)
-
-        #  3) Erode then Dilate Right Atrium label to clip vessels
-        imMath.Erode(round(7 / spacing[0]), 4, 0)
-        imMath.Dilate(round(7 / spacing[0]), 4, 0)
-        simple_img = imMath.GetOutput()
-        simple_arr = itk.array_from_image(simple_img)
-
-        #  Keep the largest component of the left atrium
-        simple_arr_3 = simple_arr.copy()
-        simple_arr_3[simple_arr_3 != 3] = 0
-        simple_arr_3[simple_arr_3 == 3] = 1
-        simple_img_3 = itk.image_from_array(simple_arr_3)
-        connComp = tube.SegmentConnectedComponents.New(simple_img_3)
-        connComp.SetKeepOnlyLargestComponent(True)
-        connComp.Update()
-        mask_img_3 = connComp.GetOutput()
-        mask_arr_3 = itk.array_from_image(mask_img_3)
-        simple_arr_3[mask_arr_3 == 0] = 0
-
-        #  Keep the largest component of the right atrium
-        simple_arr_4 = simple_arr.copy()
-        simple_arr_4[simple_arr_4 != 4] = 0
-        simple_arr_4[simple_arr_4 == 4] = 1
-        simple_img_4 = itk.image_from_array(simple_arr_4)
-        connComp = tube.SegmentConnectedComponents.New(simple_img_4)
-        connComp.SetKeepOnlyLargestComponent(True)
-        connComp.Update()
-        mask_img_4 = connComp.GetOutput()
-        mask_arr_4 = itk.array_from_image(mask_img_4)
-        simple_arr_4[mask_arr_4 == 0] = 0
-
-        #  Replace the left and right atrium labels with the largest components
-        simple_arr[simple_arr == 3] = 0
-        simple_arr[simple_arr == 4] = 0
-        simple_arr[simple_arr_3 > 0] = 3
-        simple_arr[simple_arr_4 > 0] = 4
-        simple_img = itk.image_from_array(simple_arr)
-        simple_img.CopyInformation(labelmap_image)
-
-        #  4) Dilate all others = keep_mask
-        keep_mask_arr = heart_arr.copy()
-        keep_mask_arr[keep_mask_arr == 2] = 1
-        keep_mask_arr[keep_mask_arr == 5] = 1
-        keep_mask_arr[keep_mask_arr != 1] = 0
-        keep_mask = itk.image_from_array(keep_mask_arr)
-        keep_mask.CopyInformation(labelmap_image)
-        imMath.SetInput(keep_mask)
-        imMath.Dilate(round(7 / spacing[0]), 1, 0)
-        keep_mask = imMath.GetOutput()
-        keep_mask_arr = itk.array_from_image(keep_mask)
-
-        #  Add the left and right atrium labels to the keep_mask
-        heart_arr = heart_arr * keep_mask_arr
-        heart_arr[simple_arr == 3] = 3
-        heart_arr[simple_arr == 4] = 4
-        heart_img = itk.image_from_array(heart_arr)
-        heart_img.CopyInformation(labelmap_image)
-
-        #  Dilate the keep_mask to simulate 3mm (heart)
-        keep_mask_arr = heart_arr.copy()
-        keep_mask_arr[keep_mask_arr == 1] = 0
-        keep_mask_arr[keep_mask_arr > 0] = 1
-        keep_mask = itk.image_from_array(keep_mask_arr)
-        keep_mask.CopyInformation(labelmap_image)
-        imMath.SetInput(keep_mask)
-        imMath.Dilate(round(5 / spacing[0]), 1, 0)
-        imMath.Erode(round(2 / spacing[0]), 1, 0)
-        heart_mask = imMath.GetOutput()
-
-        #  Insert the heart and myo labels back into the labelmap
-        heart_mask_arr = itk.array_from_image(heart_mask)
-        heart_mask_arr[heart_arr > 0] = 0
-        heart_arr[heart_mask_arr > 0] = 6
-        heart_arr_myo = itk.array_from_image(labelmap_image)
-        heart_arr[heart_arr_myo == 5] = 5
-        heart_arr[heart_arr_myo == 1] = 1
-        heart_img = itk.image_from_array(heart_arr)
-        heart_img.CopyInformation(labelmap_image)
-
-        #  Add in missing pieces / gaps of the myocardium
-        lv_arr = heart_arr.copy()
-        lv_arr[lv_arr != 1] = 0
-        lv_img = itk.image_from_array(lv_arr)
-        lv_img.CopyInformation(labelmap_image)
-        imMath.SetInput(lv_img)
-        imMath.Dilate(round(2 / spacing[0]), 1, 0)
-        lv_img = imMath.GetOutput()
-        lv_arr = itk.array_from_image(lv_img)
-        lv_arr = lv_arr * 5  # Myocardium label is 5
-
-        #  Add the gap-filled myocardium back into the labelmap
-        heart_arr = np.where(heart_arr == 0, lv_arr, heart_arr)
-        # Eliminate overlap with other labels
-        heart_arr = np.where(labelmap_arr > 6, 0, heart_arr)
-        heart_img = itk.image_from_array(heart_arr)
-        heart_img.CopyInformation(labelmap_image)
-
-        return heart_img

--- a/src/physiomotion4d/segment_heart_simpleware_trimmed_branches.py
+++ b/src/physiomotion4d/segment_heart_simpleware_trimmed_branches.py
@@ -1,0 +1,193 @@
+"""Module for heart segmentation with pulmonary/great-vessel branches trimmed.
+
+This module provides the SegmentHeartSimplewareTrimmedBranches class, a
+specialization of SegmentHeartSimpleware that clips vessel branches back to
+the cardiac region after Simpleware segmentation.
+"""
+
+import logging
+
+import itk
+import numpy as np
+from itk import TubeTK as tube
+
+from .segment_heart_simpleware import SegmentHeartSimpleware
+
+
+class SegmentHeartSimplewareTrimmedBranches(SegmentHeartSimpleware):
+    """SegmentHeartSimpleware with pulmonary/great-vessel branches trimmed
+    to the cardiac region (matches KCL-Heart-Model template extent).
+
+    Example:
+        >>> segmenter = SegmentHeartSimplewareTrimmedBranches()
+        >>> result = segmenter.segment(ct_image, contrast_enhanced_study=True)
+        >>> labelmap = result['labelmap']
+    """
+
+    def __init__(self, log_level: int | str = logging.INFO):
+        """Initialize the trimmed-branches heart segmentation.
+
+        Args:
+            log_level: Logging level (default: logging.INFO)
+        """
+        super().__init__(log_level=log_level)
+
+    def segmentation_method(self, preprocessed_image: itk.image) -> itk.image:
+        """Run Simpleware ASCardio segmentation, then trim vessel branches.
+
+        Args:
+            preprocessed_image (itk.image): The preprocessed CT image
+
+        Returns:
+            itk.image: The segmentation labelmap with branches trimmed
+        """
+        labelmap_image = super().segmentation_method(preprocessed_image)
+        return self.trim_branches(labelmap_image)
+
+    def trim_branches(self, labelmap_image: itk.image) -> itk.image:
+        """Trim pulmonary and great-vessel branches back to the cardiac region.
+
+        Clips pulmonary veins and the great vessels (aorta, pulmonary artery)
+        to the portions adjacent to the heart and keeps only the largest
+        connected component of the left and right atria.  Reduces inter-subject
+        variability in vessel extent, simplifying AI-Ready and Sim-Ready model
+        fitting.  Consistent with how vessels were trimmed in the example KCL
+        Heart dataset.
+
+        Depends on the specific label IDs assigned in
+        :meth:`SegmentHeartSimpleware.__init__` (1=left_ventricle,
+        2=right_ventricle, 3=left_atrium, 4=right_atrium, 5=myocardium,
+        6=heart) - a future change to that label scheme must keep this
+        method in sync.
+        """
+
+        # Reference code for cropping aorta and pulmonary artery to
+        #    portions adjacent to the heart.
+        # Trim z-axis
+        # z = labelmap_array.shape[2] - 1
+        # z_classes = np.unique(labelmap_array[z, :, :])
+        # heart_count = np.sum((c in [1, 2, 3, 4, 5]) for c in z_classes)
+        # while heart_count < 3 and z > 0:
+        #     z -= 1
+        #     z_classes = np.unique(labelmap_array[z, :, :])
+        #     heart_count = np.sum((c in [1, 2, 3, 4, 5]) for c in z_classes)
+        # if z < labelmap_array.shape[2] - 3:
+        # labelmap_array[(z + 3) :, :, :] = 0
+
+        # In labelmap,
+        #  if pixel is in keep_mask, was left or right atrium, then keep as
+        #     left or right atrium
+
+        #  1) Erase Heart and Myo label
+        labelmap_arr = itk.array_from_image(labelmap_image)
+
+        heart_arr = itk.array_from_image(labelmap_image)
+        heart_arr[heart_arr == 6] = 0
+        heart_arr[heart_arr == 5] = 0
+
+        img = itk.image_from_array(heart_arr)
+        img.CopyInformation(labelmap_image)
+        imMath = tube.ImageMath.New(img)
+
+        #  2) Erode then Dilate Left Atrium label to clip vessels
+        spacing = labelmap_image.GetSpacing()
+        imMath.Erode(round(7 / spacing[0]), 3, 0)
+        imMath.Dilate(round(7 / spacing[0]), 3, 0)
+
+        #  3) Erode then Dilate Right Atrium label to clip vessels
+        imMath.Erode(round(7 / spacing[0]), 4, 0)
+        imMath.Dilate(round(7 / spacing[0]), 4, 0)
+        simple_img = imMath.GetOutput()
+        simple_arr = itk.array_from_image(simple_img)
+
+        #  Keep the largest component of the left atrium
+        simple_arr_3 = simple_arr.copy()
+        simple_arr_3[simple_arr_3 != 3] = 0
+        simple_arr_3[simple_arr_3 == 3] = 1
+        simple_img_3 = itk.image_from_array(simple_arr_3)
+        connComp = tube.SegmentConnectedComponents.New(simple_img_3)
+        connComp.SetKeepOnlyLargestComponent(True)
+        connComp.Update()
+        mask_img_3 = connComp.GetOutput()
+        mask_arr_3 = itk.array_from_image(mask_img_3)
+        simple_arr_3[mask_arr_3 == 0] = 0
+
+        #  Keep the largest component of the right atrium
+        simple_arr_4 = simple_arr.copy()
+        simple_arr_4[simple_arr_4 != 4] = 0
+        simple_arr_4[simple_arr_4 == 4] = 1
+        simple_img_4 = itk.image_from_array(simple_arr_4)
+        connComp = tube.SegmentConnectedComponents.New(simple_img_4)
+        connComp.SetKeepOnlyLargestComponent(True)
+        connComp.Update()
+        mask_img_4 = connComp.GetOutput()
+        mask_arr_4 = itk.array_from_image(mask_img_4)
+        simple_arr_4[mask_arr_4 == 0] = 0
+
+        #  Replace the left and right atrium labels with the largest components
+        simple_arr[simple_arr == 3] = 0
+        simple_arr[simple_arr == 4] = 0
+        simple_arr[simple_arr_3 > 0] = 3
+        simple_arr[simple_arr_4 > 0] = 4
+        simple_img = itk.image_from_array(simple_arr)
+        simple_img.CopyInformation(labelmap_image)
+
+        #  4) Dilate all others = keep_mask
+        keep_mask_arr = heart_arr.copy()
+        keep_mask_arr[keep_mask_arr == 2] = 1
+        keep_mask_arr[keep_mask_arr == 5] = 1
+        keep_mask_arr[keep_mask_arr != 1] = 0
+        keep_mask = itk.image_from_array(keep_mask_arr)
+        keep_mask.CopyInformation(labelmap_image)
+        imMath.SetInput(keep_mask)
+        imMath.Dilate(round(7 / spacing[0]), 1, 0)
+        keep_mask = imMath.GetOutput()
+        keep_mask_arr = itk.array_from_image(keep_mask)
+
+        #  Add the left and right atrium labels to the keep_mask
+        heart_arr = heart_arr * keep_mask_arr
+        heart_arr[simple_arr == 3] = 3
+        heart_arr[simple_arr == 4] = 4
+        heart_img = itk.image_from_array(heart_arr)
+        heart_img.CopyInformation(labelmap_image)
+
+        #  Dilate the keep_mask to simulate 3mm (heart)
+        keep_mask_arr = heart_arr.copy()
+        keep_mask_arr[keep_mask_arr == 1] = 0
+        keep_mask_arr[keep_mask_arr > 0] = 1
+        keep_mask = itk.image_from_array(keep_mask_arr)
+        keep_mask.CopyInformation(labelmap_image)
+        imMath.SetInput(keep_mask)
+        imMath.Dilate(round(5 / spacing[0]), 1, 0)
+        imMath.Erode(round(2 / spacing[0]), 1, 0)
+        heart_mask = imMath.GetOutput()
+
+        #  Insert the heart and myo labels back into the labelmap
+        heart_mask_arr = itk.array_from_image(heart_mask)
+        heart_mask_arr[heart_arr > 0] = 0
+        heart_arr[heart_mask_arr > 0] = 6
+        heart_arr_myo = itk.array_from_image(labelmap_image)
+        heart_arr[heart_arr_myo == 5] = 5
+        heart_arr[heart_arr_myo == 1] = 1
+        heart_img = itk.image_from_array(heart_arr)
+        heart_img.CopyInformation(labelmap_image)
+
+        #  Add in missing pieces / gaps of the myocardium
+        lv_arr = heart_arr.copy()
+        lv_arr[lv_arr != 1] = 0
+        lv_img = itk.image_from_array(lv_arr)
+        lv_img.CopyInformation(labelmap_image)
+        imMath.SetInput(lv_img)
+        imMath.Dilate(round(2 / spacing[0]), 1, 0)
+        lv_img = imMath.GetOutput()
+        lv_arr = itk.array_from_image(lv_img)
+        lv_arr = lv_arr * 5  # Myocardium label is 5
+
+        #  Add the gap-filled myocardium back into the labelmap
+        heart_arr = np.where(heart_arr == 0, lv_arr, heart_arr)
+        # Eliminate overlap with other labels
+        heart_arr = np.where(labelmap_arr > 6, 0, heart_arr)
+        heart_img = itk.image_from_array(heart_arr)
+        heart_img.CopyInformation(labelmap_image)
+
+        return heart_img

--- a/src/physiomotion4d/segment_heart_simpleware_trimmed_branches.py
+++ b/src/physiomotion4d/segment_heart_simpleware_trimmed_branches.py
@@ -24,7 +24,7 @@ class SegmentHeartSimplewareTrimmedBranches(SegmentHeartSimpleware):
         >>> labelmap = result['labelmap']
     """
 
-    def __init__(self, log_level: int | str = logging.INFO):
+    def __init__(self, log_level: int | str = logging.INFO) -> None:
         """Initialize the trimmed-branches heart segmentation.
 
         Args:

--- a/src/physiomotion4d/workflow_convert_image_to_usd.py
+++ b/src/physiomotion4d/workflow_convert_image_to_usd.py
@@ -20,23 +20,11 @@ from .convert_image_4d_to_3d import ConvertImage4DTo3D
 from .convert_vtk_to_usd import ConvertVTKToUSD
 from .physiomotion4d_base import PhysioMotion4DBase
 from .register_images_base import RegisterImagesBase
-from .register_images_greedy import RegisterImagesGreedy
 from .register_images_icon import RegisterImagesICON
 from .segment_anatomy_base import SegmentAnatomyBase
 from .segment_chest_total_segmentator import SegmentChestTotalSegmentator
-from .segment_heart_simpleware import SegmentHeartSimpleware
 from .transform_tools import TransformTools
 from .usd_anatomy_tools import USDAnatomyTools
-
-#: Supported segmentation backend identifiers.
-SEGMENTATION_METHODS: tuple[str, ...] = (
-    "ChestTotalSegmentator",
-    "HeartSimpleware",
-    "HeartSimplewareTrimmedBranches",
-)
-
-#: Supported registration backend identifiers.
-REGISTRATION_METHODS: tuple[str, ...] = ("Greedy", "ICON")
 
 
 class WorkflowConvertImageToUSD(PhysioMotion4DBase):
@@ -46,16 +34,12 @@ class WorkflowConvertImageToUSD(PhysioMotion4DBase):
     This class implements the full workflow from 4D CT images to painted USD files
     suitable for visualization in NVIDIA Omniverse.
 
-    **Segmentation backends** (``segmentation_method``):
-
-    - ``'ChestTotalSegmentator'`` — :class:`SegmentChestTotalSegmentator`.
-    - ``'HeartSimpleware'`` — :class:`SegmentHeartSimpleware`. **Behavior
-      change**: this workflow previously called ``set_trim_branches(True)``
-      for this option implicitly. It no longer does — for the trimmed
-      behavior, use ``'HeartSimplewareTrimmedBranches'``.
-    - ``'HeartSimplewareTrimmedBranches'`` — :class:`SegmentHeartSimpleware`
-      with branch trimming enabled, matching the KCL-Heart-Model template
-      extent.
+    ``segmentation_method`` and ``registration_method`` accept a
+    pre-configured :class:`SegmentAnatomyBase` / :class:`RegisterImagesBase`
+    instance. Configure backend-specific parameters (iteration counts,
+    trim_branches, mass preservation, etc.) on the instance before passing
+    it in. Defaults to :class:`SegmentChestTotalSegmentator` /
+    :class:`RegisterImagesICON` when omitted.
     """
 
     def __init__(
@@ -65,9 +49,8 @@ class WorkflowConvertImageToUSD(PhysioMotion4DBase):
         output_directory: str,
         project_name: str,
         reference_image_filename: Optional[str] = None,
-        number_of_registration_iterations: Optional[int] = 1,
-        segmentation_method: str = "ChestTotalSegmentator",
-        registration_method: str = "ICON",
+        segmentation_method: Optional[SegmentAnatomyBase] = None,
+        registration_method: Optional[RegisterImagesBase] = None,
         times_per_second: float = 24.0,
         log_level: int | str = logging.INFO,
         save_registered_images: bool = True,
@@ -89,13 +72,14 @@ class WorkflowConvertImageToUSD(PhysioMotion4DBase):
             output_directory (str): Directory path where output files will be stored
             project_name (str): Project name for USD file organization
             reference_image_filename (Optional[str]): Path to reference image file
-            number_of_registration_iterations (Optional[int]): Number of registration iterations
-            segmentation_method (str): Segmentation backend to use:
-                ``'ChestTotalSegmentator'`` (default), ``'HeartSimpleware'``,
-                or ``'HeartSimplewareTrimmedBranches'`` (HeartSimpleware with
-                pulmonary/great-vessel branches trimmed to the cardiac region).
-            registration_method (str): Registration method to use:
-                ``'Greedy'`` or ``'ICON'`` (default: ``'ICON'``).
+            segmentation_method (Optional[SegmentAnatomyBase]): Segmentation
+                backend instance. Defaults to a new
+                :class:`SegmentChestTotalSegmentator` when None.
+            registration_method (Optional[RegisterImagesBase]): Registration
+                backend instance. Defaults to a new :class:`RegisterImagesICON`
+                when None. A caller-supplied instance is mutated (fixed
+                image/mask/modality) during :meth:`process` - pass a fresh
+                instance per run unless intentionally reusing state.
             times_per_second: Frames per second for animated USD time series.
                 Defaults to 24.0, matching the underlying VTK-to-USD converter.
             log_level: Logging level (default: logging.INFO)
@@ -105,6 +89,11 @@ class WorkflowConvertImageToUSD(PhysioMotion4DBase):
                 output_directory when True
             save_labelmaps: Write segmentation labelmaps and registration masks to
                 output_directory when True
+
+        Raises:
+            TypeError: If segmentation_method is neither None nor a
+                SegmentAnatomyBase instance, or registration_method is
+                neither None nor a RegisterImagesBase instance.
         """
         super().__init__(class_name=self.__class__.__name__, log_level=log_level)
 
@@ -113,83 +102,36 @@ class WorkflowConvertImageToUSD(PhysioMotion4DBase):
         self.output_directory = output_directory
         self.project_name = project_name
         self.reference_image_filename = reference_image_filename
-        self.number_of_registration_iterations = number_of_registration_iterations
         self.save_registered_images = save_registered_images
         self.save_registration_transforms = save_registration_transforms
         self.save_labelmaps = save_labelmaps
         self.times_per_second = times_per_second
 
-        # Validate segmentation method
-        if segmentation_method not in SEGMENTATION_METHODS:
-            raise ValueError(
-                f"Invalid segmentation_method '{segmentation_method}'. "
-                f"Must be one of: {', '.join(SEGMENTATION_METHODS)}."
+        if segmentation_method is None:
+            segmentation_method = SegmentChestTotalSegmentator(log_level=log_level)
+            segmentation_method.contrast_threshold = 500
+        elif not isinstance(segmentation_method, SegmentAnatomyBase):
+            raise TypeError(
+                "segmentation_method must be a SegmentAnatomyBase instance or None"
             )
-        self.segmentation_method = segmentation_method
+        self.segmenter: SegmentAnatomyBase = segmentation_method
 
-        # Validate registration method
-        if registration_method not in REGISTRATION_METHODS:
-            raise ValueError(
-                f"Invalid registration_method '{registration_method}'. "
-                f"Must be one of: {', '.join(REGISTRATION_METHODS)}."
+        if registration_method is None:
+            registration_method = RegisterImagesICON(log_level=log_level)
+            registration_method.set_mass_preservation(not contrast_enhanced)
+        elif not isinstance(registration_method, RegisterImagesBase):
+            raise TypeError(
+                "registration_method must be a RegisterImagesBase instance or None"
             )
-        self.registration_method = registration_method
+        registration_method.set_modality("ct")
+        registration_method.set_mask_dilation(5)
+        self.registrar: RegisterImagesBase = registration_method
 
         # Create output directory if it doesn't exist
         os.makedirs(output_directory, exist_ok=True)
 
         # Initialize processing components
         self.converter = ConvertImage4DTo3D(log_level=log_level)
-        self.segmenter: SegmentAnatomyBase
-        if self.segmentation_method == "ChestTotalSegmentator":
-            chest_segmenter = SegmentChestTotalSegmentator(log_level=log_level)
-            chest_segmenter.contrast_threshold = 500
-            self.segmenter = chest_segmenter
-        elif self.segmentation_method in (
-            "HeartSimpleware",
-            "HeartSimplewareTrimmedBranches",
-        ):
-            heart_segmenter = SegmentHeartSimpleware(log_level=log_level)
-            heart_segmenter.set_trim_branches(
-                self.segmentation_method == "HeartSimplewareTrimmedBranches"
-            )
-            self.segmenter = heart_segmenter
-        else:
-            raise ValueError(f"Unknown segmentation method: {self.segmentation_method}")
-
-        # Initialize registration method
-        self.registrar: RegisterImagesBase
-        if self.registration_method == "Greedy":
-            self.log_info("Initializing Greedy registration...")
-            greedy_registrar = RegisterImagesGreedy(log_level=log_level)
-            greedy_registrar.set_modality("ct")
-            greedy_registrar.set_transform_type("Deformable")
-            if (
-                number_of_registration_iterations is not None
-                and number_of_registration_iterations > 0
-            ):
-                greedy_registrar.set_number_of_iterations(
-                    [
-                        number_of_registration_iterations,
-                        number_of_registration_iterations // 2,
-                        0,
-                    ]
-                )
-            self.registrar = greedy_registrar
-        else:  # ICON (default)
-            self.log_info("Initializing ICON registration...")
-            icon_registrar = RegisterImagesICON(log_level=log_level)
-            icon_registrar.set_modality("ct")
-            if (
-                number_of_registration_iterations is not None
-                and number_of_registration_iterations > 0
-            ):
-                icon_registrar.set_number_of_iterations(
-                    number_of_registration_iterations
-                )
-            self.registrar = icon_registrar
-
-        self.registrar.set_mask_dilation(5)
         self.contour_tools = ContourTools()
 
         # Data storage for processing pipeline
@@ -372,13 +314,6 @@ class WorkflowConvertImageToUSD(PhysioMotion4DBase):
 
         # Set up registrar with fixed image
         self.registrar.set_fixed_image(self._fixed_image)
-        if self.registration_method == "ICON" and isinstance(
-            self.registrar, RegisterImagesICON
-        ):
-            if self.contrast_enhanced:
-                self.registrar.set_mass_preservation(False)
-            else:
-                self.registrar.set_mass_preservation(True)
 
         # Process each time point
         self._time_series_transforms = []

--- a/src/physiomotion4d/workflow_convert_image_to_vtk.py
+++ b/src/physiomotion4d/workflow_convert_image_to_vtk.py
@@ -9,10 +9,11 @@ directly.
 Typical usage::
 
     import itk
-    from physiomotion4d import WorkflowConvertImageToVTK
+    from physiomotion4d import SegmentChestTotalSegmentator, WorkflowConvertImageToVTK
 
     ct = itk.imread('chest_ct.nii.gz')
-    workflow = WorkflowConvertImageToVTK(segmentation_method='ChestTotalSegmentator')
+    segmenter = SegmentChestTotalSegmentator()
+    workflow = WorkflowConvertImageToVTK(segmentation_method=segmenter)
     result = workflow.run_workflow(ct, contrast_enhanced_study=True)
 
     # Combined single-file output (default)
@@ -35,6 +36,7 @@ import pyvista as pv
 from .contour_tools import ContourTools
 from .physiomotion4d_base import PhysioMotion4DBase
 from .segment_anatomy_base import SegmentAnatomyBase
+from .segment_chest_total_segmentator import SegmentChestTotalSegmentator
 from .usd_anatomy_tools import USDAnatomyTools
 
 #: Ordered tuple of anatomy group names matching :meth:`SegmentAnatomyBase.segment` keys.
@@ -48,29 +50,16 @@ ANATOMY_GROUPS: tuple[str, ...] = (
     "contrast",
 )
 
-#: Supported segmentation backend identifiers.
-SEGMENTATION_METHODS: tuple[str, ...] = (
-    "ChestTotalSegmentator",
-    "HeartSimpleware",
-    "HeartSimplewareTrimmedBranches",
-)
-
 
 class WorkflowConvertImageToVTK(PhysioMotion4DBase):
     """Segment a CT image and produce per-anatomy-group VTK surfaces and meshes.
 
-    **Segmentation backends**
-
-    - ``'ChestTotalSegmentator'`` — :class:`SegmentChestTotalSegmentator`
-      (CPU-capable, default).
-    - ``'HeartSimpleware'`` — :class:`SegmentHeartSimpleware` (cardiac only;
-      requires a Simpleware Medical installation). **Behavior change**: this
-      workflow previously called ``set_trim_branches(True)`` for this option
-      implicitly. It no longer does — for the trimmed behavior, use
-      ``'HeartSimplewareTrimmedBranches'`` below.
-    - ``'HeartSimplewareTrimmedBranches'`` — :class:`SegmentHeartSimpleware`
-      with :meth:`SegmentHeartSimpleware.set_trim_branches` set to ``True``,
-      trimming pulmonary and great-vessel branches to the cardiac region.
+    ``segmentation_method`` accepts a pre-configured
+    :class:`SegmentAnatomyBase` instance (e.g. :class:`SegmentChestTotalSegmentator`,
+    :class:`SegmentHeartSimpleware`, or :class:`SegmentHeartSimplewareTrimmedBranches`
+    for cardiac-only segmentation with pulmonary/great-vessel branches
+    trimmed). Defaults to a new :class:`SegmentChestTotalSegmentator` when
+    omitted.
 
     **Output anatomy groups**
 
@@ -99,37 +88,32 @@ class WorkflowConvertImageToVTK(PhysioMotion4DBase):
 
     #: Valid anatomy group names.
     ANATOMY_GROUPS: tuple[str, ...] = ANATOMY_GROUPS
-    #: Valid segmentation method identifiers.
-    SEGMENTATION_METHODS: tuple[str, ...] = SEGMENTATION_METHODS
 
     def __init__(
         self,
-        segmentation_method: str = "ChestTotalSegmentator",
+        segmentation_method: Optional[SegmentAnatomyBase] = None,
         log_level: int | str = logging.INFO,
     ) -> None:
         """Initialize the workflow.
 
         Args:
-            segmentation_method: Segmentation backend to use.  One of
-                ``'ChestTotalSegmentator'`` (default), ``'HeartSimpleware'``,
-                or ``'HeartSimplewareTrimmedBranches'`` (HeartSimpleware with
-                pulmonary/great-vessel branches trimmed to the cardiac region).
+            segmentation_method: Segmentation backend instance. Defaults to
+                a new :class:`SegmentChestTotalSegmentator` when None.
             log_level: Logging level.  Default: ``logging.INFO``.
 
         Raises:
-            ValueError: If *segmentation_method* is not one of
-                :attr:`SEGMENTATION_METHODS`.
+            TypeError: If segmentation_method is neither None nor a
+                SegmentAnatomyBase instance.
         """
         super().__init__(class_name=self.__class__.__name__, log_level=log_level)
 
-        if segmentation_method not in self.SEGMENTATION_METHODS:
-            raise ValueError(
-                f"Unknown segmentation_method '{segmentation_method}'. "
-                f"Choose from: {', '.join(self.SEGMENTATION_METHODS)}"
+        if segmentation_method is None:
+            segmentation_method = SegmentChestTotalSegmentator(log_level=log_level)
+        elif not isinstance(segmentation_method, SegmentAnatomyBase):
+            raise TypeError(
+                "segmentation_method must be a SegmentAnatomyBase instance or None"
             )
-
-        self.segmentation_method_name: str = segmentation_method
-        self._segmenter: Optional[SegmentAnatomyBase] = None
+        self._segmenter: SegmentAnatomyBase = segmentation_method
         self._contour_tools: ContourTools = ContourTools(log_level=log_level)
 
         # Build anatomy-group → RGB color from USDAnatomyTools.
@@ -145,29 +129,6 @@ class WorkflowConvertImageToVTK(PhysioMotion4DBase):
 
     # ─────────────────────────── Internal helpers ──────────────────────────
 
-    def _create_segmenter(self) -> SegmentAnatomyBase:
-        """Instantiate the chosen segmentation backend (lazy import)."""
-        if self.segmentation_method_name == "ChestTotalSegmentator":
-            from .segment_chest_total_segmentator import (
-                SegmentChestTotalSegmentator,
-            )
-
-            return SegmentChestTotalSegmentator(log_level=self.log_level)
-        if self.segmentation_method_name in (
-            "HeartSimpleware",
-            "HeartSimplewareTrimmedBranches",
-        ):
-            from .segment_heart_simpleware import SegmentHeartSimpleware
-
-            segmenter = SegmentHeartSimpleware(log_level=self.log_level)
-            segmenter.set_trim_branches(
-                self.segmentation_method_name == "HeartSimplewareTrimmedBranches"
-            )
-            return segmenter
-        raise ValueError(
-            f"Unknown segmentation method: {self.segmentation_method_name}"
-        )
-
     def _get_label_info_for_group(self, group: str) -> tuple[list[str], list[int]]:
         """Return ``(label_names, label_ids)`` for *group* from the active segmenter.
 
@@ -175,9 +136,6 @@ class WorkflowConvertImageToVTK(PhysioMotion4DBase):
         the group is not present (e.g. HeartSimpleware does not register
         lung/bone).
         """
-        assert self._segmenter is not None, (
-            "_create_segmenter() must be called before _get_label_info_for_group()"
-        )
         mask_ids = self._segmenter.taxonomy.labels_in_group(group)
         return list(mask_ids.values()), list(mask_ids.keys())
 
@@ -296,9 +254,8 @@ class WorkflowConvertImageToVTK(PhysioMotion4DBase):
         else:
             groups_to_process = list(self.ANATOMY_GROUPS)
 
-        # Create and run segmenter
-        self.log_info("Creating segmenter: %s", self.segmentation_method_name)
-        self._segmenter = self._create_segmenter()
+        # Run segmenter
+        self.log_info("Running segmenter: %s", type(self._segmenter).__name__)
 
         self.log_section("Running segmentation")
         seg_result: dict[str, Any] = self._segmenter.segment(

--- a/src/physiomotion4d/workflow_fine_tune_icon_registration.py
+++ b/src/physiomotion4d/workflow_fine_tune_icon_registration.py
@@ -44,6 +44,7 @@ import yaml
 
 from .labelmap_tools import LabelmapTools
 from .physiomotion4d_base import PhysioMotion4DBase
+from .register_images_icon import RegisterImagesICON
 from .register_time_series_images import RegisterTimeSeriesImages
 from .transform_tools import TransformTools
 
@@ -776,15 +777,16 @@ class WorkflowFineTuneICONRegistration(PhysioMotion4DBase):
                     for labelmap in moving_labelmaps
                 ]
 
+        icon = RegisterImagesICON(log_level=self.log_level)
+        icon.set_number_of_iterations(number_of_iterations)
+        if weights_path is not None:
+            icon.set_weights_path(str(weights_path))
         self.registrar = RegisterTimeSeriesImages(
-            registration_method="ICON", log_level=self.log_level
+            registration_method=icon, log_level=self.log_level
         )
         self.registrar.set_modality(modality)
         self.registrar.set_fixed_image(reference_image)
         self.registrar.set_fixed_mask(reference_mask)
-        self.registrar.set_number_of_iterations_ICON(number_of_iterations)
-        if weights_path is not None:
-            self.registrar.registrar_ICON.set_weights_path(str(weights_path))
 
         # TODO: set reference frame and register reference
         result = self.registrar.register_time_series(

--- a/src/physiomotion4d/workflow_fit_statistical_model_to_patient.py
+++ b/src/physiomotion4d/workflow_fit_statistical_model_to_patient.py
@@ -38,6 +38,10 @@ from .register_images_icon import RegisterImagesICON
 from .register_models_distance_maps import RegisterModelsDistanceMaps
 from .register_models_icp import RegisterModelsICP
 from .register_models_pca import RegisterModelsPCA
+from .segment_anatomy_base import SegmentAnatomyBase
+from .segment_heart_simpleware_trimmed_branches import (
+    SegmentHeartSimplewareTrimmedBranches,
+)
 from .transform_tools import TransformTools
 from .workflow_convert_image_to_vtk import WorkflowConvertImageToVTK
 
@@ -126,7 +130,7 @@ class WorkflowFitStatisticalModelToPatient(PhysioMotion4DBase):
         patient_labelmap: Optional[itk.Image] = None,
         template_labelmap: Optional[itk.Image] = None,
         labelmap_interior_object_ids: Optional[list] = None,
-        segmentation_method: str = "HeartSimplewareTrimmedBranches",
+        segmentation_method: Optional[SegmentAnatomyBase] = None,
         log_level: int | str = logging.INFO,
     ):
         """Initialize the model-to-image-and-model registration pipeline.
@@ -141,20 +145,30 @@ class WorkflowFitStatisticalModelToPatient(PhysioMotion4DBase):
             labelmap_interior_object_ids: Optional list of labelmap IDs that should
                 not be used when computing the distance map since they are interior (surrounded
                 by other objects).
-            segmentation_method: Segmentation backend used by
+            segmentation_method: Segmentation backend instance used by
                 WorkflowConvertImageToVTK when patient_models is None and
-                patient_image is provided. One of
-                ``'HeartSimplewareTrimmedBranches'`` (default — produces
-                cardiac extent that matches KCL-Heart-Model templates),
-                ``'HeartSimpleware'``, or ``'ChestTotalSegmentator'``.
+                patient_image is provided. Defaults to a new
+                :class:`SegmentHeartSimplewareTrimmedBranches` (matches
+                KCL-Heart-Model template extent) when None.
                 Ignored when patient_models is supplied.
             log_level: Logging level (logging.DEBUG, logging.INFO, logging.WARNING).
                 Default: logging.INFO
+
+        Raises:
+            TypeError: If segmentation_method is neither None nor a
+                SegmentAnatomyBase instance.
         """
         # Initialize base class with logging
         super().__init__(
             class_name="WorkflowFitStatisticalModelToPatient", log_level=log_level
         )
+
+        if segmentation_method is not None and not isinstance(
+            segmentation_method, SegmentAnatomyBase
+        ):
+            raise TypeError(
+                "segmentation_method must be a SegmentAnatomyBase instance or None"
+            )
 
         self.template_model = template_model
         self.template_model_surface = template_model.extract_surface(
@@ -168,6 +182,10 @@ class WorkflowFitStatisticalModelToPatient(PhysioMotion4DBase):
         self.labelmap_interior_object_ids: Optional[list] = labelmap_interior_object_ids
 
         if patient_models is None and patient_image is not None:
+            if segmentation_method is None:
+                segmentation_method = SegmentHeartSimplewareTrimmedBranches(
+                    log_level=log_level
+                )
             convert_image_to_vtk = WorkflowConvertImageToVTK(
                 segmentation_method=segmentation_method,
                 log_level=log_level,

--- a/src/physiomotion4d/workflow_reconstruct_highres_4d_ct.py
+++ b/src/physiomotion4d/workflow_reconstruct_highres_4d_ct.py
@@ -29,6 +29,8 @@ from typing import Optional
 import itk
 
 from .physiomotion4d_base import PhysioMotion4DBase
+from .register_images_base import RegisterImagesBase
+from .register_images_greedy_icon import RegisterImagesGreedyICON
 from .register_time_series_images import RegisterTimeSeriesImages
 
 
@@ -41,7 +43,7 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
 
     **Registration Pipeline:**
         1. **Time Series Registration**: Register each time-series image to the
-           high-resolution reference using RegisterTimeSeriesImages with Greedy_ICON method
+           high-resolution reference using RegisterTimeSeriesImages
         2. **Reconstruction**: Apply inverse transforms to reconstruct high-resolution
            time series
         3. **Optional Upsampling**: Resample to isotropic high resolution
@@ -51,6 +53,12 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
         - fixed_image: High-resolution reference image
         - All images should be in the same anatomical coordinate system
 
+    ``registration_method`` accepts a pre-configured
+    :class:`RegisterImagesBase` instance. Configure backend-specific
+    parameters (iteration counts, etc.) on the instance before passing it
+    in. Defaults to a new :class:`RegisterImagesGreedyICON` (Greedy followed
+    by ICON refinement) when omitted.
+
     Attributes:
         time_series_images (list[itk.Image]): Ordered list of time-series images
         fixed_image (itk.Image): High-resolution reference image
@@ -58,8 +66,6 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
         register_reference (bool): Whether to register reference frame
         prior_weight (float): Weight for temporal smoothing (0.0-1.0)
         upsample_to_fixed_resolution (bool): Whether to upsample reconstruction
-        registration_method (str): Registration method ('Greedy', 'ICON', or 'Greedy_ICON')
-        number_of_iterations: Iterations for registration
         registrar (RegisterTimeSeriesImages): Internal registration object
         forward_transforms (list[itk.Transform]): one per frame; each warps its
             moving image onto the fixed grid
@@ -70,16 +76,17 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
 
     Example:
         >>> # Initialize workflow with data
+        >>> registration_method = RegisterImagesGreedyICON()
+        >>> registration_method.greedy.set_number_of_iterations([30, 15, 7])
+        >>> registration_method.icon.set_number_of_iterations(20)
         >>> workflow = WorkflowReconstructHighres4DCT(
         ...     time_series_images=lowres_images,
         ...     fixed_image=highres_reference,
         ...     reference_frame=3,
-        ...     registration_method='Greedy_ICON',
+        ...     registration_method=registration_method,
         ... )
         >>>
-        >>> # Configure registration parameters
-        >>> workflow.set_number_of_iterations_Greedy([30, 15, 7])
-        >>> workflow.set_number_of_iterations_ICON(20)
+        >>> # Configure workflow-level registration parameters
         >>> workflow.set_prior_weight(0.5)
         >>>
         >>> # Run complete workflow
@@ -97,7 +104,7 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
         fixed_image: itk.Image,
         reference_frame: int = 0,
         register_reference: bool = False,
-        registration_method: str = "Greedy_ICON",
+        registration_method: Optional[RegisterImagesBase] = None,
         log_level: int | str = logging.INFO,
     ):
         """Initialize the high-resolution 4D CT reconstruction workflow.
@@ -112,15 +119,17 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
             register_reference (bool, optional): If True, register the reference frame
                 to the fixed image. If False, use identity transform for reference.
                 Default: False
-            registration_method (str, optional): Registration method to use.
-                Options: 'Greedy', 'ICON', or 'Greedy_ICON'. Default: 'Greedy_ICON'
+            registration_method (Optional[RegisterImagesBase]): Registration
+                backend instance. Defaults to a new
+                :class:`RegisterImagesGreedyICON` when None.
             log_level: Logging level (logging.DEBUG, logging.INFO, etc.).
                 Default: logging.INFO
 
         Raises:
             ValueError: If time_series_images is empty
             ValueError: If reference_frame is out of range
-            ValueError: If registration_method is invalid
+            TypeError: If registration_method is neither None nor a
+                RegisterImagesBase instance
         """
         # Initialize base class with logging
         super().__init__(
@@ -137,10 +146,11 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
                 f"[0, {len(time_series_images) - 1}]"
             )
 
-        if registration_method not in ["Greedy", "ICON", "Greedy_ICON"]:
-            raise ValueError(
-                f"registration_method must be 'Greedy', 'ICON', or 'Greedy_ICON', "
-                f"got '{registration_method}'"
+        if registration_method is None:
+            registration_method = RegisterImagesGreedyICON(log_level=log_level)
+        elif not isinstance(registration_method, RegisterImagesBase):
+            raise TypeError(
+                "registration_method must be a RegisterImagesBase instance or None"
             )
 
         # Store input data
@@ -148,7 +158,6 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
         self.fixed_image = fixed_image
         self.reference_frame = reference_frame
         self.register_reference = register_reference
-        self.registration_method = registration_method
 
         # Initialize parameters with defaults
         self.prior_weight: float = 0.0
@@ -157,10 +166,6 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
         self.mask_dilation_mm: float = 0.0
         self.fixed_mask: Optional[itk.Image] = None
         self.moving_masks: Optional[list[Optional[itk.Image]]] = None
-
-        # Set default number of iterations based on registration method
-        self.number_of_iterations_Greedy: list[int] = [30, 15, 7, 3]
-        self.number_of_iterations_ICON: Optional[int] = 20
 
         # Initialize registrar
         self.registrar = RegisterTimeSeriesImages(
@@ -172,29 +177,6 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
         self.inverse_transforms: Optional[list[itk.Transform]] = None
         self.losses: Optional[list[float]] = None
         self.reconstructed_images: Optional[list[itk.Image]] = None
-
-    def set_number_of_iterations_Greedy(
-        self, number_of_iterations_Greedy: list[int]
-    ) -> None:
-        """Set the number of iterations for Greedy registration.
-
-        Args:
-            number_of_iterations_Greedy: List of iterations for Greedy multi-resolution
-                (e.g., [30, 15, 7, 3] for four resolution levels)
-        """
-        self.number_of_iterations_Greedy = number_of_iterations_Greedy
-
-    def set_number_of_iterations_ICON(
-        self, number_of_iterations_ICON: Optional[int]
-    ) -> None:
-        """Set the number of iterations for ICON registration.
-
-        Args:
-            number_of_iterations_ICON: Number of fine-tuning steps for ICON.
-                If None, ICON fine-tuning is disabled (the pretrained network
-                is used as-is).
-        """
-        self.number_of_iterations_ICON = number_of_iterations_ICON
 
     def set_prior_weight(self, prior_weight: float) -> None:
         """Set the weight for temporal smoothing with prior transforms.
@@ -284,19 +266,13 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
         self.registrar.set_fixed_image(self.fixed_image)
         self.registrar.set_modality(self.modality)
         self.registrar.set_mask_dilation(self.mask_dilation_mm)
-        self.registrar.set_number_of_iterations_greedy(self.number_of_iterations_Greedy)
-        self.registrar.set_number_of_iterations_ICON(self.number_of_iterations_ICON)
         self.registrar.set_fixed_mask(self.fixed_mask)
 
-        self.log_info(f"Registration method: {self.registration_method}")
+        self.log_info(f"Registration method: {type(self.registrar.registrar).__name__}")
         self.log_info(f"Number of time points: {len(self.time_series_images)}")
         self.log_info(f"Reference frame: {self.reference_frame}")
         self.log_info(f"Register reference: {self.register_reference}")
         self.log_info(f"Prior weight: {self.prior_weight}")
-        self.log_info(
-            f"Number of iterations (Greedy): {self.number_of_iterations_Greedy}"
-        )
-        self.log_info(f"Number of iterations (ICON): {self.number_of_iterations_ICON}")
 
         # Perform registration
         result = self.registrar.register_time_series(
@@ -403,7 +379,8 @@ class WorkflowReconstructHighres4DCT(PhysioMotion4DBase):
 
         self.log_info("Input configuration:")
         self.log_info(f"  Number of time points: {len(self.time_series_images)}")
-        self.log_info(f"  Registration method: {self.registration_method}")
+        registrar_type = type(self.registrar.registrar).__name__
+        self.log_info(f"  Registration method: {registrar_type}")
         self.log_info(f"  Reference frame: {self.reference_frame}")
         self.log_info(f"  Prior weight: {self.prior_weight}")
         self.log_info(f"  Upsample reconstruction: {upsample_to_fixed_resolution}")

--- a/tests/test_convert_vtk_to_usd.py
+++ b/tests/test_convert_vtk_to_usd.py
@@ -69,11 +69,11 @@ class TestConvertVTKToUSD:
             return meshes
         # Load existing contours
         print("\nLoading existing contour files...")
-        meshes = [
+        loaded_meshes: list[Any] = [
             pv.read(str(contour_output_dir / "heart_contours_slice000.vtp")),
             pv.read(str(contour_output_dir / "heart_contours_slice001.vtp")),
         ]
-        return meshes
+        return loaded_meshes
 
     def test_converter_initialization(self) -> None:
         """Test that ConvertVTKToUSD initializes correctly."""

--- a/tests/test_register_images_chain.py
+++ b/tests/test_register_images_chain.py
@@ -109,6 +109,32 @@ def test_chain_propagates_fixed_and_moving_state_to_each_child() -> None:
         assert stage.preprocess_call_count == 1
 
 
+def test_chain_recomputes_fixed_image_pre_when_fixed_image_changes() -> None:
+    """A reused chain must recompute each child's fixed_image_pre when the
+    chain's fixed image changes, not reuse a stale pre from the prior image;
+    but it must NOT recompute across frames that share the same fixed image."""
+    stage = _RecordingRegistrar("stage", 1.0)
+    chain = RegisterImagesChain([stage])
+
+    fixed_a = _small_image(value=1.0)
+    chain.set_fixed_image(fixed_a)
+    chain.register(_small_image(value=9.0))
+    # The stub's preprocess() is identity, so fixed_image_pre is fixed_a.
+    assert stage.fixed_image_pre is fixed_a
+    assert stage.preprocess_call_count == 1
+
+    # Second frame, same fixed image: pre is cached, not recomputed.
+    chain.register(_small_image(value=8.0))
+    assert stage.preprocess_call_count == 1
+
+    # New fixed image: the stale pre for fixed_a must be discarded and recomputed.
+    fixed_b = _small_image(value=2.0)
+    chain.set_fixed_image(fixed_b)
+    chain.register(_small_image(value=7.0))
+    assert stage.fixed_image_pre is fixed_b
+    assert stage.preprocess_call_count == 2
+
+
 def test_chain_rejects_empty_list() -> None:
     """An empty registrars list is not a valid chain."""
     with pytest.raises(ValueError, match="registrars must not be empty"):

--- a/tests/test_register_images_chain.py
+++ b/tests/test_register_images_chain.py
@@ -1,0 +1,126 @@
+"""Unit tests for RegisterImagesChain's sequencing and state-propagation.
+
+These are pure plumbing tests using stub RegisterImagesBase subclasses -
+no real registration is performed. RegisterImagesChain composes independent
+backends that may each need different intensity preprocessing, so the
+chain's job is dict/attribute routing, not numeric accuracy; per this
+project's testing conventions, that's exactly the kind of behavior
+appropriate for synthetic/stub-based unit tests rather than real data.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+
+import itk
+import numpy as np
+import pytest
+
+from physiomotion4d.register_images_base import RegisterImagesBase
+from physiomotion4d.register_images_chain import RegisterImagesChain
+
+
+def _small_image(value: float = 0.0) -> itk.Image:
+    """A tiny constant-valued synthetic image, shape (Z, Y, X) = (4, 4, 4)."""
+    arr = np.full((4, 4, 4), value, dtype=np.float32)
+    return itk.image_from_array(arr)
+
+
+class _RecordingRegistrar(RegisterImagesBase):
+    """Stub registrar that records the state visible to it when
+    registration_method() is called, and returns a sentinel transform."""
+
+    def __init__(self, name: str, sentinel_value: float) -> None:
+        """Args: name: label used in the sentinel transform strings.
+        sentinel_value: loss value this stub's registration_method() returns.
+        """
+        super().__init__()
+        self.name = name
+        self.sentinel_value = sentinel_value
+        self.seen_fixed_image_pre: Optional[itk.Image] = None
+        self.seen_moving_image: Optional[itk.Image] = None
+        self.seen_moving_image_pre: Optional[itk.Image] = None
+        self.seen_moving_mask: Optional[itk.Image] = None
+        self.seen_initial_forward_transform: Optional[object] = None
+        self.preprocess_call_count = 0
+
+    def preprocess(self, image: itk.Image, modality: str = "ct") -> itk.Image:
+        """No-op preprocessing that records how many times it was called."""
+        self.preprocess_call_count += 1
+        return image
+
+    def registration_method(
+        self,
+        moving_image: itk.Image,
+        moving_mask: Optional[itk.Image] = None,
+        moving_labelmap: Optional[itk.Image] = None,
+        moving_image_pre: Optional[itk.Image] = None,
+        initial_forward_transform: Optional[object] = None,
+    ) -> dict[str, Union[object, float]]:
+        """Record the state visible at call time; return a sentinel result."""
+        self.seen_fixed_image_pre = self.fixed_image_pre
+        self.seen_moving_image = self.moving_image
+        self.seen_moving_image_pre = moving_image_pre
+        self.seen_moving_mask = moving_mask
+        self.seen_initial_forward_transform = initial_forward_transform
+        return {
+            "forward_transform": f"forward_{self.name}",
+            "inverse_transform": f"inverse_{self.name}",
+            "loss": self.sentinel_value,
+        }
+
+
+def test_chain_feeds_forward_transform_to_next_stage() -> None:
+    """Stage 2 must receive stage 1's forward_transform as its
+    initial_forward_transform."""
+    stage1 = _RecordingRegistrar("stage1", 1.0)
+    stage2 = _RecordingRegistrar("stage2", 2.0)
+    chain = RegisterImagesChain([stage1, stage2])
+    chain.set_fixed_image(_small_image())
+
+    result = chain.register(_small_image())
+
+    assert stage1.seen_initial_forward_transform is None
+    assert stage2.seen_initial_forward_transform == "forward_stage1"
+    assert result["forward_transform"] == "forward_stage2"
+    assert result["loss"] == 2.0
+
+
+def test_chain_propagates_fixed_and_moving_state_to_each_child() -> None:
+    """Every child must see a non-None fixed_image_pre (computed via its own
+    preprocess(), not copied from the chain's no-op preprocess()) and the
+    raw moving_image, before its registration_method() runs."""
+    stage1 = _RecordingRegistrar("stage1", 1.0)
+    stage2 = _RecordingRegistrar("stage2", 2.0)
+    chain = RegisterImagesChain([stage1, stage2])
+    fixed = _small_image(value=5.0)
+    moving = _small_image(value=7.0)
+    chain.set_fixed_image(fixed)
+
+    chain.register(moving)
+
+    for stage in (stage1, stage2):
+        assert stage.seen_fixed_image_pre is not None
+        assert stage.seen_moving_image is moving
+        # Each stage must compute its own preprocessing (moving_image_pre is
+        # not inherited from the chain, which has no meaningful preprocess()
+        # of its own).
+        assert stage.seen_moving_image_pre is None
+        assert stage.preprocess_call_count == 1
+
+
+def test_chain_rejects_empty_list() -> None:
+    """An empty registrars list is not a valid chain."""
+    with pytest.raises(ValueError, match="registrars must not be empty"):
+        RegisterImagesChain([])
+
+
+def test_chain_rejects_non_register_images_base_element() -> None:
+    """Every element must be a RegisterImagesBase instance."""
+    with pytest.raises(TypeError, match="RegisterImagesBase"):
+        bad_registrars: list[Any] = [_RecordingRegistrar("a", 0.0), "not-a-registrar"]
+        RegisterImagesChain(bad_registrars)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_register_images_greedy_icon.py
+++ b/tests/test_register_images_greedy_icon.py
@@ -1,0 +1,48 @@
+"""Unit tests for RegisterImagesGreedyICON.
+
+The real-data behavioral-equivalence claim (RegisterImagesGreedyICON must
+match the deleted RegisterTimeSeriesImages "Greedy_ICON" string path) is a
+one-time manual check performed during implementation, not a permanent test
+asset - see the implementation plan's Verification section. These tests
+cover the class's wiring: it is a 2-stage RegisterImagesChain of the
+expected backend types, accessible by name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from physiomotion4d.register_images_chain import RegisterImagesChain
+from physiomotion4d.register_images_greedy import RegisterImagesGreedy
+from physiomotion4d.register_images_greedy_icon import RegisterImagesGreedyICON
+from physiomotion4d.register_images_icon import RegisterImagesICON
+
+
+def test_greedy_icon_is_a_two_stage_chain() -> None:
+    """RegisterImagesGreedyICON wraps exactly [Greedy, ICON]."""
+    registrar = RegisterImagesGreedyICON()
+    assert isinstance(registrar, RegisterImagesChain)
+    assert len(registrar.registrars) == 2
+    assert isinstance(registrar.registrars[0], RegisterImagesGreedy)
+    assert isinstance(registrar.registrars[1], RegisterImagesICON)
+
+
+def test_greedy_icon_named_accessors() -> None:
+    """.greedy/.icon return the same objects as positional registrars[0]/[1]."""
+    registrar = RegisterImagesGreedyICON()
+    assert registrar.greedy is registrar.registrars[0]
+    assert registrar.icon is registrar.registrars[1]
+
+
+def test_greedy_icon_stage_configuration_is_independent() -> None:
+    """Configuring one stage must not affect the other."""
+    registrar = RegisterImagesGreedyICON()
+    registrar.greedy.set_number_of_iterations([30, 15, 7, 3])
+    registrar.icon.set_number_of_iterations(20)
+
+    assert registrar.greedy.number_of_iterations == [30, 15, 7, 3]
+    assert registrar.icon.number_of_iterations == 20
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_register_images_icon.py
+++ b/tests/test_register_images_icon.py
@@ -8,7 +8,7 @@ Note: ICON requires CUDA-enabled GPU.
 """
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import itk
 import numpy as np
@@ -74,22 +74,24 @@ class TestRegisterImagesICON:
     def test_set_mass_preservation(self, registrar_ICON: RegisterImagesICON) -> None:
         """Test setting mass preservation flag."""
         registrar_ICON.set_mass_preservation(True)
-        assert registrar_ICON.use_mass_preservation, "Mass preservation not set"
+        enabled = registrar_ICON.use_mass_preservation
+        assert enabled, "Mass preservation not set"
 
         registrar_ICON.set_mass_preservation(False)
-        assert not registrar_ICON.use_mass_preservation, (
-            "Mass preservation update failed"
-        )
+        disabled = registrar_ICON.use_mass_preservation
+        assert not disabled, "Mass preservation update failed"
 
         print("\nMass preservation setting works correctly")
 
     def test_set_multi_modality(self, registrar_ICON: RegisterImagesICON) -> None:
         """Test setting multi-modality flag."""
         registrar_ICON.set_multi_modality(True)
-        assert registrar_ICON.use_multi_modality, "Multi-modality not set"
+        enabled = registrar_ICON.use_multi_modality
+        assert enabled, "Multi-modality not set"
 
         registrar_ICON.set_multi_modality(False)
-        assert not registrar_ICON.use_multi_modality, "Multi-modality update failed"
+        disabled = registrar_ICON.use_multi_modality
+        assert not disabled, "Multi-modality update failed"
 
         print("\nMulti-modality setting works correctly")
 
@@ -310,8 +312,8 @@ class TestRegisterImagesICON:
         registrar_ICON.set_number_of_iterations(2)
         result = registrar_ICON.register(moving_image=moving_image)
 
-        inverse_transform = result["inverse_transform"]
-        forward_transform = result["forward_transform"]
+        inverse_transform = cast(itk.Transform, result["inverse_transform"])
+        forward_transform = cast(itk.Transform, result["forward_transform"])
 
         # Test point transformation
         test_point = itk.Point[itk.D, 3]()

--- a/tests/test_register_time_series_images.py
+++ b/tests/test_register_time_series_images.py
@@ -14,6 +14,9 @@ import numpy as np
 import pytest
 
 from physiomotion4d import (
+    RegisterImagesGreedy,
+    RegisterImagesGreedyICON,
+    RegisterImagesICON,
     RegisterTimeSeriesImages,
     TestTools,
     TransformTools,
@@ -26,62 +29,60 @@ class TestRegisterTimeSeriesImages:
 
     _class_name = "registration_time_series_images"
 
-    def test_registrar_initialization_Greedy_ICON(self) -> None:
-        """Test that RegisterTimeSeriesImages initializes correctly with Greedy_ICON."""
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy_ICON")
-        assert registrar is not None, "Registrar not initialized"
-        assert registrar.registration_method_name == "Greedy_ICON", (
-            "Method not set correctly"
-        )
-        assert registrar.registrar_greedy is not None, (
-            "Internal Greedy registrar not created"
-        )
-        assert registrar.registrar_ICON is not None, (
-            "Internal ICON registrar not created"
+    def test_registrar_initialization_default(self) -> None:
+        """Test that the default registration_method is RegisterImagesGreedy."""
+        registrar = RegisterTimeSeriesImages()
+        assert isinstance(registrar.registrar, RegisterImagesGreedy), (
+            "Default registrar should be RegisterImagesGreedy"
         )
 
-        print("\nTime series registrar initialized with Greedy_ICON")
+        print("\nTime series registrar defaults to RegisterImagesGreedy")
+
+    def test_registrar_initialization_Greedy_ICON(self) -> None:
+        """Initializes correctly with a RegisterImagesGreedyICON instance."""
+        registrar = RegisterTimeSeriesImages(
+            registration_method=RegisterImagesGreedyICON()
+        )
+        assert registrar is not None, "Registrar not initialized"
+        assert isinstance(registrar.registrar, RegisterImagesGreedyICON), (
+            "Method not set correctly"
+        )
+
+        print("\nTime series registrar initialized with RegisterImagesGreedyICON")
 
     def test_registrar_initialization_ICON(self) -> None:
-        """Test that RegisterTimeSeriesImages initializes correctly with ICON."""
-        registrar = RegisterTimeSeriesImages(registration_method="ICON")
+        """RegisterTimeSeriesImages initializes correctly with RegisterImagesICON."""
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesICON())
         assert registrar is not None, "Registrar not initialized"
-        assert registrar.registration_method_name == "ICON", "Method not set correctly"
-        assert registrar.registrar_greedy is not None, (
-            "Internal Greedy registrar not created"
-        )
-        assert registrar.registrar_ICON is not None, (
-            "Internal ICON registrar not created"
-        )
-
-        print("\nTime series registrar initialized with ICON")
-
-    def test_registrar_initialization_greedy(self) -> None:
-        """Test that RegisterTimeSeriesImages initializes correctly with Greedy."""
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
-        assert registrar is not None, "Registrar not initialized"
-        assert registrar.registration_method_name == "Greedy", (
+        assert isinstance(registrar.registrar, RegisterImagesICON), (
             "Method not set correctly"
         )
-        assert registrar.registrar_greedy is not None, (
-            "Internal Greedy registrar not created"
-        )
-        assert registrar.registrar_ICON is not None, (
-            "Internal ICON registrar not created"
+
+        print("\nTime series registrar initialized with RegisterImagesICON")
+
+    def test_registrar_initialization_greedy(self) -> None:
+        """RegisterTimeSeriesImages initializes correctly with RegisterImagesGreedy."""
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
+        assert registrar is not None, "Registrar not initialized"
+        assert isinstance(registrar.registrar, RegisterImagesGreedy), (
+            "Method not set correctly"
         )
 
-        print("\nTime series registrar initialized with Greedy")
+        print("\nTime series registrar initialized with RegisterImagesGreedy")
 
     def test_registrar_initialization_invalid_method(self) -> None:
-        """Test that invalid registration method raises error."""
-        with pytest.raises(ValueError, match="registration_method must be"):
-            RegisterTimeSeriesImages(registration_method="invalid")
+        """Test that a non-RegisterImagesBase registration method raises TypeError."""
+        with pytest.raises(
+            TypeError, match="registration_method must be a RegisterImagesBase"
+        ):
+            invalid_method: Any = "invalid"
+            RegisterTimeSeriesImages(registration_method=invalid_method)
 
         print("\nInvalid method correctly rejected")
 
     def test_set_modality(self) -> None:
         """Test setting imaging modality."""
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
         registrar.set_modality("ct")
         assert registrar.modality == "ct", "Modality not set correctly"
 
@@ -89,7 +90,7 @@ class TestRegisterTimeSeriesImages:
 
     def test_set_fixed_image(self, test_images: list[Any]) -> None:
         """Test setting fixed image."""
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
         fixed_image = test_images[0]
 
         registrar.set_fixed_image(fixed_image)
@@ -99,30 +100,25 @@ class TestRegisterTimeSeriesImages:
         print(f"  Image size: {itk.size(registrar.fixed_image)}")
 
     def test_set_number_of_iterations(self) -> None:
-        """Test setting number of iterations."""
-        registrar_Greedy_ICON = RegisterTimeSeriesImages(
-            registration_method="Greedy_ICON"
+        """Test setting number of iterations on the underlying registrar(s)."""
+        greedy_icon = RegisterImagesGreedyICON()
+        iterations_greedy_icon = [30, 15, 5]
+        greedy_icon.greedy.set_number_of_iterations(iterations_greedy_icon)
+        assert greedy_icon.greedy.number_of_iterations == iterations_greedy_icon, (
+            "Greedy_ICON iterations not set correctly"
         )
-        iterations_Greedy_ICON = [30, 15, 5]
 
-        registrar_Greedy_ICON.set_number_of_iterations_greedy(iterations_Greedy_ICON)
-        assert (
-            registrar_Greedy_ICON.number_of_iterations_greedy == iterations_Greedy_ICON
-        ), "Greedy_ICON iterations not set correctly"
-
-        registrar_greedy = RegisterTimeSeriesImages(registration_method="Greedy")
+        greedy = RegisterImagesGreedy()
         iterations_greedy = [25, 10, 3]
-
-        registrar_greedy.set_number_of_iterations_greedy(iterations_greedy)
-        assert registrar_greedy.number_of_iterations_greedy == iterations_greedy, (
+        greedy.set_number_of_iterations(iterations_greedy)
+        assert greedy.number_of_iterations == iterations_greedy, (
             "Greedy iterations not set correctly"
         )
 
-        registrar_ICON = RegisterTimeSeriesImages(registration_method="ICON")
-        iterations_ICON = 50
-
-        registrar_ICON.set_number_of_iterations_ICON(iterations_ICON)
-        assert registrar_ICON.number_of_iterations_ICON == iterations_ICON, (
+        icon = RegisterImagesICON()
+        iterations_icon = 50
+        icon.set_number_of_iterations(iterations_icon)
+        assert icon.number_of_iterations == iterations_icon, (
             "ICON iterations not set correctly"
         )
 
@@ -140,10 +136,11 @@ class TestRegisterTimeSeriesImages:
         print(f"  Fixed image: {itk.size(fixed_image)}")
         print(f"  Number of moving images: {len(moving_images)}")
 
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        greedy = RegisterImagesGreedy()
+        greedy.set_number_of_iterations([20, 10, 2])
+        registrar = RegisterTimeSeriesImages(registration_method=greedy)
         registrar.set_modality("ct")
         registrar.set_fixed_image(fixed_image)
-        registrar.set_number_of_iterations_greedy([20, 10, 2])
 
         result = registrar.register_time_series(
             moving_images=moving_images,
@@ -221,10 +218,11 @@ class TestRegisterTimeSeriesImages:
         print(f"  Number of moving images: {len(moving_images)}")
         print("  Using prior transform weight: 0.5")
 
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        greedy = RegisterImagesGreedy()
+        greedy.set_number_of_iterations([20, 10, 2])
+        registrar = RegisterTimeSeriesImages(registration_method=greedy)
         registrar.set_modality("ct")
         registrar.set_fixed_image(fixed_image)
-        registrar.set_number_of_iterations_greedy([20, 10, 2])
 
         result = registrar.register_time_series(
             moving_images=moving_images,
@@ -278,10 +276,11 @@ class TestRegisterTimeSeriesImages:
 
         print("\nRegistering time series (identity start)...")
 
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        greedy = RegisterImagesGreedy()
+        greedy.set_number_of_iterations([20, 10, 2])
+        registrar = RegisterTimeSeriesImages(registration_method=greedy)
         registrar.set_modality("ct")
         registrar.set_fixed_image(fixed_image)
-        registrar.set_number_of_iterations_greedy([20, 10, 2])
 
         result = registrar.register_time_series(
             moving_images=moving_images,
@@ -306,10 +305,11 @@ class TestRegisterTimeSeriesImages:
 
         print("\nTesting different starting indices...")
 
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        greedy = RegisterImagesGreedy()
+        greedy.set_number_of_iterations([10, 5, 1])
+        registrar = RegisterTimeSeriesImages(registration_method=greedy)
         registrar.set_modality("ct")
         registrar.set_fixed_image(fixed_image)
-        registrar.set_number_of_iterations_greedy([10, 5, 1])
 
         # Test starting from beginning, middle, and end
         for starting_index in [0, 1]:
@@ -329,7 +329,7 @@ class TestRegisterTimeSeriesImages:
 
     def test_register_time_series_error_no_fixed_image(self) -> None:
         """Test that error is raised if fixed image not set."""
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
 
         moving_images = [None, None, None]  # Dummy list
 
@@ -342,7 +342,7 @@ class TestRegisterTimeSeriesImages:
         self, test_images: list[Any]
     ) -> None:
         """Test that error is raised for invalid starting index."""
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
         registrar.set_fixed_image(test_images[0])
 
         moving_images = test_images[1:4]
@@ -365,7 +365,7 @@ class TestRegisterTimeSeriesImages:
         self, test_images: list[Any]
     ) -> None:
         """Test that error is raised for invalid prior portion value."""
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
         registrar.set_fixed_image(test_images[0])
 
         moving_images = test_images[1:4]
@@ -395,10 +395,11 @@ class TestRegisterTimeSeriesImages:
 
         print("\nTesting transform application...")
 
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        greedy = RegisterImagesGreedy()
+        greedy.set_number_of_iterations([20, 10, 2])
+        registrar = RegisterTimeSeriesImages(registration_method=greedy)
         registrar.set_modality("ct")
         registrar.set_fixed_image(fixed_image)
-        registrar.set_number_of_iterations_greedy([20, 10, 2])
 
         result = registrar.register_time_series(
             moving_images=moving_images,
@@ -445,10 +446,11 @@ class TestRegisterTimeSeriesImages:
 
         print("\nTesting time series registration with ICON...")
 
-        registrar = RegisterTimeSeriesImages(registration_method="ICON")
+        icon = RegisterImagesICON()
+        icon.set_number_of_iterations(5)  # ICON uses single int
+        registrar = RegisterTimeSeriesImages(registration_method=icon)
         registrar.set_modality("ct")
         registrar.set_fixed_image(fixed_image)
-        registrar.set_number_of_iterations_ICON(5)  # ICON uses single int
 
         result = registrar.register_time_series(
             moving_images=moving_images,
@@ -491,11 +493,12 @@ class TestRegisterTimeSeriesImages:
         print("\nTesting time series registration with mask...")
         print(f"  Mask voxels: {np.sum(fixed_mask_arr)}")
 
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        greedy = RegisterImagesGreedy()
+        greedy.set_number_of_iterations([20, 10, 2])
+        registrar = RegisterTimeSeriesImages(registration_method=greedy)
         registrar.set_modality("ct")
         registrar.set_fixed_image(fixed_image)
         registrar.set_fixed_mask(fixed_mask)
-        registrar.set_number_of_iterations_greedy([20, 10, 2])
 
         result = registrar.register_time_series(
             moving_images=moving_images,
@@ -517,10 +520,11 @@ class TestRegisterTimeSeriesImages:
         print(f"  Total images: {len(moving_images)}")
         print("  Starting from middle (index 2)")
 
-        registrar = RegisterTimeSeriesImages(registration_method="Greedy")
+        greedy = RegisterImagesGreedy()
+        greedy.set_number_of_iterations([20, 10, 2])
+        registrar = RegisterTimeSeriesImages(registration_method=greedy)
         registrar.set_modality("ct")
         registrar.set_fixed_image(fixed_image)
-        registrar.set_number_of_iterations_greedy([20, 10, 2])
 
         result = registrar.register_time_series(
             moving_images=moving_images,

--- a/tests/test_segment_heart_simpleware_trimmed_branches.py
+++ b/tests/test_segment_heart_simpleware_trimmed_branches.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+"""
+Tests for SegmentHeartSimplewareTrimmedBranches.
+
+trim_branches() itself is pure ITK/numpy post-processing on an
+already-produced labelmap - it never touches Simpleware - so it is tested
+unmarked, by default, with a small synthetic labelmap. The end-to-end
+regression test (moving the code out of SegmentHeartSimpleware must not
+change its behavior) requires Simpleware Medical with ASCardio, matching
+tests/test_segment_heart_simpleware.py's gating.
+"""
+
+import os
+
+import itk
+import numpy as np
+import pytest
+
+from physiomotion4d.segment_heart_simpleware import SegmentHeartSimpleware
+from physiomotion4d.segment_heart_simpleware_trimmed_branches import (
+    SegmentHeartSimplewareTrimmedBranches,
+)
+
+
+def _simpleware_available(segmenter: SegmentHeartSimpleware) -> bool:
+    """Return True if Simpleware Medical executable and script exist."""
+    return os.path.exists(segmenter.simpleware_exe_path) and os.path.exists(
+        segmenter.simpleware_script_path
+    )
+
+
+def _synthetic_heart_labelmap() -> itk.Image:
+    """Small synthetic labelmap, shape (Z, Y, X) = (32, 32, 32), with a
+    solid block of each ASCardio label (1=LV, 2=RV, 3=LA, 4=RA, 5=myocardium,
+    6=heart) so trim_branches() has non-trivial connected components to
+    operate on."""
+    arr = np.zeros((32, 32, 32), dtype=np.uint8)
+    arr[4:12, 4:12, 4:12] = 1  # left_ventricle
+    arr[4:12, 4:12, 12:20] = 2  # right_ventricle
+    arr[12:20, 4:12, 4:12] = 3  # left_atrium
+    arr[12:20, 4:12, 12:20] = 4  # right_atrium
+    arr[4:20, 12:20, 4:20] = 5  # myocardium
+    arr[20:28, 20:28, 20:28] = 6  # heart
+    image = itk.image_from_array(arr)
+    image.SetSpacing([1.0, 1.0, 1.0])
+    return image
+
+
+def test_trim_branches_runs_on_synthetic_labelmap() -> None:
+    """trim_branches() is pure post-processing - it must run without
+    Simpleware and return a labelmap matching the input's geometry."""
+    segmenter = SegmentHeartSimplewareTrimmedBranches()
+    labelmap = _synthetic_heart_labelmap()
+
+    trimmed = segmenter.trim_branches(labelmap)
+
+    assert itk.size(trimmed) == itk.size(labelmap)
+    trimmed_arr = itk.array_from_image(trimmed)
+    # trim_branches() only redistributes the existing heart labels (1, 5, 6)
+    # and the largest connected component of 3/4; it must not invent labels
+    # outside the ASCardio heart label set.
+    assert set(np.unique(trimmed_arr)) <= {0, 1, 2, 3, 4, 5, 6}
+
+
+@pytest.mark.requires_gpu
+@pytest.mark.requires_simpleware
+@pytest.mark.slow
+def test_segment_trims_branches_relative_to_plain_segmenter(
+    test_images: list,
+) -> None:
+    """SegmentHeartSimplewareTrimmedBranches().segment(...) must actually
+    apply trimming: its output should differ from the untrimmed
+    SegmentHeartSimpleware().segment(...) output on the same input, while
+    both remain valid labelmaps of the same size.
+
+    Note: this does not assert bit-exact equivalence to a manually
+    reconstructed "trim after the fact" pipeline, because trim_branches()
+    runs on the raw Simpleware output *before* postprocess_labelmap()'s
+    resampling - applying it after resampling instead would not be
+    equivalent. The trim_branches()-correctness itself is covered by
+    test_trim_branches_runs_on_synthetic_labelmap above; this test only
+    confirms the subclass's segmentation_method() actually invokes it as
+    part of segment()'s pipeline.
+    """
+    plain = SegmentHeartSimpleware()
+    if not _simpleware_available(plain):
+        pytest.skip(
+            "Simpleware Medical not found (executable or script). "
+            "Install Simpleware Medical with ASCardio to run this test."
+        )
+
+    input_image = test_images[3]
+
+    plain_result = plain.segment(input_image, contrast_enhanced_study=True)
+    trimmed_result = SegmentHeartSimplewareTrimmedBranches().segment(
+        input_image, contrast_enhanced_study=True
+    )
+
+    plain_labelmap = plain_result["labelmap"]
+    trimmed_labelmap = trimmed_result["labelmap"]
+    assert itk.size(trimmed_labelmap) == itk.size(plain_labelmap)
+    assert not np.array_equal(
+        itk.array_from_image(plain_labelmap), itk.array_from_image(trimmed_labelmap)
+    ), "Trimming should change the labelmap relative to the untrimmed segmenter"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_segment_heart_simpleware_trimmed_branches.py
+++ b/tests/test_segment_heart_simpleware_trimmed_branches.py
@@ -2,15 +2,17 @@
 """
 Tests for SegmentHeartSimplewareTrimmedBranches.
 
-trim_branches() itself is pure ITK/numpy post-processing on an
-already-produced labelmap - it never touches Simpleware - so it is tested
-unmarked, by default, with a small synthetic labelmap. The end-to-end
-regression test (moving the code out of SegmentHeartSimpleware must not
-change its behavior) requires Simpleware Medical with ASCardio, matching
-tests/test_segment_heart_simpleware.py's gating.
+Structural tests (subclass identity, method placement) run everywhere,
+including the Python 3.11 baseline. Tests that actually execute
+trim_branches() are gated behind Python >= 3.12: trim_branches() uses
+itk.TubeTK's SegmentConnectedComponents, whose native module segfaults
+when loaded under CPython 3.11 (it is stable on 3.12+). The end-to-end
+segmentation test additionally requires Simpleware Medical with ASCardio,
+matching tests/test_segment_heart_simpleware.py's gating.
 """
 
 import os
+import sys
 
 import itk
 import numpy as np
@@ -19,6 +21,16 @@ import pytest
 from physiomotion4d.segment_heart_simpleware import SegmentHeartSimpleware
 from physiomotion4d.segment_heart_simpleware_trimmed_branches import (
     SegmentHeartSimplewareTrimmedBranches,
+)
+
+# itk.TubeTK's SegmentConnectedComponents (used by trim_branches) segfaults
+# when its native module loads under CPython 3.11; it is stable on 3.12+.
+# A skipped segfault-guard is the only option here - a C-level segfault
+# cannot be caught with try/except, so any test that reaches TubeTK on 3.11
+# would crash the whole pytest process.
+_tubetk_segfaults_on_this_python = sys.version_info < (3, 12)
+_TUBETK_SKIP_REASON = (
+    "itk.TubeTK SegmentConnectedComponents segfaults on CPython < 3.12"
 )
 
 
@@ -46,6 +58,18 @@ def _synthetic_heart_labelmap() -> itk.Image:
     return image
 
 
+def test_subclass_owns_trim_branches() -> None:
+    """SegmentHeartSimplewareTrimmedBranches is a SegmentHeartSimpleware that
+    owns trim_branches(); the base class no longer defines trim_branches() or
+    set_trim_branches(). This runs on every supported Python (no TubeTK)."""
+    segmenter = SegmentHeartSimplewareTrimmedBranches()
+    assert isinstance(segmenter, SegmentHeartSimpleware)
+    assert hasattr(segmenter, "trim_branches")
+    assert not hasattr(SegmentHeartSimpleware, "trim_branches")
+    assert not hasattr(SegmentHeartSimpleware, "set_trim_branches")
+
+
+@pytest.mark.skipif(_tubetk_segfaults_on_this_python, reason=_TUBETK_SKIP_REASON)
 def test_trim_branches_runs_on_synthetic_labelmap() -> None:
     """trim_branches() is pure post-processing - it must run without
     Simpleware and return a labelmap matching the input's geometry."""
@@ -65,6 +89,7 @@ def test_trim_branches_runs_on_synthetic_labelmap() -> None:
 @pytest.mark.requires_gpu
 @pytest.mark.requires_simpleware
 @pytest.mark.slow
+@pytest.mark.skipif(_tubetk_segfaults_on_this_python, reason=_TUBETK_SKIP_REASON)
 def test_segment_trims_branches_relative_to_plain_segmenter(
     test_images: list,
 ) -> None:

--- a/tests/test_vtk_to_usd_library.py
+++ b/tests/test_vtk_to_usd_library.py
@@ -159,7 +159,13 @@ class TestFromFilesValidation:
                 "OpenGL context"
             )
 
-        tt = TestTools(class_name="openusd", results_dir=tmp_path)
+        # mypy runs on Windows in this repo (no python_platform override), so
+        # it statically infers the `sys.platform == "win32"` branch above as
+        # always-taken and flags this line as unreachable; on the Linux CI
+        # runner (or any non-Windows dev machine) it is reachable.
+        tt = TestTools(  # type: ignore[unreachable]
+            class_name="openusd", results_dir=tmp_path
+        )
         screenshot = tt.save_screenshot_openusd(usd_path, "triangle.png")
 
         assert screenshot.exists()

--- a/tests/test_workflow_convert_image_to_usd.py
+++ b/tests/test_workflow_convert_image_to_usd.py
@@ -6,9 +6,72 @@ import logging
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from physiomotion4d.physiomotion4d_base import PhysioMotion4DBase
+from physiomotion4d.register_images_base import RegisterImagesBase
+from physiomotion4d.register_images_icon import RegisterImagesICON
+from physiomotion4d.segment_chest_total_segmentator import SegmentChestTotalSegmentator
 from physiomotion4d.workflow_convert_image_to_usd import WorkflowConvertImageToUSD
 import physiomotion4d.workflow_convert_image_to_usd as workflow_module
+
+
+def _make_workflow(**overrides: Any) -> WorkflowConvertImageToUSD:
+    """Construct a WorkflowConvertImageToUSD with minimal required args,
+    overridable via keyword (e.g. segmentation_method=..., output_directory=...)."""
+    kwargs: dict[str, Any] = {
+        "input_filenames": ["input.nrrd"],
+        "contrast_enhanced": False,
+        "output_directory": str(overrides.pop("output_directory", "results")),
+        "project_name": "patient",
+        "log_level": logging.CRITICAL,
+    }
+    kwargs.update(overrides)
+    return WorkflowConvertImageToUSD(**kwargs)
+
+
+def test_default_segmentation_and_registration_methods(tmp_path: Path) -> None:
+    """Omitting segmentation_method/registration_method defaults to
+    SegmentChestTotalSegmentator (contrast_threshold=500) and
+    RegisterImagesICON, matching this workflow's historical string defaults."""
+    workflow = _make_workflow(output_directory=tmp_path)
+
+    assert isinstance(workflow.segmenter, SegmentChestTotalSegmentator)
+    assert workflow.segmenter.contrast_threshold == 500
+    assert isinstance(workflow.registrar, RegisterImagesICON)
+
+
+def test_segmentation_method_rejects_wrong_type(tmp_path: Path) -> None:
+    """A non-SegmentAnatomyBase segmentation_method raises TypeError."""
+    with pytest.raises(TypeError, match="segmentation_method must be"):
+        _make_workflow(
+            output_directory=tmp_path, segmentation_method="ChestTotalSegmentator"
+        )
+
+
+def test_registration_method_rejects_wrong_type(tmp_path: Path) -> None:
+    """A non-RegisterImagesBase registration_method raises TypeError."""
+    with pytest.raises(TypeError, match="registration_method must be"):
+        _make_workflow(output_directory=tmp_path, registration_method="ICON")
+
+
+def test_caller_supplied_instances_are_used_as_is(tmp_path: Path) -> None:
+    """A caller-supplied segmenter/registrar instance is stored unmodified
+    (beyond the documented shared setters): the workflow must not apply its
+    default-only contrast_threshold=500 tuning to a caller-supplied segmenter."""
+    segmenter = SegmentChestTotalSegmentator()
+    original_contrast_threshold = segmenter.contrast_threshold
+    registrar: RegisterImagesBase = RegisterImagesICON()
+
+    workflow = _make_workflow(
+        output_directory=tmp_path,
+        segmentation_method=segmenter,
+        registration_method=registrar,
+    )
+
+    assert workflow.segmenter is segmenter
+    assert workflow.registrar is registrar
+    assert workflow.segmenter.contrast_threshold == original_contrast_threshold
 
 
 def test_create_usd_files_passes_times_per_second(
@@ -62,7 +125,8 @@ def test_create_usd_files_passes_times_per_second(
     )
     workflow.project_name = "patient"
     workflow.output_directory = str(tmp_path)
-    workflow.segmenter = FakeSegmenter()
+    # FakeSegmenter is a minimal test double, not a real SegmentAnatomyBase.
+    workflow.segmenter = FakeSegmenter()  # type: ignore[assignment]
     workflow.times_per_second = 12.5
     workflow._transformed_contours = {
         "all": [],

--- a/tests/test_workflow_convert_image_to_vtk.py
+++ b/tests/test_workflow_convert_image_to_vtk.py
@@ -1,0 +1,32 @@
+"""Tests for the image-to-VTK workflow's instance-based segmentation_method API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from physiomotion4d.segment_chest_total_segmentator import SegmentChestTotalSegmentator
+from physiomotion4d.segment_heart_simpleware import SegmentHeartSimpleware
+from physiomotion4d.workflow_convert_image_to_vtk import WorkflowConvertImageToVTK
+
+
+def test_default_segmentation_method_is_chest_total_segmentator() -> None:
+    """Omitting segmentation_method defaults to SegmentChestTotalSegmentator,
+    matching this workflow's historical string default."""
+    workflow = WorkflowConvertImageToVTK()
+    assert isinstance(workflow._segmenter, SegmentChestTotalSegmentator)
+
+
+def test_segmentation_method_rejects_wrong_type() -> None:
+    """A non-SegmentAnatomyBase segmentation_method raises TypeError."""
+    invalid_method: Any = "ChestTotalSegmentator"
+    with pytest.raises(TypeError, match="segmentation_method must be"):
+        WorkflowConvertImageToVTK(segmentation_method=invalid_method)
+
+
+def test_caller_supplied_instance_is_used_as_is() -> None:
+    """A caller-supplied segmenter instance is stored unmodified."""
+    segmenter = SegmentHeartSimpleware()
+    workflow = WorkflowConvertImageToVTK(segmentation_method=segmenter)
+    assert workflow._segmenter is segmenter

--- a/tests/test_workflow_fine_tune_icon_registration.py
+++ b/tests/test_workflow_fine_tune_icon_registration.py
@@ -79,7 +79,7 @@ def two_subject_dataset(tmp_path: Path) -> dict[str, Any]:
 def test_init_requires_output_dir_and_name(tmp_path: Path) -> None:
     """output_dir and fine_tune_name are required positional args."""
     with pytest.raises(TypeError):
-        WorkflowFineTuneICONRegistration(
+        WorkflowFineTuneICONRegistration(  # type: ignore[call-arg]
             subject_image_files=[["a.nii.gz"]],
         )
 

--- a/tests/test_workflow_fit_statistical_model_to_patient.py
+++ b/tests/test_workflow_fit_statistical_model_to_patient.py
@@ -10,6 +10,9 @@ import numpy as np
 import pyvista as pv
 
 from physiomotion4d.segment_heart_simpleware import SegmentHeartSimpleware
+from physiomotion4d.segment_heart_simpleware_trimmed_branches import (
+    SegmentHeartSimplewareTrimmedBranches,
+)
 from physiomotion4d.workflow_convert_image_to_vtk import WorkflowConvertImageToVTK
 from physiomotion4d.workflow_fit_statistical_model_to_patient import (
     WorkflowFitStatisticalModelToPatient,
@@ -49,20 +52,25 @@ def test_transform_model_applies_staged_transform() -> None:
 
 
 def test_fit_workflow_default_segmentation_method_is_trimmed_branches() -> None:
-    """Default segmentation_method must match the KCL-Heart-Model fit contract."""
+    """Default segmentation_method is None; see
+    test_fit_workflow_routes_default_to_image_to_vtk_with_trimmed_branches for
+    confirmation that the None default resolves to
+    SegmentHeartSimplewareTrimmedBranches, matching the KCL-Heart-Model fit
+    contract."""
     default = (
         inspect.signature(WorkflowFitStatisticalModelToPatient.__init__)
         .parameters["segmentation_method"]
         .default
     )
-    assert default == "HeartSimplewareTrimmedBranches"
+    assert default is None
 
 
 def test_fit_workflow_routes_default_to_image_to_vtk_with_trimmed_branches(
     monkeypatch: Any,
 ) -> None:
     """When patient_models is omitted, the workflow must invoke
-    WorkflowConvertImageToVTK with segmentation_method='HeartSimplewareTrimmedBranches'."""
+    WorkflowConvertImageToVTK with a SegmentHeartSimplewareTrimmedBranches
+    instance."""
     image = itk.image_from_array(np.zeros((3, 3, 3), dtype=np.float32))
     template = pv.PolyData(
         np.array(
@@ -107,29 +115,30 @@ def test_fit_workflow_routes_default_to_image_to_vtk_with_trimmed_branches(
         patient_image=image,
     )
 
-    assert captured["init_kwargs"]["segmentation_method"] == (
-        "HeartSimplewareTrimmedBranches"
+    assert isinstance(
+        captured["init_kwargs"]["segmentation_method"],
+        SegmentHeartSimplewareTrimmedBranches,
     )
     assert captured["run_kwargs"]["anatomy_groups"] == ["heart"]
     assert captured["run_kwargs"]["contrast_enhanced_study"] is False
     assert workflow.patient_models == [heart_mesh]
 
 
-def test_image_to_vtk_segmenter_dispatch_for_trimmed_branches() -> None:
-    """WorkflowConvertImageToVTK('HeartSimplewareTrimmedBranches') must
-    instantiate SegmentHeartSimpleware with branch trimming enabled, while
-    'HeartSimpleware' must leave it disabled."""
+def test_image_to_vtk_segmenter_uses_supplied_instance() -> None:
+    """WorkflowConvertImageToVTK must use whatever segmenter instance it's
+    given as-is: a SegmentHeartSimplewareTrimmedBranches instance stays a
+    SegmentHeartSimplewareTrimmedBranches, and a plain SegmentHeartSimpleware
+    instance stays a SegmentHeartSimpleware (not upgraded to the trimmed
+    subclass)."""
     trimmed = WorkflowConvertImageToVTK(
-        segmentation_method="HeartSimplewareTrimmedBranches"
-    )._create_segmenter()
-    assert isinstance(trimmed, SegmentHeartSimpleware)
-    assert trimmed._trim_branches is True
+        segmentation_method=SegmentHeartSimplewareTrimmedBranches()
+    )._segmenter
+    assert isinstance(trimmed, SegmentHeartSimplewareTrimmedBranches)
 
-    plain = WorkflowConvertImageToVTK(
-        segmentation_method="HeartSimpleware"
-    )._create_segmenter()
-    assert isinstance(plain, SegmentHeartSimpleware)
-    assert plain._trim_branches is False
+    plain_instance = SegmentHeartSimpleware()
+    plain = WorkflowConvertImageToVTK(segmentation_method=plain_instance)._segmenter
+    assert plain is plain_instance
+    assert not isinstance(plain, SegmentHeartSimplewareTrimmedBranches)
 
 
 def test_transform_model_preserves_unstructured_grid_topology() -> None:

--- a/tests/test_workflow_reconstruct_highres_4d_ct.py
+++ b/tests/test_workflow_reconstruct_highres_4d_ct.py
@@ -1,0 +1,51 @@
+"""Tests for the high-resolution 4D CT reconstruction workflow's
+instance-based registration_method API."""
+
+from __future__ import annotations
+
+import numpy as np
+import itk
+import pytest
+
+from physiomotion4d.register_images_base import RegisterImagesBase
+from physiomotion4d.register_images_greedy_icon import RegisterImagesGreedyICON
+from physiomotion4d.register_images_icon import RegisterImagesICON
+from physiomotion4d.workflow_reconstruct_highres_4d_ct import (
+    WorkflowReconstructHighres4DCT,
+)
+
+
+def _small_image() -> itk.Image:
+    """A tiny synthetic image, shape (Z, Y, X) = (3, 3, 3)."""
+    return itk.image_from_array(np.zeros((3, 3, 3), dtype=np.float32))
+
+
+def test_default_registration_method_is_greedy_icon() -> None:
+    """Omitting registration_method defaults to RegisterImagesGreedyICON,
+    matching this workflow's historical 'Greedy_ICON' string default."""
+    workflow = WorkflowReconstructHighres4DCT(
+        time_series_images=[_small_image(), _small_image()],
+        fixed_image=_small_image(),
+    )
+    assert isinstance(workflow.registrar.registrar, RegisterImagesGreedyICON)
+
+
+def test_registration_method_rejects_wrong_type() -> None:
+    """A non-RegisterImagesBase registration_method raises TypeError."""
+    with pytest.raises(TypeError, match="registration_method must be"):
+        WorkflowReconstructHighres4DCT(
+            time_series_images=[_small_image(), _small_image()],
+            fixed_image=_small_image(),
+            registration_method="ICON",  # type: ignore[arg-type]
+        )
+
+
+def test_caller_supplied_instance_is_used_as_is() -> None:
+    """A caller-supplied registration_method instance is stored unmodified."""
+    registrar: RegisterImagesBase = RegisterImagesICON()
+    workflow = WorkflowReconstructHighres4DCT(
+        time_series_images=[_small_image(), _small_image()],
+        fixed_image=_small_image(),
+        registration_method=registrar,
+    )
+    assert workflow.registrar.registrar is registrar

--- a/tutorials/tutorial_01_heart_gated_ct_to_usd.py
+++ b/tutorials/tutorial_01_heart_gated_ct_to_usd.py
@@ -36,8 +36,9 @@ Strengths
 
 Weaknesses / Limitations
 ------------------------
-- Requires a GPU for ICON registration (``registration_method='ICON'``); use
-  ``registration_method='Greedy'`` for CPU-only environments (about 10x slower).
+- Requires a GPU for ICON registration (``registration_method=RegisterImagesICON()``);
+  use ``registration_method=RegisterImagesGreedy()`` for CPU-only environments
+  (about 10x slower).
 - Segmentation quality depends on TotalSegmentator's training distribution;
   unusual pathologies or pediatric anatomy may degrade results.
 - Large 4D datasets (>20 phases, high resolution) can require 32 GB+ RAM.
@@ -74,6 +75,7 @@ from pathlib import Path
 
 import itk
 
+from physiomotion4d.register_images_icon import RegisterImagesICON
 from physiomotion4d.test_tools import TestTools
 from physiomotion4d.workflow_convert_image_to_usd import (
     WorkflowConvertImageToUSD,
@@ -93,7 +95,6 @@ if __name__ == "__main__":
     FULL_DATA_DIR = DATA_DIR / "Slicer-Heart-CT"
     TEST_DATA_DIR = DATA_DIR / "test" / "slicer_heart_small"
     OUTPUT_DIR = TUTORIALS_DIR / "output" / "tutorial_01"
-    REGISTRATION_METHOD = "ICON"
     LOG_LEVEL = logging.INFO
 
     # %%
@@ -102,7 +103,6 @@ if __name__ == "__main__":
 
     data_dir = TEST_DATA_DIR if test_mode else FULL_DATA_DIR
     output_dir = OUTPUT_DIR
-    registration_method = REGISTRATION_METHOD
     log_level = LOG_LEVEL
 
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -111,6 +111,9 @@ if __name__ == "__main__":
         number_of_registration_iterations = 1
     else:
         number_of_registration_iterations = 10
+
+    registration_method = RegisterImagesICON(log_level=log_level)
+    registration_method.set_number_of_iterations(number_of_registration_iterations)
 
     # %%
     frame_files = sorted(data_dir.glob("slice_???.mha"))
@@ -134,7 +137,6 @@ if __name__ == "__main__":
         output_directory=str(output_dir),
         project_name="cardiac_model",
         registration_method=registration_method,
-        number_of_registration_iterations=number_of_registration_iterations,
         log_level=log_level,
         save_registered_images=True,
         save_registration_transforms=True,

--- a/tutorials/tutorial_02_ct_to_vtk.py
+++ b/tutorials/tutorial_02_ct_to_vtk.py
@@ -23,6 +23,9 @@ from pathlib import Path
 import itk
 import pyvista as pv
 
+from physiomotion4d.segment_chest_total_segmentator import (
+    SegmentChestTotalSegmentator,
+)
 from physiomotion4d.test_tools import TestTools
 from physiomotion4d.workflow_convert_image_to_vtk import WorkflowConvertImageToVTK
 
@@ -68,7 +71,7 @@ if __name__ == "__main__":
     # %%
     # Workflow initialization
     workflow = WorkflowConvertImageToVTK(
-        segmentation_method="ChestTotalSegmentator",
+        segmentation_method=SegmentChestTotalSegmentator(log_level=log_level),
         log_level=log_level,
     )
 

--- a/tutorials/tutorial_06_reconstruct_highres_4d_ct.py
+++ b/tutorials/tutorial_06_reconstruct_highres_4d_ct.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import itk
 
+from physiomotion4d.register_images_greedy_icon import RegisterImagesGreedyICON
 from physiomotion4d.test_tools import TestTools
 from physiomotion4d.workflow_reconstruct_highres_4d_ct import (
     WorkflowReconstructHighres4DCT,
@@ -45,7 +46,6 @@ if __name__ == "__main__":
     OUTPUT_DIR = TUTORIALS_DIR / "output" / "tutorial_06"
     BASELINES_DIR = REPO_ROOT / "tests" / "baselines"
     MAX_FRAMES = 4
-    REGISTRATION_METHOD = "Greedy_ICON"
     LOG_LEVEL = logging.INFO
 
     # %%
@@ -54,7 +54,6 @@ if __name__ == "__main__":
 
     data_dir = TEST_DATA_DIR if test_mode else FULL_DATA_DIR
     output_dir = OUTPUT_DIR
-    registration_method = REGISTRATION_METHOD
     log_level = LOG_LEVEL
 
     if test_mode:
@@ -79,6 +78,8 @@ if __name__ == "__main__":
 
     # %%
     # Workflow initialization
+    registration_method = RegisterImagesGreedyICON(log_level=log_level)
+    registration_method.greedy.set_number_of_iterations(number_of_iterations_Greedy)
     workflow = WorkflowReconstructHighres4DCT(
         time_series_images=time_series,
         fixed_image=fixed_image,
@@ -87,7 +88,6 @@ if __name__ == "__main__":
         log_level=log_level,
     )
     workflow.set_modality("ct")
-    workflow.set_number_of_iterations_Greedy(number_of_iterations_Greedy)
 
     # %%
     # Workflow execution

--- a/tutorials/tutorial_08_cardiac_fit_model.py
+++ b/tutorials/tutorial_08_cardiac_fit_model.py
@@ -60,6 +60,7 @@ import pyvista as pv
 
 from physiomotion4d import (
     ContourTools,
+    RegisterImagesICON,
     TransformTools,
     WorkflowFitStatisticalModelToPatient,
     WorkflowReconstructHighres4DCT,
@@ -207,16 +208,15 @@ if __name__ == "__main__":
             time_series_ids.append(time_id)
 
         if RECOMPUTE:
+            icon_registration_method = RegisterImagesICON()
+            icon_registration_method.set_weights_path(str(ICON_WEIGHTS_PATH))
+            icon_registration_method.set_number_of_iterations(None)
             reg_workflow = WorkflowReconstructHighres4DCT(
                 time_series_images=time_series,
                 fixed_image=ref_image,
-                registration_method="ICON",
-            )
-            reg_workflow.registrar.registrar_ICON.set_weights_path(
-                str(ICON_WEIGHTS_PATH)
+                registration_method=icon_registration_method,
             )
             reg_workflow.set_modality("ct")
-            reg_workflow.set_number_of_iterations_ICON(None)
             reg_result = reg_workflow.run_workflow()
 
             reconstructed_images = reg_result["reconstructed_images"]


### PR DESCRIPTION
Workflows and RegisterTimeSeriesImages now take pre-constructed RegisterImagesBase / SegmentAnatomyBase instances instead of string identifiers. Callers configure backend-specific options (iteration counts, mass preservation, weights path, contrast threshold) on the instance; each workflow defaults to the instance matching its previous string default, so default behavior is unchanged.

New classes:
- RegisterImagesChain: run an ordered list of registrars in sequence, feeding each stage's forward_transform to the next as initial_forward_transform.
- RegisterImagesGreedyICON(RegisterImagesChain): named Greedy-then-ICON chain with .greedy/.icon stage accessors (replaces the "Greedy_ICON" string mode).
- SegmentHeartSimplewareTrimmedBranches(SegmentHeartSimpleware): moves the ~140-line trim_branches post-processing out of the flag-gated base class into a Template-Method subclass (replaces the "HeartSimplewareTrimmedBranches" string and set_trim_branches()).

RegisterImagesBase gains _delegate_to/_capture_delegate_result helpers so composite/delegating registrars can drive an inner registrar's registration_method() without re-preprocessing the fixed image or re-dilating an already-converted mask; each stage still computes its own intensity preprocessing (ICON vs. Greedy differ).

Removed: SEGMENTATION_METHODS/REGISTRATION_METHODS string tuples and their validation, WorkflowConvertImageToUSD.number_of_registration_iterations, RegisterTimeSeriesImages.set_number_of_iterations_greedy/_ICON and its registrar_greedy/registrar_ICON fields, WorkflowReconstructHighres4DCT's per-method iteration setters, and SegmentHeartSimpleware.set_trim_branches(). Passing a string now raises TypeError pointing at the instance-based API.

CLIs keep their string flags via a shared cli/_method_factories.py that maps names to configured instances; also fixes a pre-existing bug where --ICON-iterations was read as args.icon_iterations and silently ignored.

Updates tutorials 01/02/06/08, docs (.rst) + README examples, experiments, and tests (new coverage for the chain, greedy-icon, trimmed-branches, and the three workflows' default/type-guard behavior).

Also fixes 10 pre-existing mypy errors surfaced by strict checking, including a latent runtime crash in ImageTools.flip_image whose return annotation used `itk.Image | tuple[...]` (ITK SWIG types don't support `|`); switched to typing.Union with @overload signatures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chained registration backends, including Greedy-then-ICON.
  * Added a trimmed-heart Simpleware segmentation variant for improved cardiac region handling.
  * Updated CLI tools to construct segmentation/registration backends from supported options.
* **Documentation**
  * Updated quickstart, API docs, developer guides, tutorials, and examples to use instance-based backend configuration.
* **Breaking Changes**
  * Workflows/CLIs now expect pre-configured backend instances (not string identifiers); several old configuration methods/parameters were removed or replaced.
* **Tests**
  * Added/updated unit tests for chained registration, instance-based time-series registration, and the trimmed-heart segmenter.
* **Chores**
  * Refreshed CI action versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->