### PR TITLE
ENH: Clean-up docs and add lighting to USD stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 PhysioTwin4D typically begins with a 3D medical image of a subject, extracts anatomic models from that image, and then uses AI surrogates to estimate the subject's physiological processes — initially focusing on cardiac and respiratory motion, and expanding to electrophysiology, blood flow, and organ perfusion. The package provides methods for forming these physiological AI surrogates and for finetuning the segmentation and registration AI methods that power them, with special emphasis on statistical shape models: they capture subject-specific characteristics that help determine subject-specific physiological function, and establish correspondence across subjects to aid AI surrogate generalization and simplify the application of traditional solvers.
 
-> **Not validated for clinical use.** PhysioTwin4D is a research toolkit. It
-> is not a medical device and must not be used for diagnosis, treatment
-> planning, or clinical decision-making.
+PhysioTwin4D is not validated for clinical use. It is a research and
+visualization toolkit, not a medical device, and must not be used for
+diagnosis, treatment planning, or clinical decision-making.
 
 ## Documentation
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -338,24 +338,6 @@ dt.sig {
     z-index: 2;
 }
 
-.pt4d-clinical-notice {
-    margin: -3.5rem 0 2rem;
-    padding: 1rem 1.25rem;
-    position: relative;
-    z-index: 3;
-    color: #111111;
-    background: #fff7d1;
-    border: 2px solid #8a6500;
-    border-left: 6px solid #8a6500;
-    border-radius: 8px;
-    box-shadow: 0 12px 28px rgba(17, 17, 17, 0.14);
-}
-
-.pt4d-clinical-notice strong {
-    display: block;
-    margin-bottom: 0.25rem;
-}
-
 .pt4d-card,
 .pt4d-card:visited {
     display: flex;

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -8,11 +8,6 @@ personalized physiological digital twins from 3D medical images. Runtime
 workflow classes inherit from :class:`PhysioTwin4DBase` for logging and common
 runtime configuration.
 
-.. warning::
-
-   PhysioTwin4D {{ pt4d_project_version }} beta is not validated for clinical
-   use. It is a research and visualization toolkit, not a medical device.
-
 Data Flow
 =========
 

--- a/docs/cli_scripts/byod_tutorials.rst
+++ b/docs/cli_scripts/byod_tutorials.rst
@@ -287,7 +287,7 @@ Open **Omniverse USD Composer**, drag your ``.usd`` file onto the viewport,
 then press **Play** (spacebar) to watch the animation. For 4D cardiac data,
 use the **Timeline** panel to scrub through phases. Set the viewport renderer
 to RTX and switch to the scene's ``/World/Camera`` first —
-:doc:`../viewing_usd` covers both.
+:doc:`../viewing_usd` covers why both matter.
 
 See Also
 --------

--- a/docs/cli_scripts/byod_tutorials.rst
+++ b/docs/cli_scripts/byod_tutorials.rst
@@ -9,12 +9,6 @@ of 3D or 4D DICOM data, a single 3D or 4D file in a common medical image format
 such as MHA, NRRD, or NIfTI, or a list of 3D image files representing a time
 series. VTK inputs may be one mesh file or a mesh sequence.
 
-.. note::
-
-   PhysioTwin4D is a research tool and has **not** been validated for
-   clinical use. Outputs must not be used for diagnostic or therapeutic
-   decisions without independent validation.
-
 Installation
 ------------
 
@@ -291,8 +285,9 @@ support ``.usd``, ``.usda``, or ``.usdc`` output files directly.
 
 Open **Omniverse USD Composer**, drag your ``.usd`` file onto the viewport,
 then press **Play** (spacebar) to watch the animation. For 4D cardiac data,
-use the **Timeline** panel to scrub through phases. ``usdview`` works the same
-way and is lighter to install — :doc:`../viewing_usd` covers both.
+use the **Timeline** panel to scrub through phases. Set the viewport renderer
+to RTX and switch to the scene's ``/World/Camera`` first —
+:doc:`../viewing_usd` covers both.
 
 See Also
 --------

--- a/docs/cli_scripts/heart_gated_ct.rst
+++ b/docs/cli_scripts/heart_gated_ct.rst
@@ -329,11 +329,13 @@ Approximate times on typical workstation (32GB RAM, NVIDIA GPU):
 Viewing Results
 ===============
 
-1. Open the ``.usd`` file in ``usdview`` or an Omniverse Kit application
-2. Press Play to view the cardiac motion animation
-3. Adjust the timeline speed for the visualization you want
+1. Open the ``.usd`` file in an Omniverse Kit application, with the viewport
+   renderer set to RTX
+2. Switch the viewport to the scene's ``/World/Camera``
+3. Press Play to view the cardiac motion animation
+4. Adjust the timeline speed for the visualization you want
 
-:doc:`../viewing_usd` covers installing either viewer and what to look at once
+:doc:`../viewing_usd` covers installing the viewer and what to look at once
 the scene is open.
 
 Next Steps

--- a/docs/developer/usd_generation.rst
+++ b/docs/developer/usd_generation.rst
@@ -140,14 +140,18 @@ the source array in either ``point_data`` or ``cell_data`` and writes the
 scalar back to the same data dict so the convert step picks it up as a
 USD primvar.
 
-Framing Camera
---------------
+Framing Camera and Light
+------------------------
 
 Every USD stage that ``ConvertVTKToUSD`` (and the lower-level
 ``convert_vtk_file`` facade) writes gets a ``/World/Camera`` prim with a
 tight ``clippingRange`` sized to the geometry's bounding box. This avoids
 the common "Omniverse Kit near-plane clips small geometry" problem for
-medical-scale meshes (~0.03 m wide). The camera is also baked into stages
+medical-scale meshes (~0.03 m wide). Alongside it, ``add_framing_camera``
+authors a ``/World/DistantLight`` sharing the camera's transform — a
+DistantLight emits along its local -Z, the same direction the camera looks,
+so the anatomy is lit from the viewing direction in stages that carry no
+other light. The camera is also baked into stages
 produced by ``TransformTools.convert_transform_to_usd_visualization`` and
 ``USDTools.merge_usd_files``; the helper is idempotent so re-merging a USD
 that already has a Camera does not produce a duplicate transform op.

--- a/docs/developer/usd_generation.rst
+++ b/docs/developer/usd_generation.rst
@@ -151,7 +151,8 @@ medical-scale meshes (~0.03 m wide). Alongside it, ``add_framing_camera``
 authors a ``/World/DistantLight`` sharing the camera's transform — a
 DistantLight emits along its local -Z, the same direction the camera looks,
 so the anatomy is lit from the viewing direction in stages that carry no
-other light. The camera is also baked into stages
+other light. The light is created only when valid, non-degenerate bounds
+exist; otherwise no light is authored. The camera is also baked into stages
 produced by ``TransformTools.convert_transform_to_usd_visualization`` and
 ``USDTools.merge_usd_files``; the helper is idempotent so re-merging a USD
 that already has a Camera does not produce a duplicate transform op.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -26,11 +26,10 @@ What data formats are supported?
 Do I need NVIDIA Omniverse?
 ----------------------------
 
-No, Omniverse is optional for visualization. You can also use:
+Omniverse is the recommended way to view the USD scenes: its RTX renderer is
+what evaluates the material properties assigned to each tissue. See
+:doc:`viewing_usd`. For the intermediate results you can also use:
 
-* ``usdview``, the viewer that ships with OpenUSD — note that it is **not**
-  part of the ``usd-core`` package installed with PhysioTwin4D; see
-  :doc:`viewing_usd`
 * PyVista, for the intermediate ``.vtp`` / ``.vtu`` meshes
 * ParaView, likewise for the VTK files
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@
        PhysioTwin4D is a collection of methods, workflows, tutorials, and CLI
        tools for creating personalized physiological digital twins from 3D
        medical images. Install it, clone the repository for the tutorial
-       scripts, and work through the cards below â€” each tutorial runs on
+       scripts, and work through the cards below — each tutorial runs on
        downloadable data and ends with the constants to change for your own.
        It is not validated for clinical use: PhysioTwin4D is a research and
        visualization toolkit, not a medical device, and must not be used for
@@ -28,7 +28,7 @@
      <a class="pt4d-card" href="installation.html">
        <span class="pt4d-card__number">00</span>
        <h2>Install and Clone</h2>
-       <p>Install the package, then clone the repository â€” the tutorial scripts do not ship in the wheel.</p>
+       <p>Install the package, then clone the repository — the tutorial scripts do not ship in the wheel.</p>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-1-gated-4d-ct-to-animated-usd">
        <span class="pt4d-card__number">01</span>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,85 +14,71 @@
        PhysioTwin4D is a collection of methods, workflows, tutorials, and CLI
        tools for creating personalized physiological digital twins from 3D
        medical images. Install it, clone the repository for the tutorial
-       scripts, and work through the cards below — each tutorial runs on
+       scripts, and work through the cards below â€” each tutorial runs on
        downloadable data and ends with the constants to change for your own.
+       It is not validated for clinical use: PhysioTwin4D is a research and
+       visualization toolkit, not a medical device, and must not be used for
+       diagnosis, treatment planning, or clinical decision-making.
      </p>
 
      <p class="pt4d-hero__version">Version {{ pt4d_project_version }}</p>
    </section>
 
-   <div class="pt4d-clinical-notice">
-     <strong>Not validated for clinical use.</strong> PhysioTwin4D is a
-     research and visualization toolkit, not a medical device. Do not use it
-     for diagnosis, treatment planning, or clinical decision-making.
-   </div>
-
    <section class="pt4d-card-grid" aria-label="Tutorial cards">
      <a class="pt4d-card" href="installation.html">
        <span class="pt4d-card__number">00</span>
        <h2>Install and Clone</h2>
-       <p>Install the package, then clone the repository — the tutorial scripts do not ship in the wheel.</p>
-       <span class="pt4d-card__meta">Start here</span>
+       <p>Install the package, then clone the repository â€” the tutorial scripts do not ship in the wheel.</p>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-1-gated-4d-ct-to-animated-usd">
        <span class="pt4d-card__number">01</span>
        <h2>Gated 4D CT to Animated USD</h2>
        <p>Segment, register and assemble a 4D CT series into an animated OpenUSD scene.</p>
-       <span class="pt4d-card__meta">Slicer-Heart-CT &middot; DIR-Lab</span>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-2-finetune-icon-registration">
        <span class="pt4d-card__number">02</span>
        <h2>Finetune ICON Registration</h2>
        <p>Adapt uniGradICON to your own cohort and measure what the finetuning bought you.</p>
-       <span class="pt4d-card__meta">DIR-Lab</span>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-3-reconstruct-high-resolution-4d-ct">
        <span class="pt4d-card__number">03</span>
        <h2>Reconstruct High-Resolution 4D CT</h2>
        <p>Register every phase to one reference and reconstruct the series at its resolution.</p>
-       <span class="pt4d-card__meta">Slicer-Heart-CT &middot; DIR-Lab</span>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-4-ct-segmentation-to-vtk-surfaces">
        <span class="pt4d-card__number">04</span>
        <h2>CT Segmentation to VTK Surfaces</h2>
        <p>Segment one CT phase and export patient anatomy as VTK PolyData surfaces.</p>
-       <span class="pt4d-card__meta">Slicer-Heart-CT &middot; DIR-Lab</span>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-5-vtk-surfaces-to-animated-usd">
        <span class="pt4d-card__number">05</span>
        <h2>VTK Surfaces to Animated USD</h2>
        <p>Convert meshes into a time-sampled USD scene for Omniverse playback.</p>
-       <span class="pt4d-card__meta">Tutorial 4 output</span>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-6-create-a-pca-shape-model">
        <span class="pt4d-card__number">06</span>
        <h2>Create a PCA Shape Model</h2>
        <p>Turn a population of meshes into a statistical shape model and its modes.</p>
-       <span class="pt4d-card__meta">KCL-Heart-Model &middot; DIR-Lab</span>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-7-fit-the-shape-model-to-a-patient">
        <span class="pt4d-card__number">07</span>
        <h2>Fit the Shape Model to a Patient</h2>
        <p>Fit the shape model to one routine clinical scan, PCA coefficients and all.</p>
-       <span class="pt4d-card__meta">Chest-CT &middot; Tutorial 6 output</span>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-8-propagate-the-shape-model-through-4d">
        <span class="pt4d-card__number">08</span>
        <h2>Propagate the Model Through 4D</h2>
        <p>Fit each case at its reference phase and carry the mesh through every phase.</p>
-       <span class="pt4d-card__meta">DIR-Lab &middot; Tutorials 2 and 6</span>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-9-train-a-physicsnemo-surrogate">
        <span class="pt4d-card__number">09</span>
        <h2>Train a PhysicsNeMo Surrogate</h2>
        <p>Train a MeshGraphNet to predict per-vertex motion from shape and phase.</p>
-       <span class="pt4d-card__meta">Tutorial 8 output</span>
      </a>
      <a class="pt4d-card" href="tutorials.html#tutorial-10-predict-motion-with-the-surrogate">
        <span class="pt4d-card__number">10</span>
        <h2>Predict Motion With the Surrogate</h2>
        <p>Replace the registration solve with one forward pass, then export to USD.</p>
-       <span class="pt4d-card__meta">Tutorials 8 and 9 output</span>
      </a>
    </section>
 
@@ -120,7 +106,7 @@
        </a>
        <a class="pt4d-topic-card" href="viewing_usd.html">
          <h3>Viewing USD Files</h3>
-         <p>Set up usdview or an Omniverse Kit app and open the scenes the workflows produce.</p>
+         <p>Set up an Omniverse Kit app with RTX rendering and open the scenes the workflows produce.</p>
        </a>
        <a class="pt4d-topic-card" href="cli_scripts/byod_tutorials.html">
          <h3>Bring Your Own Data</h3>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -254,7 +254,8 @@ Solution: TotalSegmentator downloads models on first use. Ensure you have:
 Solution:
 
 1. Ensure NVIDIA Omniverse is installed
-2. Check USD file integrity with ``usdview`` (included with usd-core)
+2. Set the viewport renderer to RTX and switch to the scene's
+   ``/World/Camera``; see :doc:`viewing_usd`
 3. Verify file paths are accessible to Omniverse
 
 Getting Help

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,13 +4,6 @@ Quick Start
 
 This guide will help you get started with PhysioTwin4D quickly.
 
-.. warning::
-
-   **Not validated for clinical use.** PhysioTwin4D
-   {{ pt4d_project_version }} beta is a research and visualization toolkit, not
-   a medical device. Do not use it for diagnosis, treatment planning, or
-   clinical decision-making.
-
 Prerequisites
 =============
 
@@ -277,13 +270,15 @@ Python >= 3.11.
 Visualizing Results
 ===================
 
-The workflows write OpenUSD scenes, and viewing them needs a USD viewer —
-``usdview`` for inspection and debugging, or an Omniverse Kit application for
-real-time RTX playback. Note that the ``usd-core`` package installed with
-PhysioTwin4D provides the OpenUSD *libraries* only and contains no viewer.
+The workflows write OpenUSD scenes, and viewing them needs a USD viewer — use
+an Omniverse Kit application with RTX rendering, which is what evaluates the
+material properties assigned to each tissue. Note that the ``usd-core``
+package installed with PhysioTwin4D provides the OpenUSD *libraries* only and
+contains no viewer.
 
-:doc:`viewing_usd` covers where to get each one, how to set it up, and how to
-open a PhysioTwin4D scene.
+:doc:`viewing_usd` covers where to get it, how to set it up, and how to open a
+PhysioTwin4D scene — including switching to the camera defined in the scene,
+whose clipping planes are fitted to the anatomy's scale.
 
 The intermediate meshes need no USD tooling:
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -120,14 +120,12 @@ USD Not Animating
 
       usdchecker model.usd
 
-2. Check time samples:
+   ``usdchecker`` is not part of the ``usd-core`` package installed with
+   PhysioTwin4D; it ships with the OpenUSD toolset, available pre-built from
+   https://developer.nvidia.com/usd.
 
-   .. code-block:: bash
-
-      usdview model.usd
-
-   ``usdchecker`` and ``usdview`` are not part of the ``usd-core`` package
-   installed with PhysioTwin4D; see :doc:`viewing_usd` for how to get them.
+2. Open the scene in an Omniverse Kit application, switch the viewport to the
+   scene's ``/World/Camera``, and press Play; see :doc:`viewing_usd`.
 
 3. Verify that the generated USD contains time samples.
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -815,8 +815,8 @@ Adapt to your data
 Where to Go Next
 ================
 
-- :doc:`viewing_usd` — installing ``usdview`` or an Omniverse Kit application
-  and opening the scenes these tutorials produce.
+- :doc:`viewing_usd` — installing an Omniverse Kit application and opening the
+  scenes these tutorials produce.
 - :doc:`cli_scripts/byod_tutorials` — running the workflows on your own DICOM,
   NRRD or VTK data, including directory layout and conversion.
 - :doc:`api/index` — every workflow, segmenter, registrar and utility class.

--- a/docs/viewing_usd.rst
+++ b/docs/viewing_usd.rst
@@ -8,138 +8,69 @@ commands — writes an OpenUSD scene: anatomy split into per-organ prims, painte
 with OmniSurface materials, and time-sampled when the input was a series. To
 see the motion you need a USD viewer.
 
-Two are worth knowing. Use **usdview** for day-to-day inspection and debugging,
-and an **Omniverse Kit application** when you want real-time ray tracing or to
-build on the scene.
+Use an **NVIDIA Omniverse Kit application**. It is built on OpenUSD, renders
+with RTX in real time, and is the only viewer that shows these scenes as the
+workflows intend them.
 
 .. important::
 
    ``pip install physiotwin4d`` pulls in `usd-core
    <https://pypi.org/project/usd-core/>`_, which is the OpenUSD *libraries*
    only — enough to write and read stages, but it contains no viewer.
-   ``usdview`` needs a build that includes USD Imaging, from one of the two
-   routes below.
-
-usdview
-=======
-
-``usdview`` is the canonical viewer that ships with OpenUSD. It is a
-lightweight application for opening a stage, walking its scene graph,
-inspecting prim properties and composition, scrubbing the timeline, and
-switching between renderers — the tool to reach for when you want to know what
-is actually in the file. See the `OpenUSD toolset documentation
-<https://openusd.org/release/toolset.html>`_ for the full feature list.
-
-Getting it: pre-built binaries
-------------------------------
-
-The quickest route is NVIDIA's pre-built OpenUSD libraries and tools, which
-include ``usdview`` for Windows and Linux and are matched to specific Python
-versions: https://developer.nvidia.com/usd
-
-Download the package matching your Python version, unpack it, and put its
-``bin`` and ``lib`` directories on your path. On Windows:
-
-.. code-block:: bat
-
-   set USD_ROOT=C:\usd
-   set PATH=%USD_ROOT%\bin;%USD_ROOT%\lib;%PATH%
-   set PYTHONPATH=%USD_ROOT%\lib\python;%PYTHONPATH%
-
-   usdview tutorials\output\tutorial_01_heart\cardiac_model.usd
-
-On Linux:
-
-.. code-block:: bash
-
-   export USD_ROOT=$HOME/usd
-   export PATH=$USD_ROOT/bin:$PATH
-   export PYTHONPATH=$USD_ROOT/lib/python:$PYTHONPATH
-
-   usdview tutorials/output/tutorial_01_heart/cardiac_model.usd
-
-Use a **separate environment** from the one PhysioTwin4D runs in, or at least
-be deliberate about ordering: the ``PYTHONPATH`` above puts a second copy of
-``pxr`` ahead of the ``usd-core`` wheel, and mixing two OpenUSD builds in one
-interpreter causes import errors that are tedious to diagnose.
-
-Getting it: building from source
---------------------------------
-
-To build OpenUSD yourself — needed if no pre-built package matches your Python,
-or you want a specific release — clone
-https://github.com/PixarAnimationStudios/OpenUSD and run its build script:
-
-.. code-block:: bash
-
-   git clone https://github.com/PixarAnimationStudios/OpenUSD.git
-   python OpenUSD/build_scripts/build_usd.py ~/usd
-
-The script fetches and builds the dependencies as well, so expect it to take a
-while. USD Imaging and ``usdview`` are included by default; ``usdview`` also
-needs PySide and PyOpenGL in the Python environment you launch it from. The
-repository's build instructions list the per-platform prerequisites.
-
-Using it
---------
-
-.. code-block:: bash
-
-   usdview cardiac_model.usd
-
-- The **viewport** opens on frame one. Press the play button, or scrub the
-  timeline at the bottom, to see the cardiac or respiratory motion — a static
-  scene means the workflow wrote a single time sample.
-- The **scene graph** on the left is the anatomy hierarchy the workflow built
-  (``/World/<name>/<group>/<organ>``). Select a prim to isolate an organ.
-- The **property panel** shows the attributes on the selected prim, including
-  the time-sampled ``points`` that carry the motion and the bound material.
-- The **interpreter** (``Window > Interpreter``) gives you a Python prompt on
-  the live stage, which is the fastest way to check an attribute's values at a
-  given time code.
-
-For a non-interactive sanity check that a file is valid USD, the same toolset
-ships ``usdchecker``:
-
-.. code-block:: bash
-
-   usdchecker cardiac_model.usd
 
 Omniverse Kit applications
 ==========================
 
-NVIDIA Omniverse is built on OpenUSD and renders it with RTX in real time. Use
-it when you want photorealistic playback of the anatomy, to compose a
-PhysioTwin4D scene with other assets, or to drive a downstream simulation or
-XR workflow rather than to inspect the file.
+The recommended application is **USD Composer**, built from the
+`usd_composer template
+<https://github.com/NVIDIA-Omniverse/kit-app-template/tree/main/templates/apps/usd_composer>`_
+in NVIDIA's `kit-app-template
+<https://github.com/NVIDIA-Omniverse/kit-app-template>`_ repository. Clone the
+repository and follow its README: ``repo template new`` to create an app from
+the ``usd_composer`` template, ``repo build`` to build it, and ``repo launch``
+to run it. The same repository holds a ``usd_viewer`` template if you want a
+review-and-playback app or a starting point for embedding a viewer in your own
+tool.
 
-Download the Omniverse launcher and applications from
-https://www.nvidia.com/en-us/omniverse/download/. The relevant Kit-based apps
-are **USD Composer** for authoring and layout, and **USD Presenter** for
-review and playback; the Kit SDK and the `USD Viewer
-<https://docs.omniverse.nvidia.com/>`_ sample are the starting points if you
-want to embed a viewer in your own tool.
-
-Omniverse needs an RTX-capable NVIDIA GPU and a current driver, which is a
-heavier requirement than ``usdview``'s GL preview — that is the main reason to
-keep both around.
+Omniverse needs an RTX-capable NVIDIA GPU and a current driver.
 
 Opening a PhysioTwin4D scene:
 
-1. Launch **USD Composer** (or **USD Presenter**).
+1. Launch your **USD Composer** app.
 2. ``File > Open`` and select the generated ``.usd`` file — for the tutorials,
    under ``tutorials/output/<tutorial_name>/``.
-3. Press **Play** on the timeline to run the animation. The frame rate is the
+3. Switch the viewport to the **camera defined in the USD scene**
+   (``/World/Camera``) — see below.
+4. Press **Play** on the timeline to run the animation. The frame rate is the
    ``frames_per_second`` the workflow was given, so a value of ``1.0`` plays one
    phase per second; raise it for smoother playback.
-4. Anatomy materials are already bound, so the organs arrive colored. Select a
+5. Anatomy materials are already bound, so the organs arrive colored. Select a
    prim in the stage tree to adjust its material, or to hide organs that
    occlude the structure you care about.
 
-If a scene opens but appears empty, check the units and the camera: the
-workflows write millimetre-scale geometry in USD's right-handed Y-up frame, and
-a viewport whose near plane is set for metre-scale content will clip it. See
-:doc:`developer/usd_generation` for the conversion details.
+Use RTX rendering
+-----------------
+
+The workflows assign each tissue an OmniSurface material carrying its visual
+properties — color, roughness, transmission and subsurface scattering for
+translucent tissue. Those properties are only evaluated by the **RTX**
+renderers (``RTX - Real-Time`` or ``RTX - Interactive``). In a preview or
+Storm-style render mode the organs fall back to flat approximate shading, so
+tissues that should read as translucent or wet look uniformly opaque. Set the
+viewport renderer to RTX before judging how a scene looks.
+
+Use the camera in the scene
+---------------------------
+
+Each scene ships a ``/World/Camera`` prim framing the anatomy, with clipping
+planes and focus distance fitted to the anatomy's scale — the near plane is set
+from the geometry's bounding-box diagonal, so you can zoom in close without the
+surfaces vanishing. The default Omniverse perspective camera is set up for
+room- and building-sized content, so on an organ-sized scene it clips the
+anatomy away and navigates awkwardly. In the viewport camera menu, select the
+scene's ``Camera`` rather than ``Perspective``. If a scene opens but appears
+empty, this is almost always why. See :doc:`developer/usd_generation` for the
+coordinate and unit details.
 
 Before USD: viewing the meshes directly
 =======================================

--- a/docs/viewing_usd.rst
+++ b/docs/viewing_usd.rst
@@ -26,9 +26,17 @@ The recommended application is **USD Composer**, built from the
 <https://github.com/NVIDIA-Omniverse/kit-app-template/tree/main/templates/apps/usd_composer>`_
 in NVIDIA's `kit-app-template
 <https://github.com/NVIDIA-Omniverse/kit-app-template>`_ repository. Clone the
-repository and follow its README: ``repo template new`` to create an app from
-the ``usd_composer`` template, ``repo build`` to build it, and ``repo launch``
-to run it. The same repository holds a ``usd_viewer`` template if you want a
+repository and follow its README: ``template new`` to create an app from the
+``usd_composer`` template, ``build`` to build it, and ``launch`` to run it —
+driven through ``./repo.sh`` on Linux and macOS, or ``.\repo.bat`` on Windows:
+
+.. code-block:: bat
+
+   .\repo.bat template new
+   .\repo.bat build
+   .\repo.bat launch
+
+The same repository holds a ``usd_viewer`` template if you want a
 review-and-playback app or a starting point for embedding a viewer in your own
 tool.
 

--- a/experiments/Convert_VTK_To_USD/convert_vtk_to_usd_using_class.py
+++ b/experiments/Convert_VTK_To_USD/convert_vtk_to_usd_using_class.py
@@ -376,11 +376,11 @@ print("=" * 60)
 # 7. **Data Preservation**: All VTK arrays preserved as USD primvars
 # 8. **Coordinate Systems**: Automatic LPS to USD right-handed Y-up conversion
 #
-# The library is production-ready and can be used for converting medical imaging data, simulation results, and other VTK-based datasets to USD for visualization in Omniverse, USDView, or other USD-compatible applications.
+# The library is production-ready and can be used for converting medical imaging data, simulation results, and other VTK-based datasets to USD for visualization in Omniverse or other USD-compatible applications.
 #
 # ### Next Steps
 #
-# - View the generated USD files in USDView or Omniverse
+# - View the generated USD files in Omniverse with RTX rendering enabled
 # - Experiment with different conversion settings
 # - Test with your own VTK datasets
 # - Explore advanced features like custom colormaps and transfer functions

--- a/src/physiotwin4d/vtk_to_usd/usd_utils.py
+++ b/src/physiotwin4d/vtk_to_usd/usd_utils.py
@@ -447,7 +447,8 @@ def add_framing_camera(
 
     A ``UsdLux.DistantLight`` is added at ``{parent_path}/{light_name}`` sharing
     the camera's orientation, so the anatomy is lit from the viewing direction
-    in stages that carry no other light.
+    in stages that carry no other light. The light is created only when valid,
+    non-degenerate bounds exist; otherwise no light is authored.
 
     Bounds must be expressed in stage coordinates (post axis-swap and unit
     scaling). For time-varying stages, bounds are sampled at the start time

--- a/src/physiotwin4d/vtk_to_usd/usd_utils.py
+++ b/src/physiotwin4d/vtk_to_usd/usd_utils.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
-from pxr import Gf, Sdf, Usd, UsdGeom, Vt
+from pxr import Gf, Sdf, Usd, UsdGeom, UsdLux, Vt
 
 from .data_structures import DataType, GenericArray
 
@@ -430,6 +430,8 @@ def add_framing_camera(
     *,
     parent_path: str = "/World",
     name: str = "Camera",
+    light_name: str = "DistantLight",
+    light_intensity: float = 3000.0,
     bounds_min: tuple[float, float, float] | None = None,
     bounds_max: tuple[float, float, float] | None = None,
     focal_length_mm: float = 50.0,
@@ -443,6 +445,10 @@ def add_framing_camera(
     ``clippingRange`` so users can zoom close in Omniverse Kit and other USD
     viewers without geometry vanishing at the near plane.
 
+    A ``UsdLux.DistantLight`` is added at ``{parent_path}/{light_name}`` sharing
+    the camera's orientation, so the anatomy is lit from the viewing direction
+    in stages that carry no other light.
+
     Bounds must be expressed in stage coordinates (post axis-swap and unit
     scaling). For time-varying stages, bounds are sampled at the start time
     code.
@@ -452,6 +458,9 @@ def add_framing_camera(
             supplied; world bounds are then computed from the stage.
         parent_path: Parent prim path. Defaults to ``"/World"``.
         name: Camera prim name. Defaults to ``"Camera"``.
+        light_name: Distant light prim name. Defaults to ``"DistantLight"``.
+        light_intensity: Distant light intensity. Defaults to ``3000.0``, which
+            reads as a neutral key light under the RTX renderers.
         bounds_min: Optional min corner ``(x, y, z)`` in stage coordinates.
         bounds_max: Optional max corner ``(x, y, z)`` in stage coordinates.
         focal_length_mm: Camera focal length. USD camera lens parameters are
@@ -527,5 +536,16 @@ def add_framing_camera(
     camera.CreateFocalLengthAttr().Set(float(focal_length_mm))
     camera.CreateHorizontalApertureAttr().Set(float(horizontal_aperture_mm))
     camera.CreateFocusDistanceAttr().Set(float(distance))
+
+    # A DistantLight emits along its local -Z, the same direction the camera
+    # looks, so reusing the camera transform lights whatever the camera frames.
+    light_path = f"{parent_path.rstrip('/')}/{light_name}"
+    light = UsdLux.DistantLight.Define(stage, light_path)
+    light_xformable = UsdGeom.Xformable(light.GetPrim())
+    light_xformable.ClearXformOpOrder()
+    light_xformable.AddTransformOp().Set(camera_to_world)
+    light.CreateIntensityAttr().Set(float(light_intensity))
+    # Sun-like angular diameter: soft enough to avoid hard-edged shadows.
+    light.CreateAngleAttr().Set(0.53)
 
     return camera

--- a/tutorials/tutorial_07_lung_fit_statistical_model_to_patient.py
+++ b/tutorials/tutorial_07_lung_fit_statistical_model_to_patient.py
@@ -122,6 +122,7 @@ if __name__ == "__main__":
         workflow.set_use_pca_registration(
             use_pca_registration=True,
             pca_model=pca_model,
+            pca_number_of_modes=6,
             use_surface=False,
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated USD viewing guidance to use Omniverse Kit with RTX rendering, including scene setup, camera selection, playback, and troubleshooting.
  - Expanded guidance on RTX material behavior and anatomy-specific camera clipping.
  - Refined clinical-use disclaimer placement and formatting across project documentation.
  - Added documentation for automatic distant lighting in generated scenes.

- **Enhancements**
  - Generated USD scenes now support configurable distant-light names and intensity.
  - Statistical-model fitting tutorials now explicitly use six PCA modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->