### PR TITLE
ENH: Disable AI running --run-slow tests since take too long

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,9 +153,9 @@ graphify update .               # refresh after code changes (AST-only, no API c
   Slow, GPU, Simpleware,
   experiment, and tutorial tests are auto-skipped unless their opt-in flag is
   passed.
-- Agents must never run pytest with `--run-slow` or `--run-all`; those runs take
-  far too long for an interactive session. Run the fast suite and leave the
-  opt-in buckets for the user to invoke.
+- Do not run pytest with `--run-slow` or `--run-all` unless the user explicitly
+  asks; those runs take far too long for an interactive session. Default to the
+  fast suite and leave the opt-in buckets for the user to invoke.
 - Query the graphify knowledge graph (`graphify query "<question>"`) to locate
   classes, methods, and signatures before searching manually.
 - Do not commit changes or make pull requests unless specifically told to do so.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,9 @@ graphify update .               # refresh after code changes (AST-only, no API c
   Slow, GPU, Simpleware,
   experiment, and tutorial tests are auto-skipped unless their opt-in flag is
   passed.
+- Agents must never run pytest with `--run-slow` or `--run-all`; those runs take
+  far too long for an interactive session. Run the fast suite and leave the
+  opt-in buckets for the user to invoke.
 - Query the graphify knowledge graph (`graphify query "<question>"`) to locate
   classes, methods, and signatures before searching manually.
 - Do not commit changes or make pull requests unless specifically told to do so.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,9 +136,9 @@ came from.
 - Markers (all opt-in via `--run-<bucket>`): `slow`, `requires_gpu`,
   `requires_simpleware`, `experiment`, `tutorial`. Data-dependent tests no
   longer use a marker — they pull data through fixtures and run by default.
-- **Never run `pytest` with `--run-slow` (or `--run-all`).** Those runs take far
-  too long for an interactive session. Run the fast suite and let the user
-  invoke the slow buckets themselves.
+- **Avoid `pytest --run-slow` (or `--run-all`) unless the user explicitly
+  requests it.** Those runs take far too long for an interactive session.
+  Default to the fast suite and let the user invoke the slow buckets.
 - Prefer images from `ROOT/data/test/slicer_heart_small` for tests
 - Prefer storing results in subdirs `./results/<test_name>`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,9 @@ came from.
 - Markers (all opt-in via `--run-<bucket>`): `slow`, `requires_gpu`,
   `requires_simpleware`, `experiment`, `tutorial`. Data-dependent tests no
   longer use a marker — they pull data through fixtures and run by default.
+- **Never run `pytest` with `--run-slow` (or `--run-all`).** Those runs take far
+  too long for an interactive session. Run the fast suite and let the user
+  invoke the slow buckets themselves.
 - Prefer images from `ROOT/data/test/slicer_heart_small` for tests
 - Prefer storing results in subdirs `./results/<test_name>`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance to recommend running the fast test suite by default.
  * Clarified that slow and full test suites should be run explicitly when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->