### PR TITLE
ENH: Update nightly runner to use a local install of python 3.13

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -55,10 +55,10 @@ jobs:
         run: nvidia-smi
 
       - name: Create venv in RUNNER_TEMP
-        # Python 3.11 is required because the [physicsnemo] extra pulls in
+        # Python 3.13 is required because the [physicsnemo] extra pulls in
         # nvidia-physicsnemo, which requires Python >= 3.11.
         run: |
-          & "C:\Users\saylward\AppData\Local\Programs\Python\Python311\python.exe" -m venv "$env:RUNNER_TEMP\physiotwin4d-venv"
+          & "C:\actions-runner\python-3.13.14-embed-amd64\python.exe" -m venv "$env:RUNNER_TEMP\physiotwin4d-venv"
           echo "$env:RUNNER_TEMP\physiotwin4d-venv\Scripts" >> $env:GITHUB_PATH
 
       - name: Cache uv packages
@@ -154,10 +154,10 @@ jobs:
         # Artifact may be absent if health-tests was cancelled before upload.
         continue-on-error: true
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Build dashboard
         run: |


### PR DESCRIPTION
Use an embedded python in the action directory on the remote machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly health checks and dashboard generation to run on Python 3.13.
  * Existing test execution, reports, dashboard creation, and status updates remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->