### PR TITLE
BUG: Avoid name collision when building docs on CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -125,9 +125,14 @@ jobs:
     - name: Upload artifact for Pages
       uses: actions/upload-pages-artifact@v5
       with:
+        # Per-attempt name: artifacts persist across re-run attempts, and
+        # deploy-pages fails if two artifacts share the same name.
+        name: github-pages-${{ github.run_attempt }}
         path: ./docs-html
-        
+
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v5
+      with:
+        artifact_name: github-pages-${{ github.run_attempt }}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation site deployment reliability by avoiding artifact name collisions when a workflow is re-run.
  * Pages deploys now use a run-attempt-specific artifact, reducing failed redeploys from previous attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->