### PR TITLE
ENH: Fix path to python for nightly health CI

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -58,7 +58,7 @@ jobs:
         # Python 3.11 is required because the [physicsnemo] extra pulls in
         # nvidia-physicsnemo, which requires Python >= 3.11.
         run: |
-          & py -3.11 -m venv "$env:RUNNER_TEMP\physiotwin4d-venv"
+          & "C:\Users\saylward\AppData\Local\Programs\Python\Python311\python.exe" -m venv "$env:RUNNER_TEMP\physiotwin4d-venv"
           echo "$env:RUNNER_TEMP\physiotwin4d-venv\Scripts" >> $env:GITHUB_PATH
 
       - name: Cache uv packages

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ htmlcov
 
 # AI files
 .claude
+graphify-out
 
 # Intermediate files produced by skills
 .github_review_prompt.txt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the nightly GPU Windows environment setup by explicitly selecting Python 3.11.
  * Prevented generated `graphify-out` files from appearing as untracked changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->