### PR TITLE
ENH: Cohort-based evaluation, distributed training, tutorials 14-15, cookbook

### DIFF
--- a/docs/api/physicsnemo/evaluate.rst
+++ b/docs/api/physicsnemo/evaluate.rst
@@ -44,7 +44,7 @@ Example
    result = evaluate.process(
        case_id="Case1Pack",
        shape_parameters=pca_coefficients_file,
-       reference_mesh=ssm_surface_file,
+       fitted_reference_mesh=fitted_reference_mesh_file,
        reference_labelmap=reference_labelmap,
        ground_truth_labelmaps={0.0: frame_00, 0.1: frame_10},
        output_directory=out_dir,

--- a/docs/api/physicsnemo/infer.rst
+++ b/docs/api/physicsnemo/infer.rst
@@ -77,13 +77,15 @@ Example
 Notes
 =====
 
-**Where the displacements are applied.** Give
-:meth:`WorkflowInferMovement.predict_single` or
-:meth:`~WorkflowInferMovement.create_deformation_field` a ``reference_mesh``
-and the prediction stays in that mesh's world frame — the right choice for a
-patient scan whose fit carried a pose transform. Omit it and the displacements
-are applied to the mesh reconstructed from the PCA coefficients alone, which
-needs no per-subject geometry but stays in the model's own frame.
+**Where the displacements are applied.**
+:meth:`WorkflowInferMovement.predict_single` and
+:meth:`~WorkflowInferMovement.create_deformation_field` both require a
+``fitted_reference_mesh`` — the patient's shape-model surface as fitted by
+:class:`~physiotwin4d.WorkflowFitStatisticalModelToPatient`, which is shape
+parameters *and* a deformable registration. The prediction stays in that mesh's
+world frame, so a fit that carried a pose transform lands where the patient
+actually is. A surface reconstructed from the shape parameters alone is not a
+substitute and is not accepted.
 
 **Arbitrary stages.** Nothing constrains ``stage`` to a phase that was
 acquired; predicting between acquired phases is the reason to train a

--- a/docs/api/physicsnemo/manifest.rst
+++ b/docs/api/physicsnemo/manifest.rst
@@ -7,14 +7,14 @@ The Per-Subject Manifest
 
 The manifest is the contract between your data and the training stack. It is
 the only thing you must produce to train on your own subjects: one JSON file
-per subject, naming a reference mesh, that subject's PCA shape parameters, the
+per subject, naming a fitted reference mesh, that subject's PCA shape parameters, the
 point-data array holding the training targets, and one entry per phase.
 
 .. code-block:: json
 
    {
      "subject_id": "Case1Pack",
-     "reference_mesh": "Case1Pack_ssm_surface.vtp",
+     "fitted_reference_mesh": "Case1Pack_ssm_surface.vtp",
      "pca_coefficients": "Case1Pack_ssm_pca_coefficients.json",
      "target_array": "displacement",
      "phases": [
@@ -53,7 +53,7 @@ from the top-level package — import it by module:
    from physiotwin4d.physicsnemo_tools import SubjectManifest, parse_manifest
 
 .. autoclass:: SubjectManifest
-   :exclude-members: subject_id, reference_mesh, pca_coefficients, target_array, phases
+   :exclude-members: subject_id, fitted_reference_mesh, pca_coefficients, target_array, phases
 
 .. autoclass:: PhaseEntry
    :exclude-members: mesh, stage
@@ -72,8 +72,6 @@ Supporting helpers
 .. autofunction:: mesh_to_edge_index
 
 .. autofunction:: compute_edge_features
-
-.. autofunction:: reconstruct_reference_points
 
 .. autoclass:: PhaseSampleDataset
    :members:

--- a/docs/cli_scripts/infer_physicsnemo.rst
+++ b/docs/cli_scripts/infer_physicsnemo.rst
@@ -43,13 +43,13 @@ No manifest — just the subject's PCA coefficients:
        --model-dir output/mgn_run \
        --shape-parameters Case1Pack_ssm_pca_coefficients.json \
        --stage 0.7 \
-       --reference-mesh Case1Pack_ssm_surface.vtp \
+       --fitted-reference-mesh Case1Pack_ssm_surface.vtp \
        --output output/prediction
 
-Omit ``--reference-mesh`` to displace the mesh reconstructed from the PCA
-coefficients alone, which needs no per-subject geometry but stays in the
-model's own frame. Supply ``--ground-truth`` to score the prediction against a
-known surface.
+``--fitted-reference-mesh`` is required in single-subject mode: it is the
+patient's fitted shape-model surface, written by
+``physiotwin4d-fit-statistical-model-to-patient``. Supply ``--ground-truth`` to
+score the prediction against a known surface.
 
 Deformation Fields
 ==================
@@ -63,7 +63,7 @@ and the reference-surface normals onto that image's voxel grid:
        --model-dir output/mgn_run \
        --shape-parameters coefficients.json \
        --stage 0.5 \
-       --reference-mesh patient_surface.vtp \
+       --fitted-reference-mesh patient_surface.vtp \
        --reference-image patient_ct.mha \
        --output output/fields
 
@@ -86,7 +86,7 @@ Options
 ``--manifest JSON``, ``--stages [FLOAT ...]``, ``--displacement``
    Manifest mode, as above.
 
-``--shape-parameters JSON``, ``--stage FLOAT``, ``--reference-mesh PATH``, ``--ground-truth PATH``, ``--reference-image PATH``
+``--shape-parameters JSON``, ``--stage FLOAT``, ``--fitted-reference-mesh PATH``, ``--ground-truth PATH``, ``--reference-image PATH``
    Single-subject mode, as above.
 
 ``--output PATH``

--- a/docs/cli_scripts/infer_physicsnemo.rst
+++ b/docs/cli_scripts/infer_physicsnemo.rst
@@ -48,8 +48,7 @@ No manifest — just the subject's PCA coefficients:
 
 ``--fitted-reference-mesh`` is required in single-subject mode: it is the
 patient's fitted shape-model surface, written by
-``physiotwin4d-fit-statistical-model-to-patient``. Supply ``--ground-truth`` to
-score the prediction against a known surface.
+``physiotwin4d-fit-statistical-model-to-patient``.
 
 Deformation Fields
 ==================
@@ -86,7 +85,7 @@ Options
 ``--manifest JSON``, ``--stages [FLOAT ...]``, ``--displacement``
    Manifest mode, as above.
 
-``--shape-parameters JSON``, ``--stage FLOAT``, ``--fitted-reference-mesh PATH``, ``--ground-truth PATH``, ``--reference-image PATH``
+``--shape-parameters JSON``, ``--stage FLOAT``, ``--fitted-reference-mesh PATH``, ``--reference-image PATH``
    Single-subject mode, as above.
 
 ``--output PATH``

--- a/docs/cookbook/add_a_registration_method.rst
+++ b/docs/cookbook/add_a_registration_method.rst
@@ -1,0 +1,121 @@
+.. _cookbook_new_registrar:
+
+============================
+Adding a Registration Method
+============================
+
+Wire a new deformable image-registration backend into PhysioTwin4D so every
+workflow and CLI that takes a ``registration_method`` can use it.
+
+Ingredients
+===========
+
+* **An algorithm** that aligns a moving ITK image to a fixed ITK image and can
+  express the result as ITK transforms.
+* **Both directions.** The backend must produce the forward *and* inverse
+  transform. If it natively gives only one, invert it before returning.
+* **A module** at ``src/physiotwin4d/register_images_<name>.py``.
+
+Steps
+=====
+
+**1. Subclass** :class:`~physiotwin4d.RegisterImagesBase`. The base owns
+preprocessing, mask handling and dilation, modality settings, transform
+composition, and the public ``register()`` / ``register_from()`` API. You
+supply only the solve.
+
+.. code-block:: python
+
+   import logging
+   from typing import Optional, Union
+
+   import itk
+
+   from physiotwin4d import RegisterImagesBase
+
+
+   class RegisterImagesMyMethod(RegisterImagesBase):
+       def __init__(self, log_level: int | str = logging.INFO) -> None:
+           super().__init__(log_level=log_level)
+           self.number_of_iterations = 50
+
+       def registration_method(
+           self,
+           moving_image: itk.Image,
+           moving_mask: Optional[itk.Image] = None,
+           moving_labelmap: Optional[itk.Image] = None,
+           moving_image_pre: Optional[itk.Image] = None,
+       ) -> dict[str, Union[itk.Transform, float]]:
+           if self.fixed_image_pre is None:
+               raise ValueError("Fixed image must be set before registration.")
+
+           moving_pre = moving_image_pre if moving_image_pre is not None else moving_image
+           forward, inverse, loss = solve(self.fixed_image_pre, moving_pre)
+
+           return {
+               "forward_transform": forward,
+               "inverse_transform": inverse,
+               "loss": loss,
+           }
+
+``registration_method()`` is the one required override. It is internal —
+callers use ``register()``, which wraps it.
+
+**2. Honor the contract.** ``forward_transform`` warps the *moving image* onto
+the fixed grid. ``inverse_transform`` warps *moving points* into fixed space.
+Images and points take opposite transforms; getting this backwards is the
+classic silent failure here. Read :doc:`/developer/transform_conventions`
+before you return anything.
+
+**3. Read the base's state, don't re-derive it.** Use
+``self.fixed_image_pre`` and ``moving_image_pre`` rather than preprocessing
+again, ``self.fixed_mask`` / ``self.moving_mask`` for ROI-limited solves, and
+``self.modality`` for modality-specific parameters. Honor ``self.fast_mode``
+by dropping to cheaper settings — automated tests rely on it.
+
+**4. Do not accept an initial transform.** Seeding is the base class's job:
+``register_from()`` pre-warps the moving image, calls your method on the
+residual, and composes. One implementation, identical for every backend.
+
+**5. Export it** from ``src/physiotwin4d/__init__.py``, next to the other
+``register_images_*`` imports, and add it to ``__all__``.
+
+**6. Add it to the CLI dispatch** in
+``src/physiotwin4d/cli/_method_factories.py`` — the single place strings become
+instances. Append the name to ``REGISTRATION_METHODS`` and a branch to
+``build_registration_method()``. Every ``--registration-method`` flag picks it
+up from there.
+
+**7. Test it.** Copy the shape of ``tests/test_register_images_greedy.py``.
+Register a synthetic image against a known warp of itself and assert the
+recovered transform, in both directions. Mark GPU-bound tests ``requires_gpu``.
+
+.. code-block:: bash
+
+   py -m pytest tests/test_register_images_my_method.py -v
+
+**8. Document it.** Add ``docs/api/registration/<name>.rst``, list it in that
+directory's ``index.rst``, and mention it in
+:doc:`/developer/registration_images`. Then run ``graphify update .``.
+
+Notes
+=====
+
+* Your backend composes for free:
+  :class:`~physiotwin4d.RegisterImagesChain` will run it as one stage of a
+  multi-stage pipeline, and
+  :class:`~physiotwin4d.RegisterTimeSeriesImages` will apply it across a whole
+  4D series, without either class knowing about it.
+* Use ``TransformTools.transform_image()`` and
+  ``TransformTools.transform_pvcontour()`` to apply results — they encode the
+  direction rules.
+* Registering *models* to patients is a different base class; see
+  :doc:`/developer/registration_models`.
+
+See Also
+========
+
+* :doc:`/developer/registration_images` — the extended guide
+* :doc:`/developer/transform_conventions` — required reading
+* :doc:`/api/registration/base`
+* :doc:`add_a_segmentation_method`

--- a/docs/cookbook/add_a_segmentation_method.rst
+++ b/docs/cookbook/add_a_segmentation_method.rst
@@ -1,0 +1,116 @@
+.. _cookbook_new_segmenter:
+
+=============================
+Adding a Segmentation Method
+=============================
+
+Wire a new segmentation backend into PhysioTwin4D so every workflow and CLI
+that takes a ``segmentation_method`` can use it.
+
+Ingredients
+===========
+
+* **A model or algorithm** that turns one 3D image into an integer labelmap.
+* **A label map of your own**: which integer id means which organ, and which
+  anatomy group each organ belongs to.
+* **A module** at ``src/physiotwin4d/segment_<name>.py``.
+
+Steps
+=====
+
+**1. Subclass** :class:`~physiotwin4d.SegmentAnatomyBase`. The base owns
+preprocessing, postprocessing, contrast fusion, and anatomy-group splitting;
+you supply only the model call.
+
+.. code-block:: python
+
+   import logging
+
+   import itk
+
+   from physiotwin4d import SegmentAnatomyBase
+
+
+   class SegmentBrainMyModel(SegmentAnatomyBase):
+       def __init__(self, log_level: int | str = logging.INFO) -> None:
+           super().__init__(log_level=log_level)
+           self.target_spacing = 1.5
+
+       def segmentation_method(self, preprocessed_image: itk.Image) -> itk.Image:
+           return run_my_model(preprocessed_image)
+
+``segmentation_method()`` is the one required override. Return an
+``itk.Image`` labelmap on the preprocessed grid — the base resamples it back.
+
+**2. Declare the taxonomy** in ``__init__``, then finalize. Group names are
+free-form; new ones are allowed.
+
+.. code-block:: python
+
+   for group_name, organs in (
+       ("brain", {1: "cerebrum", 2: "cerebellum"}),
+       ("bone", {3: "skull"}),
+   ):
+       for label_id, organ_name in organs.items():
+           self.taxonomy.add_organ(group_name, label_id, organ_name)
+
+   self._finalize_other_group()
+
+The base contributes ``contrast`` (id 135) and ``soft_tissue`` (id 133)
+already. ``_finalize_other_group()`` claims the remaining ids in ``[1, 256)``
+for ``"other"``.
+
+**3. Register a look** if you introduced a group outside the default chest set
+(``heart``, ``lung``, ``bone``, ``major_vessels``, ``contrast``,
+``soft_tissue``, ``other``). Without one, USD export falls back to the generic
+``"other"`` material.
+
+.. code-block:: python
+
+   from physiotwin4d.usd_anatomy_tools import DEFAULT_RENDER_PARAMS
+
+   DEFAULT_RENDER_PARAMS["brain"] = {
+       "name": "Brain",
+       "diffuse_reflection_color": (0.85, 0.75, 0.7),
+       # ... copy the parameter list from an existing entry ...
+   }
+
+**4. Export it** from ``src/physiotwin4d/__init__.py``, next to the other
+``segment_*`` imports, and add it to ``__all__``.
+
+**5. Add it to the CLI dispatch** in
+``src/physiotwin4d/cli/_method_factories.py`` — the single place strings become
+instances. Append the name to ``SEGMENTATION_METHODS`` and a branch to
+``build_segmentation_method()``. Every ``--segmentation-method`` flag picks it
+up from there.
+
+**6. Test it.** Copy the shape of
+``tests/test_segment_chest_total_segmentator.py``. Keep inputs synthetic where
+possible; for real data use the session fixtures (``test_directories``,
+``download_test_data``, ``test_images``). Mark GPU- or license-bound tests
+``requires_gpu`` / ``requires_simpleware``.
+
+.. code-block:: bash
+
+   py -m pytest tests/test_segment_brain_my_model.py -v
+
+**7. Document it.** Add an ``docs/api/segmentation/<name>.rst`` page, list it in
+that directory's ``index.rst``, and add the class to the implemented-segmenters
+list in :doc:`/developer/segmentation`. Then run ``graphify update .``.
+
+Notes
+=====
+
+* Output is a dict of ITK images: ``"labelmap"`` plus one entry per anatomy
+  group, keyed by group name, original label ids preserved. Callers should
+  check key membership, not assume a fixed schema.
+* Use ``self.log_info()`` / ``self.log_debug()``; never ``print()``.
+* Set ``self.target_spacing`` to whatever resolution your model was trained at.
+
+See Also
+========
+
+* :doc:`/developer/segmentation` — the extended guide
+* :doc:`/api/segmentation/base` — ``AnatomyTaxonomy`` reference
+* :doc:`/developer/usd_generation` — how the taxonomy drives USD materials
+* :doc:`add_a_registration_method`

--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -1,0 +1,35 @@
+.. _cookbook:
+
+=====================
+PhysioTwin4D Cookbook
+=====================
+
+Short, self-contained recipes for the things people actually ask for. Each one
+lists its **ingredients** — what you must have on hand before you start — then
+the **steps** that turn them into a result.
+
+Recipes assume you already installed the package (:doc:`/installation`) and
+know roughly what the pipeline does (:doc:`/architecture`). Where a recipe
+needs more depth than a step can carry, it links to the reference page instead
+of repeating it.
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 1
+
+   * - Recipe
+     - Makes
+   * - :doc:`train_and_infer_on_your_own_data`
+     - A motion surrogate trained on your cohort, predicting unseen stages
+   * - :doc:`add_a_segmentation_method`
+     - A new ``SegmentAnatomyBase`` backend, usable from workflows and CLIs
+   * - :doc:`add_a_registration_method`
+     - A new ``RegisterImagesBase`` backend, usable anywhere a registrar is
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   train_and_infer_on_your_own_data
+   add_a_segmentation_method
+   add_a_registration_method

--- a/docs/cookbook/train_and_infer_on_your_own_data.rst
+++ b/docs/cookbook/train_and_infer_on_your_own_data.rst
@@ -73,8 +73,8 @@ its PCA coefficient JSON.
        --output-dir work/sub01/fit \
        --output-prefix sub01_T00
 
-**5. Write one manifest per subject.** This is the only artifact the training
-stack requires, and the only place your data meets it. Name the reference mesh,
+**5. Write one manifest per subject.** This is the only per-subject artifact
+the training stack requires, and the only place your data meets it. Name the reference mesh,
 the PCA coefficients, the point-data array holding your targets, and one entry
 per phase with its normalized ``stage``. Targets are read verbatim — write
 ``phase.points - reference.points`` for a motion model, or any other per-vertex
@@ -107,8 +107,9 @@ See :doc:`/api/physicsnemo/manifest` for the full schema and its rules.
        --pca-mean-mesh work/ssm/pca_mean_surface.vtp \
        --output work/mgn_run
 
-**7. Predict.** Manifest mode scores against stored targets; ``--stages`` asks
-for phases that were never acquired.
+**7. Predict.** Manifest mode predicts the stages the manifest stores;
+``--stages`` asks for phases that were never acquired. Neither scores the
+result --- for that, see :doc:`/tutorials` Tutorial 11.
 
 .. code-block:: bash
 

--- a/docs/cookbook/train_and_infer_on_your_own_data.rst
+++ b/docs/cookbook/train_and_infer_on_your_own_data.rst
@@ -1,0 +1,152 @@
+.. _cookbook_own_data:
+
+==========================================
+Training and Inference on Your Own Data
+==========================================
+
+Train a motion surrogate on your own cohort, then predict phases you never
+acquired. Tutorials 4 through 12 are this recipe on public data.
+
+Ingredients
+===========
+
+* **A cohort.** Several subjects, each with a gated series covering the cycle.
+  Any ITK-readable input: a DICOM directory, ``.mha``, ``.nrrd``, ``.nii.gz``,
+  or a 4D file.
+* **One held-out subject**, kept out of training, for scoring.
+* **A segmentation backend** that covers your anatomy — see
+  :doc:`add_a_segmentation_method` if none does.
+* **The optional extra**, plus a CUDA GPU::
+
+     pip install "physiotwin4d[physicsnemo]"
+     pip install torch-geometric      # MeshGraphNet only
+
+  PhysicsNeMo requires Python >= 3.11.
+
+Steps
+=====
+
+**1. Split 4D into a 3D time series.** Skip if your data is already per-phase
+files.
+
+.. code-block:: bash
+
+   physiotwin4d-convert-image-4d-to-3d \
+       --input-image subject_4d.seq.nrrd \
+       --output-dir work/sub01/phases \
+       --basename phase
+
+**2. Segment each phase to surfaces.** Repeat per phase, per subject.
+
+.. code-block:: bash
+
+   physiotwin4d-convert-image-to-vtk \
+       --input-image work/sub01/phases/phase_000.mha \
+       --output-dir work/sub01/surfaces \
+       --segmentation-method ChestTotalSegmentator \
+       --anatomy-groups heart
+
+**3. Build one PCA shape model for the cohort.** Every subject's fitted mesh
+inherits this template's point count and ordering, which is what makes vertices
+comparable across subjects.
+
+.. code-block:: bash
+
+   physiotwin4d-create-statistical-model \
+       --sample-meshes-dir work/reference_surfaces \
+       --reference-mesh work/reference_surfaces/sub01_heart.vtp \
+       --output-dir work/ssm \
+       --number-of-pca-components 20
+
+**4. Fit the model to each subject, at every phase.** Fit the reference phase
+first, then carry that fitted mesh through the remaining phases. This yields
+the two per-subject artifacts training needs: a fitted reference surface and
+its PCA coefficient JSON.
+
+.. code-block:: bash
+
+   physiotwin4d-fit-statistical-model-to-patient \
+       --template-model work/ssm/pca_mean_surface.vtp \
+       --pca-json work/ssm/pca_model.json \
+       --patient-models work/sub01/surfaces/phase_000_heart.vtp \
+       --patient-image work/sub01/phases/phase_000.mha \
+       --output-dir work/sub01/fit \
+       --output-prefix sub01_T00
+
+**5. Write one manifest per subject.** This is the only artifact the training
+stack requires, and the only place your data meets it. Name the reference mesh,
+the PCA coefficients, the point-data array holding your targets, and one entry
+per phase with its normalized ``stage``. Targets are read verbatim — write
+``phase.points - reference.points`` for a motion model, or any other per-vertex
+quantity for something else.
+
+.. code-block:: json
+
+   {
+     "subject_id": "sub01",
+     "fitted_reference_mesh": "sub01_ssm_surface.vtp",
+     "pca_coefficients": "sub01_ssm_pca_coefficients.json",
+     "target_array": "displacement",
+     "phases": [
+       {"mesh": "sub01_T00_target.vtp", "stage": 0.0},
+       {"mesh": "sub01_T50_target.vtp", "stage": 0.5}
+     ]
+   }
+
+See :doc:`/api/physicsnemo/manifest` for the full schema and its rules.
+``tutorials/tutorial_09_lung_train_physicsnemo_mgn.py`` has a working writer.
+
+**6. Train.** Hold your test subject back; list the rest.
+
+.. code-block:: bash
+
+   physiotwin4d-train-physicsnemo \
+       --network mgn \
+       --train-manifest work/manifests/sub0{2,3,4}_manifest.json \
+       --val-manifest work/manifests/sub05_manifest.json \
+       --pca-mean-mesh work/ssm/pca_mean_surface.vtp \
+       --output work/mgn_run
+
+**7. Predict.** Manifest mode scores against stored targets; ``--stages`` asks
+for phases that were never acquired.
+
+.. code-block:: bash
+
+   physiotwin4d-infer-physicsnemo \
+       --model-dir work/mgn_run \
+       --manifest work/manifests/sub01_manifest.json \
+       --displacement \
+       --output work/mgn_run/eval
+
+   physiotwin4d-infer-physicsnemo \
+       --model-dir work/mgn_run \
+       --shape-parameters work/sub01/fit/sub01_ssm_pca_coefficients.json \
+       --stage 0.35 \
+       --fitted-reference-mesh work/sub01/fit/sub01_ssm_surface.vtp \
+       --output work/prediction
+
+**8. Score against the images.** Pass the inference workflow to
+:class:`~physiotwin4d.WorkflowEvaluateMovement` with the structures to score,
+which reports per-structure surface and volume error against the acquired
+frames.
+
+Notes
+=====
+
+* Every phase mesh must share the template's point count and ordering. A
+  mismatch here is the most common training failure.
+* ``stage`` is your own normalization of position in the cycle. Nothing parses
+  filenames for it.
+* ``.vtp`` trains on surface points, ``.vtu`` on volume points — the template
+  mesh decides.
+* Add ``--reference-image`` at inference to rasterize predictions into
+  ``deformation_field.mha`` for warping volumes and labelmaps.
+
+See Also
+========
+
+* :doc:`/api/physicsnemo/manifest`
+* :doc:`/cli_scripts/train_physicsnemo`
+* :doc:`/cli_scripts/infer_physicsnemo`
+* :doc:`/cli_scripts/byod_tutorials` — your own data straight to USD, no training
+* :doc:`/tutorials`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,6 +127,10 @@
          <h3>Bring Your Own Data</h3>
          <p>Point the workflows at your own DICOM, NRRD, or VTK data instead of the sample datasets.</p>
        </a>
+       <a class="pt4d-topic-card" href="cookbook/index.html">
+         <h3>PhysioTwin4D Cookbook</h3>
+         <p>Short recipes — ingredients and steps — for training on your own data and adding new segmentation or registration methods.</p>
+       </a>
        <a class="pt4d-topic-card" href="api/index.html">
          <h3>API Reference</h3>
          <p>Browse classes and modules for workflows, segmentation, registration, USD, and utilities.</p>
@@ -188,6 +192,13 @@ close every section.
    cli_scripts/train_physicsnemo
    cli_scripts/infer_physicsnemo
    cli_scripts/best_practices
+
+.. toctree::
+   :maxdepth: 2
+   :caption: PhysioTwin4D Cookbook
+   :hidden:
+
+   cookbook/index
 
 .. toctree::
    :maxdepth: 2

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -11,9 +11,9 @@ Tutorials
      <p class="pt4d-kicker">PhysioTwin4D tutorials</p>
      <h1>From a CT scan to an animated digital twin</h1>
      <p>
-       Thirteen numbered stages across 29 Python scripts, 19 of them runnable
-       today: the ten <code>duke_heart</code> variants wait on a dataset that
-       is being released soon.
+       Fifteen numbered stages across 33 Python scripts, 21 of them runnable
+       today: the twelve <code>duke_heart</code> variants wait on a dataset
+       that is being released soon.
        Each one drives the real workflow classes end-to-end on downloadable
        data, shows what it produced, and ends with the handful of constants
        to change so it runs on your own scans.
@@ -145,6 +145,12 @@ second run is cheap and later tutorials pick up earlier results automatically.
        <p>Animate one ungated breath-hold scan with both rhythms, from two networks at once.</p>
        <span class="pt4d-card__meta">Chest-CT &middot; Tutorials 7 and 9 output</span>
      </a>
+     <a class="pt4d-card" href="#tutorial-15-leave-one-out-cross-validation">
+       <span class="pt4d-card__number">15</span>
+       <h2>Leave-One-Out Cross-Validation</h2>
+       <p>Rebuild the model, refit, retrain and rescore once per fold, for a spread rather than a number.</p>
+       <span class="pt4d-card__meta">DIR-Lab &middot; Duke-Heart-4DLabelmaps</span>
+     </a>
    </section>
 
 Recommended Run Order
@@ -154,7 +160,7 @@ Tutorials are straightforward Python scripts: run one with
 ``python tutorials/tutorial_01_heart_gated_ct_to_usd.py``, or open it in your
 editor and read it top to bottom. Numbers 1, 4 and 5 are the fastest way to see
 the toolkit
-work end-to-end; 6 through 13 build the statistical-model and AI-surrogate
+work end-to-end; 6 through 15 build the statistical-model and AI-surrogate
 pipeline on top.
 
 1. **Tutorial 1** — after downloading Slicer-Heart-CT.
@@ -176,6 +182,9 @@ pipeline on top.
     the model to the patient itself, so nothing is read from Tutorial 8.
 13. **Tutorial 13** — after Tutorial 7 (lung) and Tutorial 9 for both anatomies.
     It also needs Simpleware Medical, which segments the heart it fits.
+14. **Tutorial 15** — needs only the cohort. It rebuilds the shape model, the
+    fits and the network per fold, so nothing from Tutorials 6, 8 or 9 is read;
+    those outputs are reused as a cache when they happen to be there.
 
 Tutorial 1: Gated 4D CT to Animated USD
 =======================================
@@ -926,7 +935,7 @@ Inner API usage
           shape_parameters=pca_file,
           stages=stages,
           output_directory=output_dir,
-          reference_mesh=reference_file,
+          fitted_reference_mesh=fitted_reference_mesh_file,
           ground_truth=phase_files,
           reference_image=itk.imread(str(reference_ct_file)),
           warp_interpolation="linear",
@@ -948,8 +957,6 @@ Outputs
 Adapt to your data
    Change ``case_id`` to predict a different subject, or pass ``stages`` that
    were never acquired — which is the point of the surrogate. Omit
-   ``reference_mesh`` to displace the mesh reconstructed from the PCA
-   coefficients alone, needing no per-subject geometry at all. Omit
    ``reference_image`` to write meshes without warping anything. Use
    :class:`~physiotwin4d.WorkflowInferPhysicsNeMo` on its own to get the raw
    target array when your model predicts something other than displacement.
@@ -1008,12 +1015,12 @@ Inner API usage
       result = evaluate.process(
           case_id=case_id,
           shape_parameters=pca_file,
-          reference_mesh=reference_mesh_file,
+          fitted_reference_mesh=fitted_reference_mesh_file,
           reference_labelmap=itk.imread(str(reference_labelmap_file)),
           ground_truth_labelmaps=ground_truth_labelmaps,
           output_directory=output_dir,
           evaluation_spacing_mm=2.0,
-          include_dice=False,
+          report_dice=False,
       )
 
 Run
@@ -1030,7 +1037,7 @@ Outputs
    the hold-out case name, its shape parameters, and the network weights path
    with its dates, so a number can be traced back to the run that produced it.
 
-   The lung variant passes ``include_dice=False``. Dice is an overlap fraction,
+   The lung variant passes ``report_dice=False``. Dice is an overlap fraction,
    so a lobe that moves a few millimeters against its own bulk scores over 0.96
    however well or badly the motion is predicted; the column would describe the
    lobe rather than the model. Chambers change shape enough over a heartbeat for
@@ -1106,7 +1113,7 @@ Inner API usage
           shape_parameters=pca_coefficients_file,
           stages=stages,
           output_directory=output_dir,
-          reference_mesh=reference_mesh_file,
+          fitted_reference_mesh=fitted_reference_mesh_file,
           reference_image=reference_image,
           usd_project_name=f"{case_id}_mgn_motion",
           anatomy_type="lung",
@@ -1184,7 +1191,7 @@ Inner API usage
           shape_parameters=lung_coefficients_file,
           stage=0.0,
           reference_image=patient_image,
-          reference_mesh=lung_reference_mesh_file,
+          fitted_reference_mesh=lung_fitted_reference_mesh_file,
           direction="forward",
       )
       transform = TransformTools().smooth_deformation_field_transform(
@@ -1208,6 +1215,76 @@ Adapt to your data
    ``cardiac_cycles_per_phase`` to re-time the heartbeat against the breath, and
    the two ``*_sigma_mm`` values to change how far each rhythm's surface motion
    is carried into the surrounding tissue.
+
+Tutorial 15: Leave-One-Out Cross-Validation
+==========================================
+
+Script
+   ``tutorials/tutorial_15_lung_leave_one_out.py`` (DIR-Lab)
+
+   ``tutorials/tutorial_15_duke_heart_leave_one_out.py``
+   (Duke-Heart-4DLabelmaps)
+
+Workflow
+   :class:`~physiotwin4d.WorkflowCreateMeanSurface` and
+   :class:`~physiotwin4d.WorkflowCreateStatisticalModel` per fold,
+   :class:`~physiotwin4d.WorkflowFitStatisticalModelToPatient` per case,
+   :class:`~physiotwin4d.WorkflowTrainPhysicsNeMo` driving
+   :class:`~physiotwin4d.TrainPhysicsNeMoMGN`, and
+   :class:`~physiotwin4d.WorkflowEvaluateMovement` on the held-out case.
+
+Dataset
+   The whole cohort, and nothing else. Tutorials 6, 8 and 9 outputs are reused
+   as a cache when they are present, but every fold builds its own shape model,
+   its own fits and its own network.
+
+Requirements
+   The ``[physicsnemo]`` extra plus ``torch-geometric``. Written for a
+   multi-GPU Linux host, though it runs as a single process too.
+
+What it does
+   Tutorials 6 through 11 report accuracy for one fixed held-out case, which is
+   a single observation: it says nothing about how far the number would move
+   had a different patient been held out. This tutorial runs that chain once
+   per fold. Each fold rebuilds the PCA model from the population *without* its
+   held-out case, refits the cohort to that model, retrains the MeshGraphNet on
+   the other cases, infers the held-out case at every acquired stage, and scores
+   it against that stage's own ground truth. Rebuilding is the point --- a model
+   built once from everyone has already seen every case, so scoring against it
+   measures recall rather than generalization.
+
+   ``number_of_leave_one_out_runs`` near the top of each script sets the fold
+   count and defaults to 5.
+
+   Two things do not depend on which case is held out --- the segmentations
+   and, for the lung, the phase-to-reference image registrations --- so they
+   are computed once into ``shared/`` and reused. Hoisting the registrations is
+   what makes the lung variant tractable. The Duke variant cannot hoist its
+   frame registrations: they warp the fold's own fitted surface, which changes
+   with the fold, so a Duke fold costs materially more than a lung one.
+
+Run
+   .. code-block:: bash
+
+      # One process
+      python tutorials/tutorial_15_lung_leave_one_out.py
+
+      # Data-parallel training and rank-split per-case loops
+      torchrun --standalone --nproc_per_node=8           tutorials/tutorial_15_lung_leave_one_out.py
+
+Outputs
+   Under ``tutorials/output/tutorial_15_<anatomy>/``: ``loo_metrics.csv`` with
+   every metric row of every fold, ``loo_report.md`` with the per-structure mean
+   and standard deviation across folds, ``loo_metrics_by_label.png`` as the
+   matching box plot, and one ``fold_<case>/`` directory per fold holding that
+   fold's shape model, fits, manifests, weights and evaluation.
+
+Adapt to your data
+   Raise ``number_of_leave_one_out_runs`` to the cohort size for a full
+   leave-one-out study; the runtime is linear in it. ``epochs`` and
+   ``batch_size`` mirror Tutorial 9 so each fold's network is comparable to the
+   one that tutorial trains --- lower them for a quicker sweep, at the cost of
+   comparability.
 
 Where to Go Next
 ================

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -52,9 +52,9 @@ animates. ``DirLab-4DCT`` — used by Lung Tutorials 1, 2, 3, 4, 6, 8, 10, 11 an
 each case individually and may require registration.
 
 Tutorials 5 and 9 need no dataset of their own; they consume the outputs of
-Tutorials 4 and 8. ``Duke-Heart-4DLabelmaps`` drives the ten ``duke_heart``
-variants: a nine-tutorial chain from Tutorial 4 through Tutorial 12, plus the
-separate, optional Tutorial 2 ICON finetuning variant; the dataset is
+Tutorials 4 and 8. ``Duke-Heart-4DLabelmaps`` drives the twelve ``duke_heart``
+variants: an eleven-tutorial chain from Tutorial 4 through Tutorial 15, plus
+the separate, optional Tutorial 2 ICON finetuning variant; the dataset is
 being released soon, and until then access can be requested from Stephen Aylward
 (saylward@nvidia.com). See ``data/DirLab-4DCT/README.md``,
 ``data/Duke-Heart-4DLabelmaps/README.md``, and
@@ -145,6 +145,12 @@ second run is cheap and later tutorials pick up earlier results automatically.
        <p>Animate one ungated breath-hold scan with both rhythms, from two networks at once.</p>
        <span class="pt4d-card__meta">Chest-CT &middot; Tutorials 7 and 9 output</span>
      </a>
+     <a class="pt4d-card" href="#tutorial-14-sweep-the-shape-parameters">
+       <span class="pt4d-card__number">14</span>
+       <h2>Sweep the Shape Parameters</h2>
+       <p>Re-infer and rescore over a grid of PCA coefficients, to see how far the motion moves with them.</p>
+       <span class="pt4d-card__meta">Tutorials 8 and 9 output</span>
+     </a>
      <a class="pt4d-card" href="#tutorial-15-leave-one-out-cross-validation">
        <span class="pt4d-card__number">15</span>
        <h2>Leave-One-Out Cross-Validation</h2>
@@ -182,7 +188,10 @@ pipeline on top.
     the model to the patient itself, so nothing is read from Tutorial 8.
 13. **Tutorial 13** — after Tutorial 7 (lung) and Tutorial 9 for both anatomies.
     It also needs Simpleware Medical, which segments the heart it fits.
-14. **Tutorial 15** — needs only the cohort. It rebuilds the shape model, the
+14. **Tutorial 14** — after Tutorial 8 and Tutorial 9, whose fit and
+    checkpoint every point of the grid reuses. It scores each point the way
+    Tutorial 11 does, so it needs a GPU and the segmentation weights too.
+15. **Tutorial 15** — needs only the cohort. It rebuilds the shape model, the
     fits and the network per fold, so nothing from Tutorials 6, 8 or 9 is read;
     those outputs are reused as a cache when they happen to be there.
 
@@ -950,9 +959,10 @@ Run
       python tutorials/tutorial_10_lung_infer_physicsnemo_mgn.py
 
 Outputs
-   One predicted surface and one warped CT per stage, one animated USD across
-   all of them, and ``statistics_per_stage.csv`` with the mm error against each
-   acquired phase, under ``tutorials/output/tutorial_10_lung_mgn/<case>/``.
+   One predicted surface and one warped CT per stage, and one animated USD
+   across all of them, under ``tutorials/output/tutorial_10_lung_mgn/<case>/``.
+   The acquired phase surface is rendered beside the prediction for visual
+   comparison; scoring it is Tutorial 11's job.
 
 Adapt to your data
    Change ``case_id`` to predict a different subject, or pass ``stages`` that
@@ -1216,8 +1226,78 @@ Adapt to your data
    the two ``*_sigma_mm`` values to change how far each rhythm's surface motion
    is carried into the surrounding tissue.
 
+Tutorial 14: Sweep the Shape Parameters
+=======================================
+
+Script
+   ``tutorials/tutorial_14_lung_shape_parameter_sweep.py`` (DIR-Lab)
+
+   ``tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py``
+   (Duke-Heart-4DLabelmaps)
+
+Workflow
+   :class:`~physiotwin4d.WorkflowInferPhysicsNeMo` driving
+   :class:`~physiotwin4d.InferPhysicsNeMoMGN`, scored by
+   :class:`~physiotwin4d.WorkflowEvaluateMovement` once per grid point.
+
+Dataset
+   The held-out case of Tutorial 9, plus its Tutorial 8 fit and the Tutorial 9
+   checkpoint.
+
+Requirements
+   The ``[physicsnemo]`` extra plus ``torch-geometric``, a GPU, and the
+   segmentation weights --- every grid point is scored against independently
+   segmented frames, exactly as Tutorial 11 scores its one fit.
+
+What it does
+   Tutorial 11 scores the inferred motion at the one point in shape space the
+   statistical-model fit happened to land on. This tutorial sweeps that point:
+   it perturbs the first few PCA coefficients over a grid, re-infers the whole
+   cycle at every combination, and scores each the way Tutorial 11 scores its
+   single fit.
+
+   Only the coefficients handed to the network change. The reference anatomy
+   stays the Tutorial 8 fitted surface at every grid point, so what the
+   perturbation moves is the displacement field the MeshGraphNet infers, not
+   the patient's own shape. The sweep therefore isolates the network's
+   sensitivity to its shape conditioning. Because the reference surface, the
+   reference labelmap and the acquired frames are identical across the grid,
+   every combination is scored on the same evaluation grid and the figures are
+   directly comparable point to point.
+
+   The all-zero combination is in the grid, so the unperturbed score comes out
+   of the same code path as every perturbed one.
+   ``number_of_modes_to_vary``, ``perturbation_range`` and
+   ``perturbation_step`` set the grid; the default is ``5 ** 2 = 25``
+   combinations, each costing one Tutorial 11 run.
+
+   Read the sweep by the displacement columns rather than by Dice: a perturbed
+   coefficient can leave a structure the same size in the same place and still
+   move every point of it wrong, which the labelmap metrics cannot see.
+
+Run
+   .. code-block:: bash
+
+      python tutorials/tutorial_14_lung_shape_parameter_sweep.py
+
+      python tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
+
+Outputs
+   Under ``tutorials/output/tutorial_14_<anatomy>/<case>/``:
+   ``shape_sweep_metrics.csv`` with one row per combination, stage and
+   structure, ``shape_sweep_summary.csv`` with one row per combination carrying
+   that combination's pooled displacement error, and one ``combo_<NNN>/``
+   directory per grid point holding its own Tutorial 11 style report,
+   predicted surfaces and warped labelmaps.
+
+Adapt to your data
+   ``number_of_modes_to_vary``, ``perturbation_step`` and
+   ``evaluation_spacing_mm`` are the cost knobs --- the grid is exponential in
+   the first. Point ``case_id`` at a different subject to sweep that one
+   instead.
+
 Tutorial 15: Leave-One-Out Cross-Validation
-==========================================
+===========================================
 
 Script
    ``tutorials/tutorial_15_lung_leave_one_out.py`` (DIR-Lab)
@@ -1268,9 +1348,13 @@ Run
 
       # One process
       python tutorials/tutorial_15_lung_leave_one_out.py
+      python tutorials/tutorial_15_duke_heart_leave_one_out.py
 
       # Data-parallel training and rank-split per-case loops
-      torchrun --standalone --nproc_per_node=8           tutorials/tutorial_15_lung_leave_one_out.py
+      torchrun --standalone --nproc_per_node=8 \
+          tutorials/tutorial_15_lung_leave_one_out.py
+      torchrun --standalone --nproc_per_node=8 \
+          tutorials/tutorial_15_duke_heart_leave_one_out.py
 
 Outputs
    Under ``tutorials/output/tutorial_15_<anatomy>/``: ``loo_metrics.csv`` with

--- a/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_patient-CHOPValve.py
+++ b/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_patient-CHOPValve.py
@@ -69,8 +69,8 @@ itk.imwrite(
 results = registrar.process()
 
 # %%
-registered_model = results["registered_template_model"]
-registered_model_surface = results["registered_template_model_surface"]
+registered_model = results["fitted_reference_model"]
+registered_model_surface = results["fitted_reference_mesh"]
 
 registered_model.save(str(output_dir / "registered_model.vtp"))
 registered_model_surface.save(str(output_dir / "registered_model_surface.vtp"))

--- a/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_patient.py
+++ b/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_patient.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
     icp_results = registrar.register_model_to_model_icp()
     icp_inverse_point_transform = icp_results["inverse_point_transform"]
     icp_forward_point_transform = icp_results["forward_point_transform"]
-    icp_model_surface = icp_results["registered_template_model_surface"]
+    icp_model_surface = icp_results["fitted_reference_mesh"]
     icp_labelmap = icp_results["registered_template_labelmap"]
 
     icp_model_surface.save(str(output_dir / "icp_model_surface.vtp"))
@@ -170,7 +170,7 @@ if __name__ == "__main__":
     # %%
     pca_results = registrar.register_model_to_model_pca()
     pca_coefficients = pca_results["pca_coefficients"]
-    pca_model_surface = pca_results["registered_template_model_surface"]
+    pca_model_surface = pca_results["fitted_reference_mesh"]
     pca_labelmap = pca_results["registered_template_labelmap"]
 
     pca_model_surface.save(str(output_dir / "pca_model_surface.vtp"))
@@ -186,7 +186,7 @@ if __name__ == "__main__":
     l2l_results = registrar.register_labelmap_to_labelmap()
     l2l_inverse_transform = l2l_results["inverse_transform"]
     l2l_forward_transform = l2l_results["forward_transform"]
-    l2l_model_surface = l2l_results["registered_template_model_surface"]
+    l2l_model_surface = l2l_results["fitted_reference_mesh"]
     l2l_labelmap = l2l_results["registered_template_labelmap"]
 
     print("Registration complete!")
@@ -201,7 +201,7 @@ if __name__ == "__main__":
     l2i_results = registrar.register_labelmap_to_image()
     l2i_inverse_transform = l2i_results["inverse_transform"]
     l2i_forward_transform = l2i_results["forward_transform"]
-    l2i_surface = l2i_results["registered_template_model_surface"]
+    l2i_surface = l2i_results["fitted_reference_mesh"]
     l2i_labelmap = l2i_results["registered_template_labelmap"]
     print("\nRegistration complete!")
 
@@ -255,7 +255,7 @@ if __name__ == "__main__":
     # %%
     # Load meshes from registrar member variables
     patient_surface = registrar.patient_model_surface
-    registered_surface = registrar.registered_template_model_surface
+    registered_surface = registrar.fitted_reference_mesh
     icp_surface = registrar.icp_template_model_surface
     pca_surface = registrar.pca_template_model_surface
     l2l_surface = registrar.l2l_template_model_surface

--- a/experiments/Heart_and_Lungs_Motion/0-heart_and_lungs_beating_heart.py
+++ b/experiments/Heart_and_Lungs_Motion/0-heart_and_lungs_beating_heart.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
             shape_parameters=coefficients_file,
             stage=float(stage),
             reference_image=reference_image,
-            reference_mesh=registered_mesh_file,
+            fitted_reference_mesh=registered_mesh_file,
         )
         pct = int(round(stage * 100))
         field_path = output_dir / f"deformation_field_s{pct:03d}.mha"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,7 @@ show_error_codes = true
 [[tool.mypy.overrides]]
 module = [
     "ants",
+    "ants.*",
     "cupy",
     "cupy_backends",
     "cupy_backends.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -364,6 +364,10 @@ module = [
     "tutorial_12_duke_heart_end_to_end_inference",
     "tutorial_12_lung_end_to_end_inference",
     "tutorial_13_heart_and_lung_motion",
+    "tutorial_14_duke_heart_shape_parameter_sweep",
+    "tutorial_14_lung_shape_parameter_sweep",
+    "tutorial_15_duke_heart_leave_one_out",
+    "tutorial_15_lung_leave_one_out",
 ]
 disable_error_code = ["import-not-found", "import-untyped"]
 

--- a/src/physiotwin4d/__init__.py
+++ b/src/physiotwin4d/__init__.py
@@ -93,6 +93,10 @@ from .workflow_fit_statistical_model_to_patient import (
 )
 from .workflow_infer_physicsnemo import WorkflowInferPhysicsNeMo
 from .workflow_infer_movement import WorkflowInferMovement
+from .evaluate_movement_base import EvaluateMovementBase, MovementGroundTruth
+from .evaluate_movement_duke_heart import EvaluateMovementDukeHeart
+from .evaluate_movement_lung import EvaluateMovementLung
+from .report_evaluate_movement import ReportEvaluateMovement
 from .workflow_evaluate_movement import WorkflowEvaluateMovement
 from .infer_physicsnemo_base import InferPhysicsNeMoBase
 from .infer_physicsnemo_mgn import InferPhysicsNeMoMGN
@@ -101,6 +105,7 @@ from .train_physicsnemo_base import TrainPhysicsNeMoBase
 from .train_physicsnemo_mgn import TrainPhysicsNeMoMGN
 from .train_physicsnemo_mlp import TrainPhysicsNeMoMLP
 from .workflow_train_physicsnemo import WorkflowTrainPhysicsNeMo
+from .physicsnemo_tools import DistributedContext, distributed_context
 
 __all__ = [
     # Workflow classes
@@ -115,6 +120,11 @@ __all__ = [
     "WorkflowTrainPhysicsNeMo",
     "WorkflowInferPhysicsNeMo",
     "WorkflowInferMovement",
+    "EvaluateMovementBase",
+    "EvaluateMovementDukeHeart",
+    "EvaluateMovementLung",
+    "MovementGroundTruth",
+    "ReportEvaluateMovement",
     "WorkflowEvaluateMovement",
     # Training method classes
     "TrainPhysicsNeMoBase",
@@ -145,6 +155,9 @@ __all__ = [
     "RegisterModelsDistanceMaps",
     # Base classes
     "PhysioTwin4DBase",
+    # Distributed execution
+    "DistributedContext",
+    "distributed_context",
     # Utility classes
     "ImageTools",
     "LabelmapTools",

--- a/src/physiotwin4d/cli/fit_statistical_model_to_patient.py
+++ b/src/physiotwin4d/cli/fit_statistical_model_to_patient.py
@@ -271,7 +271,7 @@ Examples:
         print("Saving results...")
 
         # Save registered model
-        registered_model = result["registered_template_model"]
+        registered_model = result["fitted_reference_model"]
         output_model_file = os.path.join(
             args.output_dir, f"{args.output_prefix}_model.vtu"
         )
@@ -279,7 +279,7 @@ Examples:
         print(f"  Registered model: {output_model_file}")
 
         # Save registered model surface
-        registered_surface = result["registered_template_model_surface"]
+        registered_surface = result["fitted_reference_mesh"]
         output_surface_file = os.path.join(
             args.output_dir, f"{args.output_prefix}_model_surface.vtp"
         )

--- a/src/physiotwin4d/cli/infer_physicsnemo.py
+++ b/src/physiotwin4d/cli/infer_physicsnemo.py
@@ -52,7 +52,7 @@ def main() -> int:
         "--displacement",
         action="store_true",
         help="Treat the targets as displacements: write reference + prediction "
-        "meshes and error statistics in mm instead of the raw target arrays.",
+        "meshes instead of the raw target arrays.",
     )
 
     # Manifest-free single-subject mode.

--- a/src/physiotwin4d/cli/infer_physicsnemo.py
+++ b/src/physiotwin4d/cli/infer_physicsnemo.py
@@ -63,13 +63,12 @@ def main() -> int:
         "--stage", type=float, default=None, help="Target stage (single-subject mode)."
     )
     parser.add_argument(
-        "--reference-mesh",
+        "--fitted-reference-mesh",
+        type=Path,
         default=None,
-        help="Subject reference mesh the displacements are added to "
-        "(single-subject mode; omit to displace the PCA reconstruction).",
-    )
-    parser.add_argument(
-        "--ground-truth", default=None, help="Optional ground-truth surface .vtp."
+        help="The subject's fitted reference mesh, as written by "
+        "physiotwin4d-fit-statistical-model-to-patient, whose points the "
+        "displacements are added to (required in single-subject mode).",
     )
     parser.add_argument(
         "--reference-image",
@@ -116,7 +115,12 @@ def main() -> int:
         # Both single-subject modes reconstruct geometry, so they need the
         # displacement interpretation of the model's targets.
         displacement = WorkflowInferMovement(workflow)
-        reference_mesh = Path(args.reference_mesh) if args.reference_mesh else None
+        if args.fitted_reference_mesh is None:
+            parser.error(
+                "--fitted-reference-mesh is required with --shape-parameters: the "
+                "displacements are defined relative to the patient's fit, and a "
+                "surface reconstructed from the shape parameters alone is not one."
+            )
         if args.reference_image is not None:
             import itk
 
@@ -125,20 +129,18 @@ def main() -> int:
                 Path(args.shape_parameters),
                 args.stage,
                 reference_image,
+                fitted_reference_mesh=args.fitted_reference_mesh,
                 output_directory=output,
-                reference_mesh=reference_mesh,
             )
             print(
                 f"Deformation field written to {result.get('deformation_field_file')}"
             )
             return 0
 
-        ground_truth = Path(args.ground_truth) if args.ground_truth else None
         result = displacement.predict_single(
             Path(args.shape_parameters),
             args.stage,
-            reference_mesh=reference_mesh,
-            ground_truth=ground_truth,
+            fitted_reference_mesh=args.fitted_reference_mesh,
             output_directory=output,
         )
         print(f"Predicted surface written to {result['predicted_surface']}")

--- a/src/physiotwin4d/contour_tools.py
+++ b/src/physiotwin4d/contour_tools.py
@@ -1272,7 +1272,7 @@ class ContourTools(PhysioTwin4DBase):
             == reference_image.GetLargestPossibleRegion().GetSize()
         )
 
-        blurred_norm = itk.SmoothingRecursiveGaussianImageFilter(
+        blurred_norm = itk.smoothing_recursive_gaussian_image_filter(
             Input=norm_img, Sigma=blur_sigma
         )
         blurred_norm_arr = itk.GetArrayFromImage(blurred_norm)
@@ -1280,19 +1280,19 @@ class ContourTools(PhysioTwin4DBase):
 
         deformation_field_x_img = itk.GetImageFromArray(displacement_map_x)
         deformation_field_x_img.CopyInformation(reference_image)
-        deformation_field_x_img = itk.SmoothingRecursiveGaussianImageFilter(
+        deformation_field_x_img = itk.smoothing_recursive_gaussian_image_filter(
             Input=deformation_field_x_img, Sigma=blur_sigma
         )
 
         deformation_field_y_img = itk.GetImageFromArray(displacement_map_y)
         deformation_field_y_img.CopyInformation(reference_image)
-        deformation_field_y_img = itk.SmoothingRecursiveGaussianImageFilter(
+        deformation_field_y_img = itk.smoothing_recursive_gaussian_image_filter(
             Input=deformation_field_y_img, Sigma=blur_sigma
         )
 
         deformation_field_z_img = itk.GetImageFromArray(displacement_map_z)
         deformation_field_z_img.CopyInformation(reference_image)
-        deformation_field_z_img = itk.SmoothingRecursiveGaussianImageFilter(
+        deformation_field_z_img = itk.smoothing_recursive_gaussian_image_filter(
             Input=deformation_field_z_img, Sigma=blur_sigma
         )
 

--- a/src/physiotwin4d/contour_tools.py
+++ b/src/physiotwin4d/contour_tools.py
@@ -770,8 +770,9 @@ class ContourTools(PhysioTwin4DBase):
 
         Remeshing rebuilds the topology and so discards cell data, exactly as
         ``decimate_pro`` did: per-cell ``boundary_labels`` (needed for anatomy
-        splitting downstream) are transferred back onto the new cells from their
-        nearest original cell so anatomy materials still apply.  Uniform
+        splitting downstream) and ``SegmentationLabelIds`` (which structure each
+        triangle belongs to) are transferred back onto the new cells from their
+        nearest original cell so anatomy materials and structure ids still apply.  Uniform
         triangles cannot represent a label patch smaller than one of them,
         though, so such a patch is absorbed by its neighbours and its label pair
         disappears -- a warning names the pairs lost.  ``decimate_pro`` kept
@@ -802,11 +803,20 @@ class ContourTools(PhysioTwin4DBase):
                 max(4, round(original.n_points * (1.0 - surface_reduction_rate)))
             )
             conditioned = clustering.create_mesh()
+            carried = [
+                name
+                for name in ("boundary_labels", "SegmentationLabelIds")
+                if name in original.cell_data
+            ]
+            if carried:
+                nearest = original.find_closest_cell(conditioned.cell_centers().points)
+                for name in carried:
+                    conditioned.cell_data[name] = np.asarray(original.cell_data[name])[
+                        nearest
+                    ]
+
             if "boundary_labels" in original.cell_data:
                 labels = np.asarray(original.cell_data["boundary_labels"])
-                nearest = original.find_closest_cell(conditioned.cell_centers().points)
-                conditioned.cell_data["boundary_labels"] = labels[nearest]
-
                 pairs = labels.reshape(len(labels), -1)
                 before = {tuple(row) for row in np.unique(pairs, axis=0).tolist()}
                 after = {

--- a/src/physiotwin4d/evaluate_movement_base.py
+++ b/src/physiotwin4d/evaluate_movement_base.py
@@ -1,0 +1,151 @@
+"""What one cohort of subjects is scored against, and how to assemble it.
+
+:class:`EvaluateMovementBase` holds the parts of a movement evaluation that
+depend on *which cohort* is being scored -- the structures to report, how a
+stage is read off a filename, and how that cohort's ground truth is gathered --
+so that :class:`physiotwin4d.WorkflowEvaluateMovement` can hold the parts that
+do not. The workflow composes a cohort the way
+:class:`physiotwin4d.WorkflowInferPhysicsNeMo` composes an inference method.
+
+Keeping the cohort out of the workflow is what stops the workflow growing
+anatomy branches. It scores whatever structures it is handed, by whatever
+partition the shape model supports, and never learns which cohort produced them.
+
+Concrete cohorts: :class:`physiotwin4d.EvaluateMovementLung` and
+:class:`physiotwin4d.EvaluateMovementDukeHeart`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import itk
+
+from .physiotwin4d_base import PhysioTwin4DBase
+from .segment_anatomy_base import SegmentAnatomyBase
+
+
+@dataclass(frozen=True)
+class MovementGroundTruth:
+    """One case's acquired frames and the fits its prediction is scored against.
+
+    Attributes:
+        labelmaps: Acquired labelmap per stage, keyed by the normalized stage in
+            ``[0, 1]``. Every volume and overlap figure is measured against
+            these.
+        reference_labelmap: Labelmap of the frame every predicted deformation
+            starts from, the anatomy carried into every other stage.
+        reference_stage: Which stage that frame is.
+        meshes: The case's fitted surface per stage, keyed the same way and
+            sharing the fitted reference mesh's topology and point ordering. The
+            acquired labelmaps carry no point correspondence, so these are the
+            only source of a true per-point displacement.
+    """
+
+    labelmaps: dict[float, itk.Image]
+    reference_labelmap: itk.Image
+    reference_stage: float
+    meshes: dict[float, Path]
+
+
+class EvaluateMovementBase(PhysioTwin4DBase):
+    """A cohort of subjects and the ground truth its movement is scored against.
+
+    Not instantiated directly -- use :class:`physiotwin4d.EvaluateMovementLung`
+    or :class:`physiotwin4d.EvaluateMovementDukeHeart`. Subclasses set the class
+    attributes below and implement :meth:`stage_from_filename` and
+    :meth:`assemble_ground_truth`; :meth:`display_name` is an optional hook.
+
+    Attributes:
+        segmenter_class: Segmenter whose taxonomy names this cohort's
+            structures. Instantiated for its taxonomy alone, which downloads and
+            loads nothing.
+        label_ids: The structures to score, in report order.
+        report_dice: Whether Dice belongs in this cohort's report. Off for a
+            structure whose motion is small against its own size: Dice is an
+            overlap fraction, so a lung lobe scores over 0.96 undeformed.
+        evaluation_spacing_mm: Isotropic pitch every metric is measured on.
+        smoothing_sigma_mm: Gaussian sigma, in millimeters, that turns the
+            network's surface-shell deformation into a continuous field.
+
+    Args:
+        log_level: Logging level. Default: ``logging.INFO``.
+    """
+
+    segmenter_class: Optional[type[SegmentAnatomyBase]] = None
+    label_ids: tuple[int, ...] = ()
+    report_dice: bool = True
+    evaluation_spacing_mm: float = 1.0
+    smoothing_sigma_mm: float = 10.0
+
+    def __init__(self, log_level: int | str = logging.INFO) -> None:
+        super().__init__(class_name=self.__class__.__name__, log_level=log_level)
+
+    # ─────────────────────────── Public API ────────────────────────────────
+    def label_names(self) -> dict[int, str]:
+        """The structures this cohort scores, ``{label id: report name}``.
+
+        Read from :attr:`segmenter_class`'s taxonomy and passed through
+        :meth:`display_name`, so a cohort never restates names the segmenter
+        already knows.
+
+        Raises:
+            NotImplementedError: On a cohort that names no segmenter.
+        """
+        if self.segmenter_class is None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} names no segmenter_class, so it "
+                "cannot look its structures up; set that attribute or override "
+                "label_names."
+            )
+        # Constructed for the taxonomy alone: no weights are fetched and no
+        # model is loaded until a segmentation is actually asked for.
+        taxonomy = self.segmenter_class(log_level=logging.WARNING).taxonomy
+        all_labels = taxonomy.all_labels()
+        return {
+            label_id: self.display_name(label_id, all_labels[label_id])
+            for label_id in self.label_ids
+        }
+
+    def display_name(self, label_id: int, taxonomy_name: str) -> str:
+        """The report name of one structure. The base reports the taxonomy's own.
+
+        Overridden by a cohort whose taxonomy name would mislead a reader of the
+        report.
+        """
+        return taxonomy_name
+
+    def stage_from_filename(self, path: Path) -> float:
+        """The normalized stage in ``[0, 1]`` this frame was acquired at.
+
+        Raises:
+            NotImplementedError: Implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    def assemble_ground_truth(
+        self,
+        case_id: str,
+        frame_directory: Path,
+        fit_directory: Path,
+        cache_directory: Optional[Path] = None,
+    ) -> MovementGroundTruth:
+        """Gather one case's acquired frames and its per-stage fits.
+
+        Args:
+            case_id: The case being scored.
+            frame_directory: Where that case's acquired frames live.
+            fit_directory: Where its per-stage ``*_ssm_surface.vtp`` fits live --
+                Tutorial 8's case directory, or one leave-one-out fold's own
+                fits, which is what makes a fold's score honest.
+            cache_directory: Where a cohort that has to *derive* its labelmaps
+                writes them and reads them back. A cohort whose labelmaps ship
+                with the data ignores it.
+
+        Raises:
+            NotImplementedError: Implemented by subclasses.
+        """
+        raise NotImplementedError

--- a/src/physiotwin4d/evaluate_movement_duke_heart.py
+++ b/src/physiotwin4d/evaluate_movement_duke_heart.py
@@ -1,0 +1,122 @@
+"""The Duke gated-labelmap heart cohort, as a movement-evaluation subject.
+
+Unlike the lung, this cohort ships one labelmap per gated frame, each already
+carrying the four chambers, the myocardium and the whole heart, so nothing has
+to be segmented and there is nothing to cache.
+
+The shape model this cohort scores is one structure -- the whole heart minus its
+chamber cavities -- so the chambers exist only in these acquired labelmaps.
+Scoring through them is what makes per-chamber figures possible at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import itk
+
+from .evaluate_movement_base import EvaluateMovementBase, MovementGroundTruth
+from .segment_heart_simpleware_trimmed_branches import (
+    SegmentHeartSimplewareTrimmedBranches,
+)
+
+
+class EvaluateMovementDukeHeart(EvaluateMovementBase):
+    """The heart chambers, scored against the labelmaps the cohort ships.
+
+    Args:
+        log_level: Logging level. Default: ``logging.INFO``.
+    """
+
+    segmenter_class = SegmentHeartSimplewareTrimmedBranches
+    # The four chambers, plus the myocardium and the whole heart for context: 5
+    # and 6 are what the shape model itself represents, 1-4 are the cavities it
+    # does not. The great vessels and coronaries (7-10) are left out; they come
+    # and go between frames and are not part of the model.
+    label_ids = (1, 2, 3, 4, 5, 6)
+    report_dice = True
+    # Coarser than these labelmaps, whose in-plane pitch is finer than the
+    # accuracy being reported, and still below the thinnest wall of the heart.
+    evaluation_spacing_mm = 1.0
+
+    labelmap_suffix = "_labelmap.nii.gz"
+    # Tutorial 8's per-frame SSM fits, the same surfaces Tutorial 10 scores.
+    phase_surface_pattern = "*_g[0-9][0-9][0-9]_*_ssm_surface.vtp"
+
+    def display_name(self, label_id: int, taxonomy_name: str) -> str:
+        """Report the taxonomy's "heart" as "heart muscle".
+
+        The taxonomy's ``heart`` is the whole heart *minus* its chamber
+        cavities -- the muscle the shape model represents -- and a report that
+        listed it beside four chambers under the bare name "heart" would read as
+        if it were their sum.
+        """
+        return "heart muscle" if taxonomy_name == "heart" else taxonomy_name
+
+    def stage_from_filename(self, path: Path) -> float:
+        """Read the normalized cardiac stage from a ``g{PPP}`` filename.
+
+        Matched against the full name rather than the stem, since ``.nii.gz`` is
+        a double suffix that :attr:`Path.stem` only half removes.
+        """
+        for part in path.name.split("_"):
+            if part.startswith("g") and part[1:].isdigit():
+                return int(part[1:]) / 100.0
+        raise ValueError(f"Cannot parse cardiac gate from filename: {path}")
+
+    def assemble_ground_truth(
+        self,
+        case_id: str,
+        frame_directory: Path,
+        fit_directory: Path,
+        cache_directory: Optional[Path] = None,
+    ) -> MovementGroundTruth:
+        """Read one case's gated labelmaps and its per-frame fits.
+
+        ``cache_directory`` is ignored: these labelmaps are acquired, not
+        derived, so there is nothing to cache.
+
+        Raises:
+            FileNotFoundError: If the case has no gated labelmaps, no frame
+                marked ``*_ref``, or no per-frame fits.
+        """
+        frame_files = sorted(frame_directory.glob(f"*{self.labelmap_suffix}"))
+        if not frame_files:
+            raise FileNotFoundError(
+                f"No gated labelmaps found in {frame_directory}.\n"
+                "See data/Duke-Heart-4DLabelmaps/README.md."
+            )
+        reference_files = [
+            path
+            for path in frame_files
+            if path.name.endswith(f"_ref{self.labelmap_suffix}")
+        ]
+        if not reference_files:
+            raise FileNotFoundError(
+                f"No *_ref{self.labelmap_suffix} frame in {frame_directory}; "
+                "Tutorial 8 fitted the SSM to that frame, so it is the one the "
+                "deformations start from."
+            )
+
+        surface_files = sorted(fit_directory.glob(self.phase_surface_pattern))
+        if not surface_files:
+            raise FileNotFoundError(
+                f"No per-frame SSM surfaces found in {fit_directory}.\n"
+                "Run tutorials/tutorial_08_duke_heart_fit_model_to_4d_patients.py "
+                "first."
+            )
+
+        self.log_info("Case %s: %d gated frames", case_id, len(frame_files))
+        return MovementGroundTruth(
+            labelmaps={
+                self.stage_from_filename(frame_file): itk.imread(str(frame_file))
+                for frame_file in frame_files
+            },
+            reference_labelmap=itk.imread(str(reference_files[0])),
+            reference_stage=self.stage_from_filename(reference_files[0]),
+            meshes={
+                self.stage_from_filename(surface_file): surface_file
+                for surface_file in surface_files
+            },
+        )

--- a/src/physiotwin4d/evaluate_movement_lung.py
+++ b/src/physiotwin4d/evaluate_movement_lung.py
@@ -1,0 +1,129 @@
+"""The DIR-Lab gated-CT lung cohort, as a movement-evaluation subject.
+
+This cohort ships CT, not labelmaps, so its ground truth has to be *derived*:
+every gated frame is segmented on its own, which means the lobes a phase is
+scored against came from that phase's image rather than from a registration or a
+shape-model fit. Segmentation dominates the runtime, so each labelmap is cached
+and reused on a re-run.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import itk
+
+from .evaluate_movement_base import EvaluateMovementBase, MovementGroundTruth
+from .segment_nv_segment_ct_mri import SegmentNVSegmentCTMRI
+
+
+class EvaluateMovementLung(EvaluateMovementBase):
+    """The five lung lobes, scored against per-phase segmentations of gated CT.
+
+    Args:
+        reference_phase: The phase the shape model was fitted to, and therefore
+            the one whose anatomy the predicted deformations carry into every
+            other phase. Default: ``"T70"``.
+        log_level: Logging level. Default: ``logging.INFO``.
+    """
+
+    segmenter_class = SegmentNVSegmentCTMRI
+    # The five lobes of ``SegmentNVSegmentCTMRI``. Its "lung" group also carries
+    # whole-lung, tumor and airway labels, which are not lobes.
+    label_ids = (28, 29, 30, 31, 32)
+    # A lobe barely changes shape over a breath compared to how big it is, so
+    # Dice says more about the lobe than about the motion. Volume difference and
+    # surface RMSE are what resolve it here.
+    report_dice = False
+    # Coarser than the CT, whose in-plane pitch is finer than the accuracy being
+    # reported, and fine enough that a lobe boundary is not quantized away.
+    evaluation_spacing_mm = 2.0
+
+    def __init__(
+        self, reference_phase: str = "T70", log_level: int | str = logging.INFO
+    ) -> None:
+        super().__init__(log_level=log_level)
+        self.reference_phase = reference_phase
+
+    def stage_from_filename(self, path: Path) -> float:
+        """Read the normalized respiratory stage from a ``T{PP}`` filename stem."""
+        for part in path.stem.split("_"):
+            if part.startswith("T") and part[1:].isdigit():
+                return int(part[1:]) / 100.0
+        raise ValueError(f"Cannot parse respiratory phase from filename: {path}")
+
+    def assemble_ground_truth(
+        self,
+        case_id: str,
+        frame_directory: Path,
+        fit_directory: Path,
+        cache_directory: Optional[Path] = None,
+    ) -> MovementGroundTruth:
+        """Segment every gated frame of one case, then read its per-phase fits.
+
+        ``cache_directory`` is required: a segmentation pass per phase is the
+        expensive part of an evaluation, so it is written once and reused. A
+        caller that has already produced those labelmaps under the same names --
+        a leave-one-out study building a shared cache, say -- gets them read
+        straight back and pays nothing.
+
+        Raises:
+            ValueError: If ``cache_directory`` is not given.
+            FileNotFoundError: If the case has no gated frames, no per-phase
+                fits, or no frame at :attr:`reference_phase`.
+        """
+        if cache_directory is None:
+            raise ValueError(
+                "EvaluateMovementLung needs a cache_directory: it segments every "
+                "gated frame, which is too expensive to repeat on every run."
+            )
+        frame_files = sorted(frame_directory.glob(f"{case_id}_T??.mha"))
+        if not frame_files:
+            raise FileNotFoundError(
+                f"No {case_id}_T??.mha frames found under {frame_directory}.\n"
+                "See data/DirLab-4DCT/README.md for download instructions."
+            )
+        cache_directory.mkdir(parents=True, exist_ok=True)
+
+        segmenter = self.segmenter_class(log_level=self.log_level)
+        labelmaps: dict[float, itk.Image] = {}
+        for frame_file in frame_files:
+            labelmap_file = cache_directory / f"{frame_file.stem}_labelmap.nii.gz"
+            if not labelmap_file.exists():
+                self.log_info("Segmenting ground-truth frame %s", frame_file.name)
+                segmentation = segmenter.segment(itk.imread(str(frame_file)))
+                itk.imwrite(
+                    segmentation["labelmap"], str(labelmap_file), compression=True
+                )
+            labelmaps[self.stage_from_filename(frame_file)] = itk.imread(
+                str(labelmap_file)
+            )
+
+        reference_file = (
+            cache_directory / f"{case_id}_{self.reference_phase}_labelmap.nii.gz"
+        )
+        if not reference_file.exists():
+            raise FileNotFoundError(
+                f"Reference phase {self.reference_phase} is not among "
+                f"{frame_directory}'s frames, so {reference_file} was never "
+                "segmented."
+            )
+
+        surface_files = sorted(fit_directory.glob(f"{case_id}_T??_ssm_surface.vtp"))
+        if not surface_files:
+            raise FileNotFoundError(
+                f"No per-phase SSM surfaces found in {fit_directory}.\n"
+                "Run tutorials/tutorial_08_lung_fit_model_to_4d_patients.py first."
+            )
+
+        return MovementGroundTruth(
+            labelmaps=labelmaps,
+            reference_labelmap=itk.imread(str(reference_file)),
+            reference_stage=self.stage_from_filename(reference_file),
+            meshes={
+                self.stage_from_filename(surface_file): surface_file
+                for surface_file in surface_files
+            },
+        )

--- a/src/physiotwin4d/physicsnemo_tools.py
+++ b/src/physiotwin4d/physicsnemo_tools.py
@@ -36,6 +36,7 @@ needs them imports them locally so ``import physiotwin4d`` works without the
 from __future__ import annotations
 
 import json
+import os
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
@@ -234,9 +235,10 @@ def mesh_to_edge_index(mesh: pv.DataSet) -> "torch.Tensor":
         src = np.concatenate([faces[:, 0], faces[:, 1], faces[:, 2]])
         dst = np.concatenate([faces[:, 1], faces[:, 2], faces[:, 0]])
     else:
-        # use_all_points keeps every input point in the output, so the line
-        # connectivity indexes the original point ids.
-        edges = mesh.extract_all_edges(use_all_points=True, clear_data=True)
+        # extract_all_edges keeps every input point in the output, so the line
+        # connectivity indexes the original point ids.  The check below is what
+        # holds that; the guarantee is not stated in the pyvista contract.
+        edges = mesh.extract_all_edges(clear_data=True)
         if edges.n_points != mesh.n_points:
             raise ValueError(
                 f"Edge extraction returned {edges.n_points} points for a mesh "
@@ -297,6 +299,22 @@ class DistributedContext:
         torch.distributed.barrier()
 
 
+def _launched_world_size() -> int:
+    """How many processes the launcher says are in this job, 1 if none says.
+
+    Read straight from the environment rather than from PhysicsNeMo, because
+    this is what has to be known *before* PhysicsNeMo is known to be there.
+    The three variables are the ones ``DistributedManager`` itself consults,
+    for ``torchrun``, SLURM and OpenMPI respectively.
+    """
+    sizes = [
+        int(os.environ[name])
+        for name in ("WORLD_SIZE", "SLURM_NTASKS", "OMPI_COMM_WORLD_SIZE")
+        if os.environ.get(name, "").isdigit()
+    ]
+    return max(sizes, default=1)
+
+
 def distributed_context() -> DistributedContext:
     """Initialize PhysicsNeMo's ``DistributedManager`` and read it back.
 
@@ -304,12 +322,31 @@ def distributed_context() -> DistributedContext:
     environments and falls back to a single process when it finds none, so this
     is safe to call from any entry point.  Initialization is done once per
     process; calling this again returns the same context.
-    """
-    import torch
 
+    Raises:
+        ImportError: If the process was launched as one of several and
+            PhysicsNeMo is not installed. Raised before anything is imported or
+            written, so the caller has not yet created an output directory.
+    """
     try:
         from physicsnemo.distributed import DistributedManager
-    except ImportError:
+    except ImportError as exc:
+        # PhysicsNeMo is what reads the launcher's environment, so without it
+        # every rank of a multi-process launch would call itself rank 0 of a
+        # world of 1: each would train on the whole dataset and each would
+        # write over the others' checkpoints, silently and at full cost.
+        launched = _launched_world_size()
+        if launched > 1:
+            raise ImportError(
+                f"This process is 1 of {launched} in a distributed launch, but "
+                "PhysicsNeMo is not installed, and it is what assigns the "
+                "ranks. Without it every process would call itself rank 0 and "
+                "overwrite the others' output. Install with: pip install "
+                '"physiotwin4d[physicsnemo]", or run in a single process.'
+            ) from exc
+
+        import torch
+
         # The MLP path does not otherwise need the [physicsnemo] extra, so a
         # missing PhysicsNeMo means a single process rather than an error.
         return DistributedContext(
@@ -346,9 +383,9 @@ def unwrap_model(model: Any) -> Any:
         model = inner
 
 
-def uncompiled_state_dict(model: Any) -> dict:
+def uncompiled_state_dict(model: Any) -> dict[str, Any]:
     """Return a model's state dict, unwrapping ``torch.compile`` and DDP."""
-    return cast(dict, unwrap_model(model).state_dict())
+    return cast(dict[str, Any], unwrap_model(model).state_dict())
 
 
 def strip_compile_prefix(state: dict) -> dict:

--- a/src/physiotwin4d/physicsnemo_tools.py
+++ b/src/physiotwin4d/physicsnemo_tools.py
@@ -5,20 +5,21 @@ connected (MLP) PhysicsNeMo workflows so the workflow classes stay focused on
 orchestration.  It provides:
 
 - :class:`SubjectManifest` / :func:`parse_manifest` — the per-subject JSON
-  manifest that lists a reference mesh, a PCA shape-parameter file, the name of
-  the point-data array holding the training targets, and the phase meshes that
-  carry that array with their stages.
+  manifest that lists a fitted reference mesh, a PCA shape-parameter file, the
+  name of the point-data array holding the training targets, and the phase
+  meshes that carry that array with their stages.
 - :func:`load_target_array` — read one phase's ``(n_points, n_target)`` target
   values out of a mesh's point data.
 - :func:`build_node_features` — the shared per-vertex feature layout
   ``[mean_coords_norm, pca_norm (tiled), stage]`` used by both networks.
 - :func:`mesh_to_edge_index` / :func:`compute_edge_features` — MGN mesh-graph
   construction from the shared template mesh (surface or volumetric).
-- :func:`reconstruct_reference_points` — rebuild a subject reference mesh's
-  points from PCA shape parameters (``P = mean + Σ b_i·std_i·eigenvector_i``),
-  used for manifest-free single-subject inference.
 - :func:`uncompiled_state_dict` / :func:`strip_compile_prefix` — checkpoint I/O
-  that is robust to ``torch.compile`` wrapping.
+  that is robust to ``torch.compile`` and ``DistributedDataParallel`` wrapping.
+- :class:`DistributedContext` / :func:`distributed_context` — the rank, device
+  and world size of the current process, from PhysicsNeMo's
+  ``DistributedManager``.  A run started without a launcher gets world size 1,
+  so single-process callers need no distributed-specific code.
 - :class:`PhaseSampleDataset` — a lazy ``(subject, phase)`` sample provider with
   a bounded in-RAM cache so the training set need not fit in memory.
 
@@ -64,9 +65,13 @@ class SubjectManifest:
 
     Attributes:
         subject_id: Identifier used for output naming.
-        reference_mesh: The subject's SSM reference mesh (``.vtp`` surface or
-            ``.vtu`` volume). It supplies the point positions the targets are
-            defined at; the stack never derives targets from it.
+        fitted_reference_mesh: The subject's SSM surface as fitted to that
+            subject by
+            :class:`physiotwin4d.WorkflowFitStatisticalModelToPatient` (``.vtp``
+            surface or ``.vtu`` volume) --- shape parameters *and* a deformable
+            registration, never shape parameters alone. It supplies the point
+            positions the targets are defined at; the stack never derives
+            targets from it.
         pca_coefficients: JSON file holding the subject's PCA shape-parameter
             vector (a flat list of floats).
         target_array: Name of the point-data array holding the target values in
@@ -75,7 +80,7 @@ class SubjectManifest:
     """
 
     subject_id: str
-    reference_mesh: Path
+    fitted_reference_mesh: Path
     pca_coefficients: Path
     target_array: str
     phases: list[PhaseEntry]
@@ -111,7 +116,7 @@ def parse_manifest(manifest_path: Path) -> SubjectManifest:
 
     for key in (
         "subject_id",
-        "reference_mesh",
+        "fitted_reference_mesh",
         "pca_coefficients",
         "target_array",
         "phases",
@@ -136,7 +141,7 @@ def parse_manifest(manifest_path: Path) -> SubjectManifest:
 
     return SubjectManifest(
         subject_id=str(data["subject_id"]),
-        reference_mesh=_resolve(data["reference_mesh"]),
+        fitted_reference_mesh=_resolve(data["fitted_reference_mesh"]),
         pca_coefficients=_resolve(data["pca_coefficients"]),
         target_array=str(data["target_array"]),
         phases=phases,
@@ -257,57 +262,93 @@ def compute_edge_features(
 
 
 # --------------------------------------------------------------------------- #
-# PCA reconstruction (manifest-free inference)                                 #
+# Distributed context                                                          #
 # --------------------------------------------------------------------------- #
-def reconstruct_reference_points(
-    mean_mesh: pv.DataSet, pca_model: dict, coeffs: np.ndarray
-) -> np.ndarray:
-    """Reconstruct a subject reference mesh's points from PCA shape parameters.
+@dataclass
+class DistributedContext:
+    """Rank, device and world size of the current process.
 
-    Applies the statistical-shape-model equation
-    ``P = mean + Σ b_i·std_i·eigenvector_i`` on the PCA template *mesh*
-    (whose ``components`` are defined) and returns the deformed points. Because
-    every subject shares the template topology, the point ordering matches the
-    shared template mesh used for training.
-
-    Args:
-        mean_mesh: PCA template mesh (e.g. ``pca_mean.vtu``) whose point count
-            matches the model components.
-        pca_model: Dict with ``eigenvalues`` and ``components`` (the
-            ``pca_model.json`` format).
-        coeffs: Subject PCA coefficients ``b_i`` (in units of standard
-            deviations); shorter/longer than the mode count is truncated.
-
-    Returns:
-        ``(n_points, 3)`` float32 reconstructed points.
-
-    Raises:
-        ValueError: If the component dimension does not match ``mean_mesh``.
+    ``world_size == 1`` covers both a run started without a launcher and a
+    single-GPU run under one, so callers branch on that rather than on how the
+    process was started.
     """
-    std = np.sqrt(np.asarray(pca_model["eigenvalues"], dtype=np.float64))
-    components = np.asarray(pca_model["components"], dtype=np.float64)
-    expected = mean_mesh.n_points * 3
-    if components.shape[1] != expected:
-        raise ValueError(
-            f"PCA component dimension {components.shape[1]} does not match "
-            f"mean mesh ({expected} = 3 x {mean_mesh.n_points} points)."
+
+    device: "torch.device"
+    rank: int
+    local_rank: int
+    world_size: int
+
+    @property
+    def is_main(self) -> bool:
+        """True on the one rank that owns writing to disk and logging."""
+        return self.rank == 0
+
+    @property
+    def is_distributed(self) -> bool:
+        """True when gradients have to be synchronized across ranks."""
+        return self.world_size > 1
+
+    def barrier(self) -> None:
+        """Block until every rank arrives; a no-op outside a distributed run."""
+        if not self.is_distributed:
+            return
+        import torch
+
+        torch.distributed.barrier()
+
+
+def distributed_context() -> DistributedContext:
+    """Initialize PhysicsNeMo's ``DistributedManager`` and read it back.
+
+    ``DistributedManager.initialize`` picks up ``torchrun``, SLURM or OpenMPI
+    environments and falls back to a single process when it finds none, so this
+    is safe to call from any entry point.  Initialization is done once per
+    process; calling this again returns the same context.
+    """
+    import torch
+
+    try:
+        from physicsnemo.distributed import DistributedManager
+    except ImportError:
+        # The MLP path does not otherwise need the [physicsnemo] extra, so a
+        # missing PhysicsNeMo means a single process rather than an error.
+        return DistributedContext(
+            device=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+            rank=0,
+            local_rank=0,
+            world_size=1,
         )
 
-    b = np.asarray(coeffs, dtype=np.float64)
-    n_modes = min(len(b), len(std), components.shape[0])
-    deform_flat = (b[:n_modes] * std[:n_modes]) @ components[:n_modes]
-    deform = deform_flat.reshape(-1, 3)
-
-    points = np.asarray(mean_mesh.points, dtype=np.float64) + deform
-    return np.asarray(points, dtype=np.float32)
+    if not DistributedManager.is_initialized():
+        DistributedManager.initialize()
+    manager = DistributedManager()
+    return DistributedContext(
+        device=manager.device,
+        rank=int(manager.rank),
+        local_rank=int(manager.local_rank),
+        world_size=int(manager.world_size),
+    )
 
 
 # --------------------------------------------------------------------------- #
 # Checkpoint I/O                                                               #
 # --------------------------------------------------------------------------- #
+def unwrap_model(model: Any) -> Any:
+    """Return the bare module inside any ``torch.compile`` / DDP wrappers.
+
+    Both wrappers can be applied, in either order, so peel until neither
+    attribute is left rather than checking for one of them.
+    """
+    while True:
+        inner = getattr(model, "_orig_mod", None) or getattr(model, "module", None)
+        if inner is None:
+            return model
+        model = inner
+
+
 def uncompiled_state_dict(model: Any) -> dict:
-    """Return a model's state dict, unwrapping ``torch.compile`` if applied."""
-    return cast(dict, getattr(model, "_orig_mod", model).state_dict())
+    """Return a model's state dict, unwrapping ``torch.compile`` and DDP."""
+    return cast(dict, unwrap_model(model).state_dict())
 
 
 def strip_compile_prefix(state: dict) -> dict:

--- a/src/physiotwin4d/register_images_ants.py
+++ b/src/physiotwin4d/register_images_ants.py
@@ -9,9 +9,11 @@ The module uses the antspyx package which provides Python bindings to the ANTs
 C++ library, offering robust and well-established registration algorithms.
 """
 
+from __future__ import annotations
+
 import logging
 import os
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import ants
 import itk
@@ -20,6 +22,14 @@ from numpy.typing import NDArray
 
 from .register_images_base import RegisterImagesBase
 from .transform_tools import TransformTools
+
+if TYPE_CHECKING:  # typed for mypy; never imported at runtime
+    # antspyx re-exports these at the top level in some releases and not in
+    # others (0.6.1 has ants.ANTsImage, 0.5.3 does not), so they are named from
+    # the module they are defined in, which both carry.  ``ants.ants_image`` is
+    # that module, not the class -- annotating with it says nothing.
+    from ants.core.ants_image import ANTsImage
+    from ants.core.ants_transform import ANTsTransform
 
 
 class RegisterImagesANTS(RegisterImagesBase):
@@ -117,11 +127,11 @@ class RegisterImagesANTS(RegisterImagesBase):
             self.log_error("Invalid metric: %s", metric)
             raise ValueError(f"Invalid metric: {metric}")
 
-    def _ants_to_itk_image(self, ants_image: ants.ants_image) -> itk.Image:
+    def _ants_to_itk_image(self, ants_image: ANTsImage) -> itk.Image:
         """Convert ANTs image back to ITK format.
 
         Args:
-            ants_image (ants.core.ants_image): ANTs image to convert
+            ants_image (ANTsImage): ANTs image to convert
             reference_itk_image (itk.image): Reference ITK image for metadata
 
         Returns:
@@ -164,14 +174,14 @@ class RegisterImagesANTS(RegisterImagesBase):
 
     def _itk_to_ants_image(
         self, itk_image: itk.Image, dtype: str = "float"
-    ) -> ants.ants_image:
+    ) -> ANTsImage:
         """Convert ITK image to ANTs format.
 
         Args:
             itk_image (itk.image): ITK image to convert
 
         Returns:
-            ants.core.ants_image: Converted ANTs image
+            ANTsImage: Converted ANTs image
         """
         ndim = itk_image.GetImageDimension()
         if ndim not in (2, 3, 4):
@@ -211,7 +221,7 @@ class RegisterImagesANTS(RegisterImagesBase):
         else:
             data_reshaped = data.transpose(list(range(image_dimension - 1, -1, -1)))
 
-        ants_image: ants.ants_image = ants.from_numpy(
+        ants_image: ANTsImage = ants.from_numpy(
             data=data_reshaped,
             origin=origin,
             spacing=spacing,
@@ -313,7 +323,7 @@ class RegisterImagesANTS(RegisterImagesBase):
 
     def itk_affine_transform_to_ANTS_transform(
         self, itk_tfm: itk.Transform
-    ) -> ants.ANTsTransform:
+    ) -> ANTsTransform:
         """Convert ITK affine/rigid transform to ANTs affine transform.
 
         Converts an ITK MatrixOffsetTransformBase-derived transform (such as
@@ -330,7 +340,7 @@ class RegisterImagesANTS(RegisterImagesBase):
                 itk.Rigid3DTransform, etc.)
 
         Returns:
-            ants.ANTsTransform: ANTs affine transform object
+            ANTsTransform: ANTs affine transform object
 
         Raises:
             ValueError: If transform dimension is not 3D

--- a/src/physiotwin4d/register_images_ants.py
+++ b/src/physiotwin4d/register_images_ants.py
@@ -117,11 +117,11 @@ class RegisterImagesANTS(RegisterImagesBase):
             self.log_error("Invalid metric: %s", metric)
             raise ValueError(f"Invalid metric: {metric}")
 
-    def _ants_to_itk_image(self, ants_image: ants.ANTsImage) -> itk.Image:
+    def _ants_to_itk_image(self, ants_image: ants.ants_image) -> itk.Image:
         """Convert ANTs image back to ITK format.
 
         Args:
-            ants_image (ants.core.ANTsImage): ANTs image to convert
+            ants_image (ants.core.ants_image): ANTs image to convert
             reference_itk_image (itk.image): Reference ITK image for metadata
 
         Returns:
@@ -164,14 +164,14 @@ class RegisterImagesANTS(RegisterImagesBase):
 
     def _itk_to_ants_image(
         self, itk_image: itk.Image, dtype: str = "float"
-    ) -> ants.ANTsImage:
+    ) -> ants.ants_image:
         """Convert ITK image to ANTs format.
 
         Args:
             itk_image (itk.image): ITK image to convert
 
         Returns:
-            ants.core.ANTsImage: Converted ANTs image
+            ants.core.ants_image: Converted ANTs image
         """
         ndim = itk_image.GetImageDimension()
         if ndim not in (2, 3, 4):
@@ -211,7 +211,7 @@ class RegisterImagesANTS(RegisterImagesBase):
         else:
             data_reshaped = data.transpose(list(range(image_dimension - 1, -1, -1)))
 
-        ants_image: ants.ANTsImage = ants.from_numpy(
+        ants_image: ants.ants_image = ants.from_numpy(
             data=data_reshaped,
             origin=origin,
             spacing=spacing,

--- a/src/physiotwin4d/register_models_distance_maps.py
+++ b/src/physiotwin4d/register_models_distance_maps.py
@@ -291,7 +291,7 @@ class RegisterModelsDistanceMaps(PhysioTwin4DBase):
 
         Returns:
             Dictionary containing:
-                - 'moving_model': Aligned moving model (PyVista PolyData)
+                - 'registered_model': Aligned moving model (PyVista PolyData)
                 - 'forward_transform': Moving→fixed transform (ITK CompositeTransform)
                 - 'inverse_transform': Fixed→moving transform (ITK CompositeTransform)
 

--- a/src/physiotwin4d/report_evaluate_movement.py
+++ b/src/physiotwin4d/report_evaluate_movement.py
@@ -1,0 +1,417 @@
+"""Rendering of a movement evaluation: its CSVs, its plot and its report.
+
+:class:`ReportEvaluateMovement` turns the metric rows
+:class:`physiotwin4d.WorkflowEvaluateMovement` scores into the artifacts a
+reader looks at.  It computes nothing --- every number it prints was measured by
+the workflow --- so a change to how a result is *presented* never touches how it
+is *measured*.
+
+Kept separate from the workflow for the same reason the metrics were moved out
+of the inference workflows: one file, one job.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .physiotwin4d_base import PhysioTwin4DBase
+
+
+class ReportEvaluateMovement(PhysioTwin4DBase):
+    """Write the CSV, the volume plot and the markdown report of one evaluation.
+
+    Args:
+        log_level: Logging level. Default: ``logging.INFO``.
+    """
+
+    # Volume-plot series colors, assigned in this order and never cycled: eight
+    # hues whose neighbors stay apart under the common color-vision deficiencies.
+    _SERIES_COLORS = (
+        "#2a78d6",
+        "#eb6834",
+        "#1baf7a",
+        "#eda100",
+        "#e87ba4",
+        "#008300",
+        "#4a3aa7",
+        "#e34948",
+    )
+
+    def __init__(self, log_level: int | str = logging.INFO) -> None:
+        super().__init__(class_name=self.__class__.__name__, log_level=log_level)
+
+    # ─────────────────────────── Public API ────────────────────────────────
+    def report(
+        self,
+        rows: list[dict[str, Any]],
+        provenance: dict[str, Any],
+        stages: list[float],
+        smoothing_sigma_mm: float,
+        evaluation_spacing_mm: float,
+        displacement_statistics: list[dict[str, Any]],
+        pooled: dict[str, float],
+        out_dir: Path,
+    ) -> dict[str, Path]:
+        """Write every artifact of one evaluation and return their paths.
+
+        Args:
+            rows: One metric row per stage and structure, as scored by
+                :meth:`physiotwin4d.WorkflowEvaluateMovement.process`.
+            provenance: Case name, shape parameters and network weights.
+            stages: Every stage scored, in order.
+            smoothing_sigma_mm: Recorded in the report's run section.
+            evaluation_spacing_mm: Recorded in the report's run section.
+            displacement_statistics: One entry per stage, empty when the
+                point-by-point error was not measured.
+            pooled: That error over every point and stage.
+            out_dir: Directory the artifacts are written to.
+
+        Returns:
+            Dict with ``csv_file``, ``volume_plot_file`` and ``report_file``.
+        """
+        csv_file = self._write_csv(rows, out_dir)
+        plot_file = self._write_volume_plot(rows, out_dir)
+        report_file = self._write_report(
+            rows,
+            provenance,
+            stages,
+            smoothing_sigma_mm,
+            evaluation_spacing_mm,
+            plot_file,
+            displacement_statistics,
+            pooled,
+            out_dir,
+        )
+        return {
+            "csv_file": csv_file,
+            "volume_plot_file": plot_file,
+            "report_file": report_file,
+        }
+
+    # ───────────────────────────── Internals ───────────────────────────────
+    @staticmethod
+    def _write_csv(rows: list[dict[str, Any]], out_dir: Path) -> Path:
+        """Write every metric row, provenance included, to one CSV."""
+        csv_file = out_dir / "evaluation_metrics.csv"
+        with csv_file.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+        return csv_file
+
+    def _write_volume_plot(self, rows: list[dict[str, Any]], out_dir: Path) -> Path:
+        """Plot the acquired and predicted volume of every structure against stage.
+
+        One color per structure, taken in a fixed order from a hue set separable
+        under color-vision deficiency; the acquired volume is solid and the
+        predicted volume dashed, so the two never rest on color alone.
+        """
+        import matplotlib.pyplot as plt
+        from matplotlib.lines import Line2D
+
+        plot_file = out_dir / "volume_vs_stage.png"
+        fig, ax = plt.subplots(figsize=(8.0, 4.5))
+        try:
+            ends: list[tuple[float, float, str]] = []
+            for index, label in enumerate(
+                sorted({int(row["label_id"]) for row in rows})
+            ):
+                matching = sorted(
+                    (row for row in rows if row["label_id"] == label),
+                    key=lambda row: float(row["stage"]),
+                )
+                stages = [float(row["stage"]) for row in matching]
+                truth = [float(row["volume_truth_mm3"]) / 1000.0 for row in matching]
+                predicted = [
+                    float(row["volume_predicted_mm3"]) / 1000.0 for row in matching
+                ]
+                # More structures than hues reuses them; the end labels, not the
+                # color, are what name each line.
+                color = self._SERIES_COLORS[index % len(self._SERIES_COLORS)]
+                ax.plot(stages, truth, color=color, linewidth=2.0, marker="o", ms=5)
+                ax.plot(stages, predicted, color=color, linewidth=2.0, linestyle="--")
+                ends.append((stages[-1], truth[-1], str(matching[0]["label_name"])))
+
+            # Three of the hues fall below 3:1 against a white page, so each line
+            # is named where it ends rather than in a color key alone. Structures
+            # of similar size end on top of each other, so the names are pushed
+            # apart, largest first, before they are drawn.
+            span = float(np.ptp(ax.get_ylim()))
+            previous = float("inf")
+            for x_end, y_end, name in sorted(ends, key=lambda end: -end[1]):
+                text_y = min(y_end, previous - 0.05 * span)
+                ax.annotate(
+                    name,
+                    xy=(x_end, text_y),
+                    xytext=(6, 0),
+                    textcoords="offset points",
+                    color="#52514e",
+                    fontsize=9,
+                    va="center",
+                )
+                previous = text_y
+
+            ax.set_xlabel("Stage", color="#52514e")
+            ax.set_ylabel("Volume (mL)", color="#52514e")
+            ax.grid(True, color="#e1e0d9", linewidth=0.8)
+            ax.set_axisbelow(True)
+            ax.spines["top"].set_visible(False)
+            ax.spines["right"].set_visible(False)
+            ax.spines["left"].set_color("#c3c2b7")
+            ax.spines["bottom"].set_color("#c3c2b7")
+            ax.tick_params(colors="#898781", labelsize=9)
+            ax.legend(
+                handles=[
+                    Line2D([], [], color="#898781", linewidth=2.0, label="acquired"),
+                    Line2D(
+                        [],
+                        [],
+                        color="#898781",
+                        linewidth=2.0,
+                        linestyle="--",
+                        label="predicted",
+                    ),
+                ],
+                frameon=False,
+                loc="best",
+                fontsize=9,
+                labelcolor="#52514e",
+            )
+            fig.savefig(str(plot_file), bbox_inches="tight", dpi=150)
+        finally:
+            plt.close(fig)
+        self.log_info("Volume plot: %s", plot_file)
+        return plot_file
+
+    def _write_report(
+        self,
+        rows: list[dict[str, Any]],
+        provenance: dict[str, Any],
+        stages: list[float],
+        smoothing_sigma_mm: float,
+        evaluation_spacing_mm: float,
+        plot_file: Path,
+        displacement_statistics: list[dict[str, Any]],
+        pooled: dict[str, float],
+        out_dir: Path,
+    ) -> Path:
+        """Write the markdown report beside the CSV."""
+        coefficients = [
+            provenance[key] for key in sorted(provenance) if key.startswith("pca_c")
+        ]
+        # Both tables carry whichever metrics the rows were scored with.
+        has_dice = "dice" in rows[0]
+        lines = [
+            f"# Movement accuracy: {provenance['case_id']}",
+            "",
+            "## Run",
+            "",
+            f"- Hold-out case: `{provenance['case_id']}`",
+            f"- Stages evaluated: {len(stages)} "
+            f"({', '.join(f'{stage:.2f}' for stage in stages)})",
+            f"- Shape parameters: `{provenance['shape_parameters_file']}`",
+            "- Shape parameters (standard deviations): "
+            + json.dumps([round(value, 4) for value in coefficients]),
+            f"- Network weights: `{provenance['network_weights_file']}`",
+            f"- Network weights created: {provenance['network_weights_created']}",
+            f"- Network weights modified: {provenance['network_weights_modified']}",
+            f"- Network epoch: {provenance['network_epoch']}",
+            f"- Deformation smoothing sigma: {smoothing_sigma_mm:.1f} mm",
+            f"- Evaluation grid pitch: {evaluation_spacing_mm:.2f} mm isotropic",
+            "",
+            "Every score compares the reference frame carried into that stage "
+            "with the inferred deformation against the frame acquired there.",
+            "",
+            "## Volume over the stages",
+            "",
+            f"![Structure volume against stage]({plot_file.name})",
+            "",
+            "Solid: the volume acquired at that stage. Dashed: the volume the "
+            "prediction carries there.",
+            "",
+            "## Per structure, over the stages",
+            "",
+            "Mean beside worst case: the stage a structure is predicted worst at "
+            "is what a plausible mean can hide.",
+            "",
+        ]
+        metrics = (["Dice"] if has_dice else []) + [
+            "Volume difference (%)",
+            "Surface RMSE (mm)",
+        ]
+        has_displacement = "displacement_95th_mm" in rows[0]
+        summary_metrics = (["Dice (mean)", "Dice (min)"] if has_dice else []) + [
+            "Volume difference (mean %)",
+            "Volume difference (worst %)",
+            "Surface RMSE (mean mm)",
+            "Surface RMSE (max mm)",
+        ]
+        if has_displacement:
+            summary_metrics += [
+                "Displacement RMS (mean mm)",
+                "Displacement 95th (mean mm)",
+                "Displacement max (mm)",
+            ]
+        lines += self._table_header(["Structure"], summary_metrics)
+        for label in sorted({int(row["label_id"]) for row in rows}):
+            matching = [row for row in rows if row["label_id"] == label]
+            cells = [str(matching[0]["label_name"])]
+            if has_dice:
+                cells += [
+                    f"{self._mean(matching, 'dice'):.4f}",
+                    f"{self._min(matching, 'dice'):.4f}",
+                ]
+            cells += [
+                f"{self._mean(matching, 'volume_difference_percent'):+.2f}",
+                f"{self._worst(matching, 'volume_difference_percent'):+.2f}",
+                f"{self._mean(matching, 'surface_rmse_mm'):.3f}",
+                f"{self._worst(matching, 'surface_rmse_mm'):.3f}",
+            ]
+            if has_displacement:
+                cells += [
+                    f"{self._mean(matching, 'displacement_rms_mm'):.3f}",
+                    f"{self._mean(matching, 'displacement_95th_mm'):.3f}",
+                    f"{self._worst(matching, 'displacement_max_mm'):.3f}",
+                ]
+            lines.append("| " + " | ".join(cells) + " |")
+
+        lines += ["", "## Worst case, over every structure and stage", ""]
+        if has_dice:
+            lines.append(self._worst_case_line(rows, "dice", "Dice", "{:.4f}", "min"))
+        lines += [
+            self._worst_case_line(
+                rows,
+                "volume_difference_percent",
+                "Volume difference",
+                "{:+.2f} %",
+                "magnitude",
+            ),
+            self._worst_case_line(
+                rows, "surface_rmse_mm", "Surface RMSE", "{:.3f} mm", "magnitude"
+            ),
+        ]
+        if has_displacement:
+            lines.append(
+                self._worst_case_line(
+                    rows,
+                    "displacement_95th_mm",
+                    "Displacement 95th percentile",
+                    "{:.3f} mm",
+                    "magnitude",
+                )
+            )
+        lines += self._displacement_error_section(displacement_statistics, pooled)
+
+        lines += ["", "## Per stage", ""]
+        lines += self._table_header(["Stage", "Structure"], metrics)
+        for row in rows:
+            cells = [f"{row['stage']:.2f}", str(row["label_name"])]
+            if has_dice:
+                cells.append(f"{row['dice']:.4f}")
+            cells += [
+                f"{row['volume_difference_percent']:+.2f}",
+                f"{row['surface_rmse_mm']:.3f}",
+            ]
+            lines.append("| " + " | ".join(cells) + " |")
+
+        report_file = out_dir / "evaluation_report.md"
+        report_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        self.log_info("Report: %s", report_file)
+        return report_file
+
+    @staticmethod
+    def _worst_case_line(
+        rows: list[dict[str, Any]], key: str, name: str, fmt: str, pick: str
+    ) -> str:
+        """Bullet naming the structure and stage one metric is worst at.
+
+        ``pick`` is ``"min"`` for a metric whose worst value is its smallest, and
+        ``"magnitude"`` for one whose worst value is the furthest from zero in
+        either direction.
+        """
+        measured = [row for row in rows if not np.isnan(float(row[key]))]
+        if not measured:
+            return f"- Worst {name}: not measured"
+        worst = (
+            min(measured, key=lambda row: float(row[key]))
+            if pick == "min"
+            else max(measured, key=lambda row: abs(float(row[key])))
+        )
+        return (
+            f"- Worst {name}: {fmt.format(float(worst[key]))} "
+            f"({worst['label_name']}, stage {float(worst['stage']):.2f})"
+        )
+
+    def _displacement_error_section(
+        self, statistics: list[dict[str, Any]], pooled: dict[str, float]
+    ) -> list[str]:
+        """Per-stage displacement-vector error, when the true surfaces were given."""
+        if not statistics:
+            return []
+        lines = [
+            "",
+            "## Displacement error",
+            "",
+            "Distance between where the network puts each mesh point and where "
+            "the shape model fitted it in the frame acquired at that stage. "
+            "Unlike the labelmap metrics above, this is measured point by point, "
+            "so it does not average a displacement away against its opposite.",
+            "",
+            f"- RMS over every point and stage: {pooled['rms_mm']:.3f} mm",
+            f"- 95th percentile over every point and stage: {pooled['p95_mm']:.3f} mm",
+            f"- Max over every point and stage: {pooled['max_mm']:.3f} mm",
+            "",
+            "The 95th percentile is the figure to quote: the maximum is one "
+            "point of one stage, so it moves with a single badly placed vertex, "
+            "while the RMS is pulled down by the bulk of the surface that "
+            "hardly moves at all. Every figure here is over the whole shape "
+            "model; the same error split by structure is in the table above.",
+            "",
+        ]
+        lines += self._table_header(
+            ["Stage"], ["RMS (mm)", "95th percentile (mm)", "Max (mm)"]
+        )
+        for row in statistics:
+            lines.append(
+                f"| {float(row['stage']):.2f} | {float(row['rms_error_mm']):.3f} "
+                f"| {float(row['p95_error_mm']):.3f} "
+                f"| {float(row['max_error_mm']):.3f} |"
+            )
+        return lines
+
+    @staticmethod
+    def _table_header(keys: list[str], metrics: list[str]) -> list[str]:
+        """Markdown header and alignment rows: keys left, metrics right."""
+        return [
+            "| " + " | ".join(keys + metrics) + " |",
+            "| " + " | ".join(["---"] * len(keys) + ["---:"] * len(metrics)) + " |",
+        ]
+
+    @staticmethod
+    def _column(rows: list[dict[str, Any]], key: str) -> list[float]:
+        """One column's values, dropping the rows it could not be measured on."""
+        return [float(row[key]) for row in rows if not np.isnan(float(row[key]))]
+
+    @staticmethod
+    def _mean(rows: list[dict[str, Any]], key: str) -> float:
+        """Mean of one column, ignoring the rows where it could not be measured."""
+        values = ReportEvaluateMovement._column(rows, key)
+        return float(np.mean(values)) if values else float("nan")
+
+    @staticmethod
+    def _min(rows: list[dict[str, Any]], key: str) -> float:
+        """Smallest value of one column."""
+        values = ReportEvaluateMovement._column(rows, key)
+        return float(np.min(values)) if values else float("nan")
+
+    @staticmethod
+    def _worst(rows: list[dict[str, Any]], key: str) -> float:
+        """Value of one column furthest from zero, its sign kept."""
+        values = ReportEvaluateMovement._column(rows, key)
+        return float(max(values, key=abs)) if values else float("nan")

--- a/src/physiotwin4d/segment_nv_segment_ct_mri.py
+++ b/src/physiotwin4d/segment_nv_segment_ct_mri.py
@@ -584,7 +584,7 @@ class SegmentNVSegmentCTMRI(SegmentAnatomyBase):
         and reused for every subsequent image or timepoint.
 
         Returns:
-            Any: The bundle's ``VISTA3DPipeline`` on device ``cuda:0``.
+            Any: The bundle's ``VISTA3DPipeline`` on the current CUDA device.
         """
         if self._pipeline is None:
             snapshot_dir = self._ensure_model()
@@ -645,7 +645,8 @@ class SegmentNVSegmentCTMRI(SegmentAnatomyBase):
             RuntimeError: If the model pipeline produced no output volume.
 
         Note:
-            Requires a CUDA GPU (device ``cuda:0``).
+            Requires a CUDA GPU; the segmentation runs on whichever CUDA
+            device is current in this process.
 
         Example:
             >>> labelmap = segmenter.segmentation_method(preprocessed_ct)

--- a/src/physiotwin4d/segment_nv_segment_ct_mri.py
+++ b/src/physiotwin4d/segment_nv_segment_ct_mri.py
@@ -615,7 +615,11 @@ class SegmentNVSegmentCTMRI(SegmentAnatomyBase):
                 )
             )
 
-            self._pipeline = VISTA3DPipeline(model, device=torch.device("cuda:0"))
+            # Unindexed, so the pipeline follows torch.cuda.set_device: under a
+            # distributed launcher each rank segments on its own GPU instead of
+            # every rank piling onto GPU 0.  Identical in a single process,
+            # where the current device is 0.
+            self._pipeline = VISTA3DPipeline(model, device=torch.device("cuda"))
         return self._pipeline
 
     def segmentation_method(self, preprocessed_image: itk.image) -> itk.image:

--- a/src/physiotwin4d/train_physicsnemo_base.py
+++ b/src/physiotwin4d/train_physicsnemo_base.py
@@ -341,10 +341,13 @@ class TrainPhysicsNeMoBase(PhysioTwin4DBase):
         """Yield ``(node_feats, targets, batch_len)`` flattened mini-batches.
 
         With a distributed ``context``, each rank takes a strided slice of the
-        one shared permutation, so between them the ranks cover every sample
-        once. The slice is then truncated to a whole number of batches, equal
-        on every rank: a rank that yielded one batch more than its peers would
-        hang them all at the gradient all-reduce of the step they never take.
+        one shared permutation, and the slice is then truncated to a whole
+        number of batches, equal on every rank: a rank that yielded one batch
+        more than its peers would hang them all at the gradient all-reduce of
+        the step they never take. Between them the ranks therefore cover the
+        retained samples exactly once and no two ranks see the same one, but
+        the remainder the truncation drops is not covered at all -- an epoch is
+        the truncated subset, not the whole dataset.
         Omitting ``context`` iterates the whole dataset, which is what the
         RMSE evaluation wants.
         """

--- a/src/physiotwin4d/train_physicsnemo_base.py
+++ b/src/physiotwin4d/train_physicsnemo_base.py
@@ -34,7 +34,7 @@ import numpy as np
 import pyvista as pv
 
 from . import physicsnemo_tools as pnt
-from .physicsnemo_tools import PhaseSampleDataset
+from .physicsnemo_tools import DistributedContext, PhaseSampleDataset
 from .physiotwin4d_base import PhysioTwin4DBase
 
 if TYPE_CHECKING:  # typed for mypy; imported lazily at runtime
@@ -130,7 +130,7 @@ class TrainPhysicsNeMoBase(PhysioTwin4DBase):
         train_dataset: PhaseSampleDataset,
         val_dataset: PhaseSampleDataset,
         stats: dict,
-        device: "torch.device",
+        context: DistributedContext,
         epochs: int,
         output_dir: Path,
         template_mesh: pv.DataSet,
@@ -139,11 +139,15 @@ class TrainPhysicsNeMoBase(PhysioTwin4DBase):
     ) -> tuple["torch.nn.Module", list[float], list[dict]]:
         """Train the network, returning the model and the loss / RMSE logs.
 
+        Every rank runs this. Each steps over its own disjoint slice of the
+        samples and the gradients are averaged across ranks, so the effective
+        batch is ``batch_size * world_size``. Only rank 0 writes to disk.
+
         Args:
             train_dataset: Lazy training samples built by the workflow.
             val_dataset: Lazy validation samples; may be empty.
             stats: Normalization statistics computed by the workflow.
-            device: Torch device to train on.
+            context: Rank, device and world size of this process.
             epochs: Number of epochs to run. The workflow may clamp
                 :attr:`epochs` (for example in test mode), so the effective
                 count is passed in rather than read from the method.
@@ -158,6 +162,10 @@ class TrainPhysicsNeMoBase(PhysioTwin4DBase):
         """
         import torch
 
+        device = context.device
+        # One seed for every rank: _iter_batches shards a single shared
+        # permutation, so the ranks have to draw the identical one for their
+        # slices to tile the dataset exactly once.
         torch.manual_seed(self.seed)
         rng = np.random.default_rng(self.seed)
         in_features = train_dataset.n_features
@@ -167,22 +175,42 @@ class TrainPhysicsNeMoBase(PhysioTwin4DBase):
             ckpt = torch.load(str(resume_from), map_location=device, weights_only=True)
             state = ckpt.get("model_state_dict", ckpt)
             model.load_state_dict(pnt.strip_compile_prefix(state))
-            self.log_info("Loaded model weights from %s", resume_from)
+            self._log_main(context, "Loaded model weights from %s", resume_from)
 
         self.setup_inputs(device, template_mesh, template_coords)
         # Written now rather than after the last epoch: inference against an
         # intermittent checkpoint needs them, and that is the point of writing
         # those checkpoints while a long run is still going.
-        self.save_artifacts(output_dir)
+        if context.is_main:
+            self.save_artifacts(output_dir)
+
+        # Wrapped before compiling, not after: Dynamo only splits the graph at
+        # the gradient-bucket boundaries, and so only overlaps communication
+        # with compute, when it can see the DistributedDataParallel module.
+        if context.is_distributed:
+            # Both networks use every parameter on every step, so searching for
+            # unused ones would only cost a graph traversal per iteration.
+            model = cast(
+                "torch.nn.Module",
+                torch.nn.parallel.DistributedDataParallel(
+                    model,
+                    device_ids=[context.local_rank] if device.type == "cuda" else None,
+                    output_device=device if device.type == "cuda" else None,
+                    find_unused_parameters=False,
+                ),
+            )
+            self._log_main(
+                context, "DistributedDataParallel over %d ranks.", context.world_size
+            )
 
         if sys.platform != "win32":
             try:
                 model = cast("torch.nn.Module", torch.compile(model))
-                self.log_info("torch.compile enabled.")
+                self._log_main(context, "torch.compile enabled.")
             except Exception as exc:  # pragma: no cover - platform dependent
-                self.log_info("torch.compile skipped (%s).", exc)
+                self._log_main(context, "torch.compile skipped (%s).", exc)
         else:
-            self.log_info("torch.compile skipped on Windows.")
+            self._log_main(context, "torch.compile skipped on Windows.")
 
         optimizer = torch.optim.Adam(model.parameters(), lr=self.learning_rate)
         loss_fn = torch.nn.MSELoss()
@@ -195,7 +223,7 @@ class TrainPhysicsNeMoBase(PhysioTwin4DBase):
             epoch_loss = 0.0
             n_rows = 0
             for node_feats, targets, batch_len in self._iter_batches(
-                train_dataset, rng, shuffle=True
+                train_dataset, rng, shuffle=True, context=context
             ):
                 nf = torch.from_numpy(node_feats).to(device)
                 tgt = torch.from_numpy(targets).to(device)
@@ -207,21 +235,31 @@ class TrainPhysicsNeMoBase(PhysioTwin4DBase):
                 optimizer.step()
                 epoch_loss += float(loss.detach()) * len(nf)
                 n_rows += len(nf)
+            # Every rank saw a disjoint slice, so the epoch mean is only the
+            # mean over the whole epoch once the two sums are pooled.
+            epoch_loss, n_rows = self._reduce_sums(context, epoch_loss, n_rows)
             losses.append(epoch_loss / max(n_rows, 1))
 
             if (epoch + 1) % self.loss_log_interval == 0 or epoch + 1 == epochs:
-                self.log_info(
-                    "  epoch %05d/%d  loss=%.6f", epoch + 1, epochs, losses[-1]
+                self._log_main(
+                    context, "  epoch %05d/%d  loss=%.6f", epoch + 1, epochs, losses[-1]
                 )
 
-            if (epoch + 1) % self.rmse_log_interval == 0 or epoch + 1 == epochs:
+            scored_epoch = (
+                epoch + 1
+            ) % self.rmse_log_interval == 0 or epoch + 1 == epochs
+            # Scored on rank 0 alone, over the whole unsharded dataset and
+            # against the bare module: the RMSE describes the model, not how
+            # the epoch happened to be split across ranks.
+            if scored_epoch and context.is_main:
+                bare = pnt.unwrap_model(model)
                 train_rmse = self._evaluate_rmse(
-                    model, train_dataset, target_scale, device
+                    bare, train_dataset, target_scale, device
                 )
                 # None, not NaN: rmse_log is serialized with json.dumps, which
                 # emits a bare NaN token that strict JSON parsers reject.
                 val_rmse = (
-                    self._evaluate_rmse(model, val_dataset, target_scale, device)
+                    self._evaluate_rmse(bare, val_dataset, target_scale, device)
                     if len(val_dataset) > 0
                     else None
                 )
@@ -237,7 +275,8 @@ class TrainPhysicsNeMoBase(PhysioTwin4DBase):
                     / f"{self.model_tag}_stage_model_epoch_{epoch + 1:05d}.pt"
                 )
                 torch.save(self.build_checkpoint(model, stats), ckpt_path)
-                self.log_info(
+                self._log_main(
+                    context,
                     "  intermittent test epoch %05d/%d  train RMSE=%.4f  "
                     "val RMSE=%s  checkpoint=%s",
                     epoch + 1,
@@ -272,12 +311,56 @@ class TrainPhysicsNeMoBase(PhysioTwin4DBase):
         return checkpoint
 
     # ─────────────────────────── Internal steps ────────────────────────────
+    def _log_main(self, context: DistributedContext, msg: str, *args: Any) -> None:
+        """Log from rank 0 only, so an N-rank run prints one copy of each line."""
+        if context.is_main:
+            self.log_info(msg, *args)
+
+    @staticmethod
+    def _reduce_sums(
+        context: DistributedContext, loss_sum: float, row_count: int
+    ) -> tuple[float, int]:
+        """Sum a rank's loss and row totals across every rank."""
+        if not context.is_distributed:
+            return loss_sum, row_count
+        import torch
+
+        totals = torch.tensor(
+            [loss_sum, float(row_count)], dtype=torch.float64, device=context.device
+        )
+        torch.distributed.all_reduce(totals, op=torch.distributed.ReduceOp.SUM)
+        return float(totals[0].item()), int(totals[1].item())
+
     def _iter_batches(
-        self, dataset: PhaseSampleDataset, rng: Any, shuffle: bool
+        self,
+        dataset: PhaseSampleDataset,
+        rng: Any,
+        shuffle: bool,
+        context: Optional[DistributedContext] = None,
     ) -> Any:
-        """Yield ``(node_feats, targets, batch_len)`` flattened mini-batches."""
+        """Yield ``(node_feats, targets, batch_len)`` flattened mini-batches.
+
+        With a distributed ``context``, each rank takes a strided slice of the
+        one shared permutation, so between them the ranks cover every sample
+        once. The slice is then truncated to a whole number of batches, equal
+        on every rank: a rank that yielded one batch more than its peers would
+        hang them all at the gradient all-reduce of the step they never take.
+        Omitting ``context`` iterates the whole dataset, which is what the
+        RMSE evaluation wants.
+        """
         n = len(dataset)
         order = rng.permutation(n) if shuffle else np.arange(n)
+        if context is not None and context.is_distributed:
+            order = order[context.rank :: context.world_size]
+            n_per_rank = (n // context.world_size // self.batch_size) * self.batch_size
+            if n_per_rank == 0:
+                raise ValueError(
+                    f"{n} samples over {context.world_size} ranks at batch_size "
+                    f"{self.batch_size} leaves at least one rank with no full "
+                    "batch. Lower batch_size or the rank count."
+                )
+            order = order[:n_per_rank]
+        n = len(order)
         for start in range(0, n, self.batch_size):
             idx = order[start : start + self.batch_size]
             pairs = [dataset[int(i)] for i in idx]

--- a/src/physiotwin4d/workflow_create_mean_surface.py
+++ b/src/physiotwin4d/workflow_create_mean_surface.py
@@ -146,7 +146,19 @@ class WorkflowCreateMeanSurface(PhysioTwin4DBase):
         The maps saturate at its square root, and a sample further than that
         from the template has no gradient pulling it in, so the correspondence
         stops short and the mean creeps toward the template.
+
+        Args:
+            distance_squared_max: Saturation radius in squared millimeters.
+
+        Raises:
+            ValueError: If it is not positive. The maps are normalized against
+                its square root, so zero or less saturates every voxel alike
+                and leaves the registration nothing to descend.
         """
+        if distance_squared_max <= 0.0:
+            raise ValueError(
+                f"distance_squared_max must be positive, got {distance_squared_max}."
+            )
         self.distance_squared_max = distance_squared_max
 
     def set_icon_weights_path(self, weights_path: str) -> None:

--- a/src/physiotwin4d/workflow_create_mean_surface.py
+++ b/src/physiotwin4d/workflow_create_mean_surface.py
@@ -97,6 +97,13 @@ class WorkflowCreateMeanSurface(PhysioTwin4DBase):
         self.alignment_transform_type: str = "Rigid"
         self.registration_transform_type: str = "Deformable"
 
+        # Correspondence tuning, mirroring WorkflowFitStatisticalModelToPatient
+        # so that a mean built here and a fit against it see distance maps on
+        # the same scale.
+        self.mask_dilation_mm: float = 20.0
+        self.distance_squared_max: Optional[float] = None
+        self.icon_weights_path: Optional[str] = None
+
         # Results (populated by process()).
         self.mean_surface: Optional[pv.PolyData] = None
         self.corresponded_surfaces: list[pv.PolyData] = []
@@ -128,6 +135,36 @@ class WorkflowCreateMeanSurface(PhysioTwin4DBase):
                 "Must be 'Rigid' or 'Affine'."
             )
         self.alignment_transform_type = transform_type
+
+    def set_mask_dilation_mm(self, mask_dilation_mm: float) -> None:
+        """Set the dilation (mm) of the binary masks the Greedy stage registers in."""
+        self.mask_dilation_mm = mask_dilation_mm
+
+    def set_distance_squared_max(self, distance_squared_max: float) -> None:
+        """Set the squared millimetres the distance maps are normalized against.
+
+        The maps saturate at its square root, and a sample further than that
+        from the template has no gradient pulling it in, so the correspondence
+        stops short and the mean creeps toward the template.
+        """
+        self.distance_squared_max = distance_squared_max
+
+    def set_icon_weights_path(self, weights_path: str) -> None:
+        """Use a finetuned uniGradICON checkpoint for the deformable stage.
+
+        Stock weights are out of distribution for distance maps; see
+        ``RegisterModelsDistanceMaps.set_icon_weights_path``.
+
+        Args:
+            weights_path: Path to an existing uniGradICON checkpoint.
+        """
+        self.icon_weights_path = weights_path
+
+    def _distance_squared_max(self) -> float:
+        """Return the configured saturation radius, or one sized to the mask."""
+        if self.distance_squared_max is not None:
+            return self.distance_squared_max
+        return (1.25 * self.mask_dilation_mm) ** 2
 
     def set_registration_transform_type(self, transform_type: str) -> None:
         """Set the distance-map registration type used for correspondence.
@@ -292,8 +329,12 @@ class WorkflowCreateMeanSurface(PhysioTwin4DBase):
                 moving_model=aligned_surface,
                 fixed_model=template,
                 reference_image=reference_image,
+                distance_squared_max=self._distance_squared_max(),
+                mask_dilation_mm=self.mask_dilation_mm,
                 log_level=self.log_level,
             )
+            if self.icon_weights_path is not None:
+                registrar.set_icon_weights_path(self.icon_weights_path)
             result = registrar.register(transform_type=self.registration_transform_type)
 
             # The forward (image-convention) transform maps template points into

--- a/src/physiotwin4d/workflow_create_statistical_model.py
+++ b/src/physiotwin4d/workflow_create_statistical_model.py
@@ -106,13 +106,21 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
         self.reference_spatial_resolution = reference_spatial_resolution
         self.reference_buffer_factor = reference_buffer_factor
         self.solve_for_surface_pca = solve_for_surface_pca
-        self.icp_transform_type = icp_transform_type
+        # Through the setters, so the constructor cannot accept a value the
+        # setter would reject.
+        self.set_icp_transform_type(icp_transform_type)
         self.mask_dilation_mm = mask_dilation_mm
-        self.distance_squared_max = (
-            (1.25 * mask_dilation_mm) ** 2
-            if distance_squared_max is None
-            else distance_squared_max
-        )
+        if distance_squared_max is None:
+            self.distance_squared_max = (1.25 * mask_dilation_mm) ** 2
+        elif distance_squared_max <= 0.0:
+            # The distance maps are normalized against its square root, so zero
+            # or less saturates every voxel alike and leaves the registration
+            # nothing to descend.
+            raise ValueError(
+                f"distance_squared_max must be positive, got {distance_squared_max}."
+            )
+        else:
+            self.distance_squared_max = distance_squared_max
         self.project_to_measured_surfaces = project_to_measured_surfaces
         self.projection_max_distance_mm = projection_max_distance_mm
         self.icon_weights_path: Optional[str] = None

--- a/src/physiotwin4d/workflow_create_statistical_model.py
+++ b/src/physiotwin4d/workflow_create_statistical_model.py
@@ -33,7 +33,8 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
        extract surfaces for ICP alignment.
     3. Deformable registration: establish dense correspondence via Greedy affine + ICON deformable registration.  Uses
        either full meshes or surfaces.
-    4. Correspondence: warp reference model by each transform to get aligned shapes
+    4. Correspondence: warp reference model by each transform to get aligned shapes,
+       optionally snapped onto the measured ICP-aligned surfaces
     5. PCA: compute mean and modes from corresponded shapes
 
 
@@ -43,6 +44,15 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
         number_of_pca_components (int): Number of PCA components to retain
         reference_spatial_resolution (float): Resolution for reference image from mesh
         reference_buffer_factor (float): Buffer around mesh for reference image
+        icp_transform_type (str): Alignment applied before correspondence
+        mask_dilation_mm (float): Dilation of the deformable stage's masks
+        distance_squared_max (float): Squared mm the distance maps saturate at
+        project_to_measured_surfaces (bool): Snap corresponded points onto the
+            measured surfaces before the PCA
+        projection_max_distance_mm (Optional[float]): Residual above which a
+            point is left unprojected
+        pca_input_residual_rms (list[float]): Per sample, the RMS distance from
+            the corresponded shape to the measured surface, before projection
     """
 
     def __init__(
@@ -53,6 +63,11 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
         reference_spatial_resolution: float = 1.0,
         reference_buffer_factor: float = 0.25,
         solve_for_surface_pca: bool = True,
+        icp_transform_type: str = "Affine",
+        mask_dilation_mm: float = 20.0,
+        distance_squared_max: Optional[float] = None,
+        project_to_measured_surfaces: bool = True,
+        projection_max_distance_mm: Optional[float] = None,
         log_level: int | str = logging.INFO,
     ):
         """Initialize the create-statistical-model workflow.
@@ -64,6 +79,22 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
             reference_spatial_resolution: Isotropic resolution (mm) for reference image. Default 1.0.
             reference_buffer_factor: Buffer factor around mesh for reference image. Default 0.25.
             solve_for_surface_pca: Whether to reduce the reference mesh to a surface. Default True.
+            icp_transform_type: Alignment applied before correspondence, one of
+                ``"Rigid"``, ``"Similarity"`` or ``"Affine"``. Default
+                ``"Affine"``, which normalizes size and gross proportion away,
+                so the modes describe only the residual shape. The workflow
+                that fits this model must align the same way.
+            mask_dilation_mm: Dilation (mm) of the binary registration masks used
+                by the deformable stage. Default 20.0.
+            distance_squared_max: Squared millimetres the distance maps are
+                normalized against, so the saturation radius is its square root.
+                Default None, which sizes it to the mask as the fitting workflow
+                does: ``(1.25 * mask_dilation_mm) ** 2``.
+            project_to_measured_surfaces: Snap each corresponded point onto the
+                subject's measured ICP-aligned surface before the PCA. Default
+                True. Ignored when solve_for_surface_pca is False.
+            projection_max_distance_mm: Only project points whose residual is at
+                or below this distance. Default None, which projects every point.
             log_level: Logging level.
         """
         super().__init__(
@@ -75,6 +106,16 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
         self.reference_spatial_resolution = reference_spatial_resolution
         self.reference_buffer_factor = reference_buffer_factor
         self.solve_for_surface_pca = solve_for_surface_pca
+        self.icp_transform_type = icp_transform_type
+        self.mask_dilation_mm = mask_dilation_mm
+        self.distance_squared_max = (
+            (1.25 * mask_dilation_mm) ** 2
+            if distance_squared_max is None
+            else distance_squared_max
+        )
+        self.project_to_measured_surfaces = project_to_measured_surfaces
+        self.projection_max_distance_mm = projection_max_distance_mm
+        self.icon_weights_path: Optional[str] = None
 
         self.contour_tools = ContourTools()
         self.transform_tools = TransformTools()
@@ -87,6 +128,7 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
         self.forward_transforms: list = []
         self.inverse_transforms: list = []
         self.pca_input_models: list[pv.DataSet] = []
+        self.pca_input_residual_rms: list[float] = []
         self.pca_fitted: Optional[PCA] = None
         self.pca_mean_surface: Optional[pv.PolyData] = None
         self.pca_mean_mesh: Optional[pv.DataSet] = None
@@ -94,6 +136,40 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
     def set_number_of_pca_components(self, n: int) -> None:
         """Set number of PCA components to retain."""
         self.number_of_pca_components = n
+
+    def set_icp_transform_type(self, transform_type: str) -> None:
+        """Set the alignment applied to each sample before correspondence.
+
+        ``"Affine"`` (default) normalizes size, anisotropic scale and shear
+        away, leaving only residual shape for the PCA; ``"Rigid"`` keeps them
+        as modes.  Whatever is chosen, the workflow that fits the model has to
+        align the same way, or the model is asked to explain variation its ICP
+        has already absorbed.
+
+        Args:
+            transform_type: One of ``"Rigid"``, ``"Similarity"``, ``"Affine"``.
+
+        Raises:
+            ValueError: If transform_type is not one of those.
+        """
+        if transform_type not in ("Rigid", "Similarity", "Affine"):
+            raise ValueError(
+                f"Invalid ICP transform '{transform_type}'. "
+                "Must be 'Rigid', 'Similarity' or 'Affine'."
+            )
+        self.icp_transform_type = transform_type
+
+    def set_icon_weights_path(self, weights_path: str) -> None:
+        """Use a finetuned uniGradICON checkpoint for the deformable stage.
+
+        Stock weights are out of distribution for distance maps, so without this
+        the correspondences the model is built from barely move off the
+        template; see ``RegisterModelsDistanceMaps.set_icon_weights_path``.
+
+        Args:
+            weights_path: Path to an existing uniGradICON checkpoint.
+        """
+        self.icon_weights_path = weights_path
 
     def _step1_extract_surfaces(self) -> None:
         """Extract reference surface and all sample surfaces (notebook 1)."""
@@ -140,7 +216,7 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
             registrar = RegisterModelsICP(fixed_model=reference_surface)
             result = registrar.register(
                 moving_model=moving_surface,
-                transform_type="Affine",
+                transform_type=self.icp_transform_type,
                 max_iterations=2000,
             )
             if self.solve_for_surface_pca:
@@ -160,8 +236,17 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
         """Deformable registration of each aligned sample to reference (notebook 3)."""
         self.log_section("Step 3: Deformable registration (correspondence)", width=70)
         assert self.reference_model is not None and self.aligned_models
+        # The distance-map grid must contain the template *and* every aligned
+        # sample: a sample clipped by the grid registers as if it were smaller,
+        # which biases every PCA input toward the template's size.
+        bounding_cloud = pv.PolyData(
+            np.vstack(
+                [np.asarray(self.reference_model.points)]
+                + [np.asarray(model.points) for model in self.aligned_models]
+            )
+        )
         reference_image = self.contour_tools.create_reference_image(
-            mesh=self.reference_model,
+            mesh=bounding_cloud,
             spatial_resolution=self.reference_spatial_resolution,
             buffer_factor=self.reference_buffer_factor,
             ptype=itk.UC,
@@ -169,7 +254,6 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
         self.forward_transforms = []
         self.inverse_transforms = []
 
-        new_aligned_models = []
         for i, (sid, moving) in enumerate(zip(self.sample_ids, self.aligned_models)):
             self.log_info(
                 "Deformable registration %s (%d/%d)",
@@ -181,16 +265,20 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
                 moving_model=cast(pv.PolyData, moving),
                 fixed_model=cast(pv.PolyData, self.reference_model),
                 reference_image=reference_image,
+                distance_squared_max=self.distance_squared_max,
+                mask_dilation_mm=self.mask_dilation_mm,
             )
+            if self.icon_weights_path is not None:
+                registrar.set_icon_weights_path(self.icon_weights_path)
             result = registrar.register(
                 transform_type="Deformable",
             )
 
-            new_aligned_models.append(result["registered_model"])
             self.forward_transforms.append(result["forward_transform"])
             self.inverse_transforms.append(result["inverse_transform"])
 
-        self.aligned_models = new_aligned_models
+        # aligned_models stays the ICP-aligned input: step 4 measures the
+        # corresponded shapes against it.
         self.log_info(
             "Deformable registration complete for %d samples",
             len(self.forward_transforms),
@@ -203,19 +291,75 @@ class WorkflowCreateStatisticalModel(PhysioTwin4DBase):
         (= inverse point) transform from step 3, so that we get reference topology
         in ICP-aligned space with residual deformation per subject to be used as PCA
         input.
+
+        The warped template only approximates its subject: the deformable
+        registration always stops short of it, and because that shortfall is
+        one-sided it shrinks every subject toward the template, and the PCA's
+        variance with it.  The shortfall is measured here against the measured
+        ICP-aligned surface, and removed when ``project_to_measured_surfaces``
+        is set, so that the modes are scaled by the population's real spread.
         """
         self.log_section("Step 4: Build PCA inputs (corresponded shapes)", width=70)
         assert self.reference_model is not None and self.forward_transforms
+        project = self.project_to_measured_surfaces
+        if project and not self.solve_for_surface_pca:
+            # The PCA inputs are volume meshes here, so snapping their interior
+            # nodes onto the bounding surface would collapse the mesh.
+            self.log_warning(
+                "Ignoring project_to_measured_surfaces: it is only meaningful "
+                "for surface PCA."
+            )
+            project = False
+
         self.pca_input_models = []
-        for fwd_tfm in self.forward_transforms:
+        self.pca_input_residual_rms = []
+        for sid, fwd_tfm, aligned in zip(
+            self.sample_ids, self.forward_transforms, self.aligned_models
+        ):
             pca_input_model = self.contour_tools.transform_contours(
                 cast(pv.PolyData, self.reference_model),
                 tfm=fwd_tfm,
                 with_deformation_magnitude=False,
             )
+            measured_surface = self.contour_tools.extract_surface(aligned)
+            points = np.asarray(pca_input_model.points)
+            _, closest = cast(
+                "tuple[np.ndarray, np.ndarray]",
+                measured_surface.find_closest_cell(points, return_closest_point=True),
+            )
+            residuals = np.linalg.norm(closest - points, axis=1)
+            self.pca_input_residual_rms.append(float(np.sqrt(np.mean(residuals**2))))
+            if project:
+                if self.projection_max_distance_mm is None:
+                    points[:] = closest
+                else:
+                    # Where the registration landed far from the subject its
+                    # nearest point is not the corresponding one, and snapping
+                    # would fold several template points onto one feature.
+                    accepted = residuals <= self.projection_max_distance_mm
+                    points[accepted] = closest[accepted]
+                pca_input_model.points = points
             self.pca_input_models.append(pca_input_model)
+            self.log_info(
+                "  %s: %.3f mm RMS from the measured surface (max %.3f mm)",
+                sid,
+                self.pca_input_residual_rms[-1],
+                float(residuals.max()),
+            )
+
+        # Compare the registration's shortfall against the spread it has to
+        # measure: a residual near the spread means the modes are mostly noise.
+        rows = np.array([np.asarray(m.points).ravel() for m in self.pca_input_models])
+        deviations = rows - rows.mean(axis=0)
+        population_rms = float(
+            np.sqrt(np.mean(np.sum(deviations**2, axis=1) / (rows.shape[1] // 3)))
+        )
         self.log_info(
-            "Built %d corresponded surfaces for PCA", len(self.pca_input_models)
+            "Built %d corresponded surfaces for PCA: residual %.3f mm RMS, "
+            "population spread %.3f mm RMS",
+            len(self.pca_input_models),
+            float(np.mean(self.pca_input_residual_rms)),
+            population_rms,
         )
 
     def _step5_compute_pca(self) -> None:

--- a/src/physiotwin4d/workflow_evaluate_movement.py
+++ b/src/physiotwin4d/workflow_evaluate_movement.py
@@ -193,11 +193,12 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
             ``displacement_95th_mm`` and ``displacement_max_mm``.
 
         Raises:
-            ValueError: If ``ground_truth_labelmaps`` is empty, none of the
-                requested labels are in the reference frame, no label survives
-                scoring because the acquired frames contain none of them, or an
-                option needing the true displacement is requested without a
-                ``ground_truth_meshes`` entry for every stage.
+            ValueError: If ``ground_truth.labelmaps`` is empty, any stage it
+                carries a labelmap for has no entry in ``ground_truth.meshes``
+                --- checked whether or not an option needing the true
+                displacement was requested --- none of the requested labels are
+                in the reference frame, or no label survives scoring because
+                the acquired frames contain none of them.
         """
         if not ground_truth.labelmaps:
             raise ValueError("No ground-truth labelmaps to evaluate against.")
@@ -413,9 +414,34 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
 
         Returns:
             The per-stage error arrays and their per-stage statistics rows, both
-            empty when no true surfaces were given.
+            empty when no true surfaces were given or when
+            ``include_displacement_error`` is off --- the caller reports the
+            pooled figures only when it was asked for the error, so scoring one
+            it will not report would be measured and thrown away.
         """
+        # Cleared before any early return: the attribute outlives the call, so
+        # leaving it set would report the previous case's CSV as this one's.
+        self.displacement_data_file = None
         if ground_truth_meshes is None:
+            return [], []
+
+        # Reading a stage's true surface only pays for itself if something asked
+        # for it: the true displacement, the per-point error, or the CSV that
+        # carries both.
+        needs_true_points = (
+            include_true_displacements
+            or include_displacement_error
+            or report_displacement_data
+        )
+        # An option that adds no point data leaves each stage mesh exactly as the
+        # inference workflow already wrote it, so re-saving would rewrite an
+        # identical file.
+        annotated = (
+            include_predicted_displacements
+            or include_true_displacements
+            or include_displacement_error
+        )
+        if not needs_true_points and not include_predicted_displacements:
             return [], []
 
         fitted_reference_points = np.asarray(
@@ -434,48 +460,58 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
         for index, stage in enumerate(stages):
             stage_mesh = series["stage_meshes"][index]
             predicted_points = np.asarray(stage_mesh.points, dtype=np.float32)
-            true_points = np.asarray(
-                pv.read(str(ground_truth_meshes[stage])).points, dtype=np.float32
-            )
-            differences = predicted_points - true_points
-            stage_errors = np.linalg.norm(differences, axis=1).astype(np.float32)
 
             if include_predicted_displacements:
                 stage_mesh.point_data["predicted_displacement_mm"] = (
                     predicted_points - fitted_reference_points
                 ).astype(np.float32)
-            if include_true_displacements:
-                stage_mesh.point_data["true_displacement_mm"] = (
-                    true_points - fitted_reference_points
-                ).astype(np.float32)
-            if include_displacement_error:
-                stage_mesh.point_data["displacement_error_mm"] = stage_errors
-            stage_mesh.save(str(series["predicted_surfaces"][index]))
 
-            if displacement_file is not None:
-                with displacement_file.open("a", newline="", encoding="utf-8") as fh:
-                    csv.writer(fh).writerows(
-                        self._displacement_rows(
-                            case_id,
-                            stage,
-                            fitted_reference_points,
-                            predicted_points,
-                            true_points,
-                            stage_errors,
+            if needs_true_points:
+                true_points = np.asarray(
+                    pv.read(str(ground_truth_meshes[stage])).points, dtype=np.float32
+                )
+                differences = predicted_points - true_points
+                stage_errors = np.linalg.norm(differences, axis=1).astype(np.float32)
+
+                if include_true_displacements:
+                    stage_mesh.point_data["true_displacement_mm"] = (
+                        true_points - fitted_reference_points
+                    ).astype(np.float32)
+                if include_displacement_error:
+                    stage_mesh.point_data["displacement_error_mm"] = stage_errors
+
+                if displacement_file is not None:
+                    with displacement_file.open(
+                        "a", newline="", encoding="utf-8"
+                    ) as fh:
+                        csv.writer(fh).writerows(
+                            self._displacement_rows(
+                                case_id,
+                                stage,
+                                fitted_reference_points,
+                                predicted_points,
+                                true_points,
+                                stage_errors,
+                            )
+                        )
+
+                if include_displacement_error:
+                    errors.append(stage_errors)
+                    statistics.append(
+                        self.displacement_error_row(
+                            case_id, stage, differences, stage_errors
                         )
                     )
+                    self.log_info(
+                        "stage %.3f: mean=%.3f mm  95th=%.3f mm  max=%.3f mm",
+                        stage,
+                        statistics[-1]["mean_error_mm"],
+                        statistics[-1]["p95_error_mm"],
+                        statistics[-1]["max_error_mm"],
+                    )
 
-            errors.append(stage_errors)
-            statistics.append(
-                self.displacement_error_row(case_id, stage, differences, stage_errors)
-            )
-            self.log_info(
-                "stage %.3f: mean=%.3f mm  95th=%.3f mm  max=%.3f mm",
-                stage,
-                statistics[-1]["mean_error_mm"],
-                statistics[-1]["p95_error_mm"],
-                statistics[-1]["max_error_mm"],
-            )
+            if annotated:
+                stage_mesh.save(str(series["predicted_surfaces"][index]))
 
         self.displacement_data_file = displacement_file
         return errors, statistics

--- a/src/physiotwin4d/workflow_evaluate_movement.py
+++ b/src/physiotwin4d/workflow_evaluate_movement.py
@@ -6,14 +6,20 @@ gated image sequence. For every gated time point it carries the reference
 frame's labelmap into that time point with the network's own deformation and
 compares the result, structure by structure, to the labelmap of the frame that
 was actually acquired: volume difference, Dice, and surface RMSE per lung lobe
-or per heart chamber.
+or per heart chamber. Given the true surface of each frame it also reports the
+distance between where the network puts each shape-model point and where the
+model was fitted, per structure.
 
 Going through labelmaps rather than through the model's own surface is what lets
 one workflow serve both anatomies. The lung shape model carries its five lobes
 as per-cell labels, but the heart model is a single structure -- the whole heart
 minus its chamber cavities -- so its chambers exist only in the acquired
 labelmaps. Warping those labelmaps scores every structure the acquisition
-contains, whether or not the shape model represents it separately.
+contains, whether or not the shape model represents it separately. The
+point-by-point metric follows the model where it can: the lung's triangles carry
+their lobe, so its points are scored under the lobe the model names, while the
+heart's unlabelled surface is partitioned by nearest structure instead and its
+chambers are scored on the pieces of wall that bound them.
 
 Everything is measured on one isotropic evaluation grid built around the
 reference anatomy, so a case whose gated frames carry different slice pitches is
@@ -23,11 +29,10 @@ still scored on a single, stated voxel volume.
 from __future__ import annotations
 
 import csv
-import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import itk
 import numpy as np
@@ -35,7 +40,9 @@ import pyvista as pv
 
 from . import physicsnemo_tools as pnt
 from .contour_tools import ContourTools
+from .evaluate_movement_base import EvaluateMovementBase, MovementGroundTruth
 from .physiotwin4d_base import PhysioTwin4DBase
+from .report_evaluate_movement import ReportEvaluateMovement
 from .workflow_infer_movement import WorkflowInferMovement
 
 
@@ -45,97 +52,182 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
     Args:
         movement_workflow: The displacement decoder whose predictions are
             scored.
-        label_names: Structures to score, ``{label_id: name}``. Ids the
-            reference frame does not contain are dropped with a warning; ids a
-            single acquired frame does not contain are skipped for that frame
-            alone, since a structure can leave the field of view.
+        cohort: The cohort being scored ---
+            :class:`physiotwin4d.EvaluateMovementLung`,
+            :class:`physiotwin4d.EvaluateMovementDukeHeart` or another
+            :class:`physiotwin4d.EvaluateMovementBase`. It supplies the
+            structures to score and this cohort's defaults, and its
+            :meth:`~physiotwin4d.EvaluateMovementBase.assemble_ground_truth`
+            produces what :meth:`process` scores against. The workflow never
+            learns *which* cohort it holds, which is what keeps it free of
+            anatomy branches.
+        label_names: Structures to score, ``{label_id: name}``, for a caller
+            with no cohort. Ids the reference frame does not contain are dropped
+            with a warning; ids a single acquired frame does not contain are
+            skipped for that frame alone, since a structure can leave the field
+            of view.
         log_level: Logging level. Default: ``logging.INFO``.
     """
 
-    # Volume-plot series colors, assigned in this order and never cycled: eight
-    # hues whose neighbors stay apart under the common color-vision deficiencies.
-    _SERIES_COLORS = (
-        "#2a78d6",
-        "#eb6834",
-        "#1baf7a",
-        "#eda100",
-        "#e87ba4",
-        "#008300",
-        "#4a3aa7",
-        "#e34948",
+    # Columns of the per-point displacement CSV, in the order they are written.
+    _DISPLACEMENT_COLUMNS = (
+        "subject_id",
+        "stage",
+        "point_id",
+        "fitted_reference_x_mm",
+        "fitted_reference_y_mm",
+        "fitted_reference_z_mm",
+        "predicted_dx_mm",
+        "predicted_dy_mm",
+        "predicted_dz_mm",
+        "true_dx_mm",
+        "true_dy_mm",
+        "true_dz_mm",
+        "error_mm",
     )
+
+    # Per-cell structure ids a shape model may carry, written by
+    # ``ContourTools.save_combined_surfaces``.
+    _MESH_LABEL_ARRAY = "SegmentationLabelIds"
 
     def __init__(
         self,
         movement_workflow: WorkflowInferMovement,
-        label_names: dict[int, str],
+        cohort: Optional[EvaluateMovementBase] = None,
+        label_names: Optional[dict[int, str]] = None,
         log_level: int | str = logging.INFO,
     ) -> None:
         super().__init__(class_name=self.__class__.__name__, log_level=log_level)
+        if cohort is None and label_names is None:
+            raise ValueError(
+                "WorkflowEvaluateMovement needs a cohort, or the label_names to "
+                "score without one."
+            )
         self.movement_workflow = movement_workflow
-        self.label_names = dict(label_names)
+        self.cohort = cohort
+        self.label_names = (
+            dict(label_names)
+            if label_names is not None
+            else cast(EvaluateMovementBase, cohort).label_names()
+        )
         self.contour_tools = ContourTools(log_level=log_level)
+        self.displacement_data_file: Optional[Path] = None
+        self.report_tools = ReportEvaluateMovement(log_level=log_level)
 
     # ─────────────────────────── Public API ────────────────────────────────
     def process(
         self,
         case_id: str,
         shape_parameters: Path,
-        reference_mesh: Path,
-        reference_labelmap: itk.Image,
-        ground_truth_labelmaps: dict[float, itk.Image],
+        fitted_reference_mesh: Path,
+        ground_truth: MovementGroundTruth,
         output_directory: Path,
-        smoothing_sigma_mm: float = 10.0,
-        evaluation_spacing_mm: float = 1.0,
-        include_dice: bool = True,
+        smoothing_sigma_mm: Optional[float] = None,
+        evaluation_spacing_mm: Optional[float] = None,
+        report_dice: Optional[bool] = None,
+        report_displacement_data: bool = False,
+        include_predicted_displacements: bool = False,
+        include_true_displacements: bool = False,
+        include_displacement_error: bool = False,
     ) -> dict[str, Any]:
         """Score every gated time point of one case.
 
         Args:
             case_id: Name of the case being scored, recorded in every output.
             shape_parameters: JSON file with the case's PCA coefficient vector.
-            reference_mesh: The case's fitted reference-frame SSM surface. The
+            fitted_reference_mesh: The case's fitted reference-frame SSM surface,
+                as produced by
+                :class:`physiotwin4d.WorkflowFitStatisticalModelToPatient`. The
                 predicted displacements are added to its points, and its extent
                 defines the evaluation grid.
-            reference_labelmap: Labelmap of the reference frame, the anatomy
-                carried into every other time point.
-            ground_truth_labelmaps: Acquired labelmap per stage, keyed by the
-                normalized stage in ``[0, 1]``.
+            ground_truth: What this case is scored against --- the acquired
+                labelmap per stage, the reference frame's labelmap, and the
+                per-stage fits the point-by-point error is measured against ---
+                as assembled by
+                :meth:`physiotwin4d.EvaluateMovementBase.assemble_ground_truth`.
             output_directory: Directory the report, the CSV and the per-stage
                 geometry are written to.
             smoothing_sigma_mm: Gaussian sigma, in millimeters, that turns the
                 network's surface-shell deformation into a continuous field.
+                ``None`` takes the cohort's own value.
             evaluation_spacing_mm: Isotropic pitch every metric is measured on.
                 It sets both the voxel volume the Dice and volume figures are
                 quantized to and the resolution of the deformation fields, whose
-                memory grows with its cube.
-            include_dice: Report the Dice overlap. Turn it off for a structure
+                memory grows with its cube. ``None`` takes the cohort's own
+                value.
+            report_dice: Report the Dice overlap. Turn it off for a structure
                 whose motion is small against its own size: Dice is an overlap
                 fraction, so a lung lobe scores over 0.96 undeformed and the
                 column says more about the organ's bulk than about the motion.
-                The volume and surface figures still resolve it.
+                The volume and surface figures still resolve it. ``None`` takes
+                the cohort's own value.
+            report_displacement_data: Write ``displacement_per_point.csv``, one
+                row per mesh point per stage carrying that point's predicted and
+                true displacement and the error between them.
+            include_predicted_displacements: Carry
+                ``predicted_displacement_mm`` as point data on every stage's
+                predicted surface.
+            include_true_displacements: Carry ``true_displacement_mm`` as point
+                data on every stage's predicted surface.
+            include_displacement_error: Carry ``displacement_error_mm``, the
+                distance between the predicted and the true position, as point
+                data on every stage's predicted surface, and report that error's
+                RMS, 95th percentile and maximum --- per structure on every
+                metric row and in the report, and pooled over every point and
+                stage in the report and the returned dict. It is the one metric
+                here measured point by point, so a displacement predicted in the
+                wrong direction cannot cancel against another. A shape-model
+                point is attributed to the structure its own per-cell
+                ``SegmentationLabelIds`` names, or, on a model carrying no such
+                ids, to the structure whose reference-frame surface is nearest
+                --- the same nearest-label partition the labelmap metrics are
+                already scored under.
 
         Returns:
             Dict with ``rows`` (every metric row), ``csv_file``,
-            ``report_file``, ``volume_plot_file``, ``predicted_surfaces`` and
-            ``warped_labelmaps``.
+            ``report_file``, ``volume_plot_file``, ``predicted_surfaces``,
+            ``warped_labelmaps``, ``displacement_data_file``,
+            ``displacement_statistics`` (one entry per stage, empty unless
+            ``include_displacement_error``) and that error pooled over every
+            point and stage as ``displacement_rms_mm``,
+            ``displacement_95th_mm`` and ``displacement_max_mm``.
 
         Raises:
             ValueError: If ``ground_truth_labelmaps`` is empty, none of the
-                requested labels are in the reference frame, or no label
-                survives scoring because the acquired frames contain none of
-                them.
+                requested labels are in the reference frame, no label survives
+                scoring because the acquired frames contain none of them, or an
+                option needing the true displacement is requested without a
+                ``ground_truth_meshes`` entry for every stage.
         """
-        if not ground_truth_labelmaps:
+        if not ground_truth.labelmaps:
             raise ValueError("No ground-truth labelmaps to evaluate against.")
+
+        reference_labelmap = ground_truth.reference_labelmap
+        ground_truth_labelmaps = ground_truth.labelmaps
+        ground_truth_meshes = ground_truth.meshes
+        stages = sorted(ground_truth_labelmaps)
+        missing = [stage for stage in stages if stage not in ground_truth_meshes]
+        if missing:
+            raise ValueError(
+                "The ground truth needs a fitted surface for every stage it "
+                "carries a labelmap for; missing "
+                f"{', '.join(f'{stage:.3f}' for stage in missing)}."
+            )
+
+        # A setting the caller left unset is the cohort's to decide.
+        smoothing_sigma_mm = self._setting(smoothing_sigma_mm, "smoothing_sigma_mm")
+        evaluation_spacing_mm = self._setting(
+            evaluation_spacing_mm, "evaluation_spacing_mm"
+        )
+        report_dice = self._setting(report_dice, "report_dice")
 
         out_dir = Path(output_directory)
         out_dir.mkdir(parents=True, exist_ok=True)
-        stages = sorted(ground_truth_labelmaps)
         self.log_section("EVALUATE MOVEMENT [%s]: %d stages", case_id, len(stages))
 
+        fitted_reference_surface = cast(pv.DataSet, pv.read(str(fitted_reference_mesh)))
         grid = self.contour_tools.create_reference_image(
-            mesh=cast(pv.DataSet, pv.read(str(reference_mesh))),
+            mesh=fitted_reference_surface,
             spatial_resolution=evaluation_spacing_mm,
             buffer_factor=0.25,
             ptype=itk.template(reference_labelmap)[1][0],
@@ -156,11 +248,41 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
             shape_parameters=shape_parameters,
             stages=stages,
             output_directory=out_dir,
-            reference_mesh=reference_mesh,
+            fitted_reference_mesh=fitted_reference_mesh,
             reference_image=reference_on_grid,
             warp_interpolation="nearest",
             warp_background_value=0.0,
             smoothing_sigma_mm=smoothing_sigma_mm,
+        )
+
+        # The per-point displacement error is the mesh-space counterpart of the
+        # labelmap metrics, and exists only when the true surfaces were given.
+        displacement_errors, displacement_statistics = self._score_displacements(
+            case_id,
+            stages,
+            series,
+            fitted_reference_surface,
+            ground_truth_meshes,
+            out_dir,
+            report_displacement_data=report_displacement_data,
+            include_predicted_displacements=include_predicted_displacements,
+            include_true_displacements=include_true_displacements,
+            include_displacement_error=include_displacement_error,
+        )
+        pooled = self.pool_displacement_error(
+            displacement_errors if include_displacement_error else []
+        )
+        # Which mesh points belong to which structure, decided once against the
+        # reference frame so a structure owns the same points at every stage.
+        # Only the scored structures take part, so every shape-model point goes
+        # to one of them rather than being lost to a structure -- a coronary,
+        # say -- that no row reports.
+        label_points = (
+            self._label_point_indices(
+                fitted_reference_surface, scored_labels, reference_on_grid
+            )
+            if include_displacement_error
+            else {}
         )
 
         rows: list[dict[str, Any]] = []
@@ -178,7 +300,9 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
                     self._label_surfaces(predicted),
                     scored_labels,
                     provenance,
-                    include_dice,
+                    report_dice,
+                    displacement_errors[index] if include_displacement_error else None,
+                    label_points,
                 )
             )
 
@@ -188,24 +312,36 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
                 "absent from all of the acquired frames."
             )
 
-        csv_file = self._write_csv(rows, out_dir)
-        plot_file = self._write_volume_plot(rows, out_dir)
-        report_file = self._write_report(
+        written = self.report_tools.report(
             rows,
             provenance,
             stages,
             smoothing_sigma_mm,
             evaluation_spacing_mm,
-            plot_file,
+            displacement_statistics,
+            pooled,
             out_dir,
         )
+        if displacement_statistics:
+            self.log_info(
+                "Displacement error over every point and stage: rms=%.3f mm  "
+                "95th=%.3f mm  max=%.3f mm",
+                pooled["rms_mm"],
+                pooled["p95_mm"],
+                pooled["max_mm"],
+            )
         return {
             "rows": rows,
-            "csv_file": csv_file,
-            "report_file": report_file,
-            "volume_plot_file": plot_file,
+            "csv_file": written["csv_file"],
+            "report_file": written["report_file"],
+            "volume_plot_file": written["volume_plot_file"],
+            "displacement_statistics": displacement_statistics,
+            "displacement_rms_mm": pooled["rms_mm"],
+            "displacement_95th_mm": pooled["p95_mm"],
+            "displacement_max_mm": pooled["max_mm"],
             "predicted_surfaces": series["predicted_surfaces"],
             "warped_labelmaps": series["warped_images"],
+            "displacement_data_file": self.displacement_data_file,
         }
 
     # ──────────────────────────── Metrics ──────────────────────────────────
@@ -243,6 +379,181 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
         return float(np.sqrt(np.mean(distances**2)))
 
     # ──────────────────────────── Internals ────────────────────────────────
+    def _setting(self, given: Any, name: str) -> Any:
+        """The caller's value, or the cohort's when the caller gave none.
+
+        With no cohort the generic default on
+        :class:`physiotwin4d.EvaluateMovementBase` stands in, so scoring
+        something no cohort describes still works.
+        """
+        if given is not None:
+            return given
+        return getattr(self.cohort or EvaluateMovementBase, name)
+
+    def _score_displacements(
+        self,
+        case_id: str,
+        stages: list[float],
+        series: dict[str, Any],
+        fitted_reference_surface: pv.DataSet,
+        ground_truth_meshes: Optional[dict[float, Path]],
+        out_dir: Path,
+        report_displacement_data: bool,
+        include_predicted_displacements: bool,
+        include_true_displacements: bool,
+        include_displacement_error: bool,
+    ) -> tuple[list[np.ndarray], list[dict[str, Any]]]:
+        """Score every stage's prediction against its true surface, point by point.
+
+        The inference workflow hands back the stage meshes it wrote, so this
+        annotates and re-saves those very objects rather than reading them back.
+        Each stage's Euclidean error is computed **once** and then reduced four
+        ways: the mesh array, the per-point CSV, the per-stage row and the
+        pooled figures.
+
+        Returns:
+            The per-stage error arrays and their per-stage statistics rows, both
+            empty when no true surfaces were given.
+        """
+        if ground_truth_meshes is None:
+            return [], []
+
+        fitted_reference_points = np.asarray(
+            fitted_reference_surface.points, dtype=np.float32
+        )
+        # Header first, then one append per stage, so a long series never holds
+        # every point of every stage in memory at once.
+        displacement_file: Optional[Path] = None
+        if report_displacement_data:
+            displacement_file = out_dir / "displacement_per_point.csv"
+            with displacement_file.open("w", newline="", encoding="utf-8") as fh:
+                csv.writer(fh).writerow(self._DISPLACEMENT_COLUMNS)
+
+        errors: list[np.ndarray] = []
+        statistics: list[dict[str, Any]] = []
+        for index, stage in enumerate(stages):
+            stage_mesh = series["stage_meshes"][index]
+            predicted_points = np.asarray(stage_mesh.points, dtype=np.float32)
+            true_points = np.asarray(
+                pv.read(str(ground_truth_meshes[stage])).points, dtype=np.float32
+            )
+            differences = predicted_points - true_points
+            stage_errors = np.linalg.norm(differences, axis=1).astype(np.float32)
+
+            if include_predicted_displacements:
+                stage_mesh.point_data["predicted_displacement_mm"] = (
+                    predicted_points - fitted_reference_points
+                ).astype(np.float32)
+            if include_true_displacements:
+                stage_mesh.point_data["true_displacement_mm"] = (
+                    true_points - fitted_reference_points
+                ).astype(np.float32)
+            if include_displacement_error:
+                stage_mesh.point_data["displacement_error_mm"] = stage_errors
+            stage_mesh.save(str(series["predicted_surfaces"][index]))
+
+            if displacement_file is not None:
+                with displacement_file.open("a", newline="", encoding="utf-8") as fh:
+                    csv.writer(fh).writerows(
+                        self._displacement_rows(
+                            case_id,
+                            stage,
+                            fitted_reference_points,
+                            predicted_points,
+                            true_points,
+                            stage_errors,
+                        )
+                    )
+
+            errors.append(stage_errors)
+            statistics.append(
+                self.displacement_error_row(case_id, stage, differences, stage_errors)
+            )
+            self.log_info(
+                "stage %.3f: mean=%.3f mm  95th=%.3f mm  max=%.3f mm",
+                stage,
+                statistics[-1]["mean_error_mm"],
+                statistics[-1]["p95_error_mm"],
+                statistics[-1]["max_error_mm"],
+            )
+
+        self.displacement_data_file = displacement_file
+        return errors, statistics
+
+    @staticmethod
+    def pool_displacement_error(
+        stage_errors: list[np.ndarray],
+    ) -> dict[str, float]:
+        """RMS, 95th percentile and maximum over every point of every stage.
+
+        The errors themselves are pooled rather than their per-stage summaries:
+        a percentile of percentiles is not the percentile of the whole. Every
+        value is ``nan`` when no stage was scored point by point.
+        """
+        if not stage_errors:
+            return {
+                "rms_mm": float("nan"),
+                "p95_mm": float("nan"),
+                "max_mm": float("nan"),
+            }
+        errors = np.concatenate(stage_errors)
+        return {
+            "rms_mm": float(np.sqrt(np.mean(errors.astype(np.float64) ** 2))),
+            "p95_mm": float(np.percentile(errors, 95.0)),
+            "max_mm": float(errors.max()),
+        }
+
+    @staticmethod
+    def displacement_error_row(
+        case_id: str, stage: float, differences: np.ndarray, errors: np.ndarray
+    ) -> dict:
+        """One stage's displacement error, summarized over the mesh points.
+
+        Args:
+            case_id: Case being scored.
+            stage: Normalized stage.
+            differences: ``(n_points, 3)`` predicted minus true position.
+            errors: ``(n_points,)`` Euclidean norm of those differences,
+                computed once by the caller rather than again here.
+        """
+        return {
+            "subject_id": case_id,
+            "stage": stage,
+            "n_points": int(len(errors)),
+            "mean_error_mm": float(errors.mean()),
+            "median_error_mm": float(np.median(errors)),
+            "max_error_mm": float(errors.max()),
+            "p95_error_mm": float(np.percentile(errors, 95.0)),
+            "rms_error_mm": float(np.sqrt(np.mean(errors**2))),
+            "std_error_mm": float(errors.std()),
+            "mean_abs_error_x_mm": float(np.abs(differences[:, 0]).mean()),
+            "mean_abs_error_y_mm": float(np.abs(differences[:, 1]).mean()),
+            "mean_abs_error_z_mm": float(np.abs(differences[:, 2]).mean()),
+        }
+
+    @staticmethod
+    def _displacement_rows(
+        case_id: str,
+        stage: float,
+        fitted_reference_points: np.ndarray,
+        predicted_points: np.ndarray,
+        true_points: np.ndarray,
+        errors: np.ndarray,
+    ) -> list[list[Any]]:
+        """One row per mesh point, in ``_DISPLACEMENT_COLUMNS`` order."""
+        block = np.column_stack(
+            [
+                fitted_reference_points,
+                predicted_points - fitted_reference_points,
+                true_points - fitted_reference_points,
+                errors,
+            ]
+        )
+        return [
+            [case_id, stage, point_id, *values]
+            for point_id, values in enumerate(block.tolist())
+        ]
+
     @staticmethod
     def _resample_labelmap(labelmap: itk.Image, grid: itk.Image) -> itk.Image:
         """Resample a labelmap onto ``grid``, preserving its discrete values."""
@@ -279,6 +590,131 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
     def _label_surfaces(self, labelmap: itk.Image) -> dict[int, pv.PolyData]:
         """Contour every label of one labelmap on the evaluation grid's pitch."""
         return self.contour_tools.extract_label_surfaces(labelmap)
+
+    def _label_point_indices(
+        self,
+        mesh: pv.DataSet,
+        scored_labels: dict[int, str],
+        reference_labelmap: itk.Image,
+    ) -> dict[int, np.ndarray]:
+        """Shape-model point indices per structure.
+
+        A mesh that names the structure of every cell is taken at its word: the
+        lung model tags each triangle with its lobe, and no inference beats
+        that. A mesh that does not --- the heart is one surface, its chambers
+        being cavities the model excludes --- is partitioned by nearest label
+        surface instead, the same nearest-label rule
+        :meth:`ContourTools.extract_label_surfaces` already scores the labelmap
+        metrics under. A chamber is then scored on the piece of wall bounding
+        it. Either way a point belongs to at most one structure, and the
+        partition is decided once, at the reference frame.
+        """
+        labels = sorted(scored_labels)
+        indices = self._mesh_label_points(mesh, labels)
+        if indices is None:
+            self.log_info(
+                "Shape model carries no %s; attributing its points to the "
+                "nearest structure surface instead.",
+                self._MESH_LABEL_ARRAY,
+            )
+            indices = self._nearest_label_points(
+                mesh,
+                {
+                    label: surface
+                    for label, surface in self._label_surfaces(
+                        reference_labelmap
+                    ).items()
+                    if label in scored_labels
+                },
+            )
+        empty = [label for label in labels if indices.get(label, np.empty(0)).size == 0]
+        if empty:
+            self.log_warning(
+                "No shape-model point belongs to label(s) %s; their displacement "
+                "error is not measured.",
+                empty,
+            )
+        self.log_info(
+            "Shape-model points per structure: %s",
+            ", ".join(
+                f"{label}={indices.get(label, np.empty(0)).size}" for label in labels
+            ),
+        )
+        return indices
+
+    def _mesh_label_points(
+        self, mesh: pv.DataSet, labels: list[int]
+    ) -> Optional[dict[int, np.ndarray]]:
+        """Point indices per structure from the mesh's own per-cell ids.
+
+        ``None`` when the mesh does not carry them, or carries none of the ids
+        being scored, which is the caller's signal to fall back. A point shared
+        by cells of two structures --- a lobe fissure --- goes to the
+        lowest-numbered of them, so no point is counted twice.
+        """
+        if self._MESH_LABEL_ARRAY not in mesh.cell_data:
+            return None
+        cell_labels = np.asarray(mesh.cell_data[self._MESH_LABEL_ARRAY]).ravel()
+        if not set(cell_labels.tolist()) & set(labels):
+            return None
+
+        owner = np.full(mesh.n_points, -1, dtype=np.int64)
+        contested = 0
+        for label in labels:
+            cells = np.flatnonzero(cell_labels == label).astype(int)
+            if cells.size == 0:
+                continue
+            points = np.asarray(
+                mesh.extract_cells(cells).point_data["vtkOriginalPointIds"],
+                dtype=np.int64,
+            )
+            taken = owner[points]
+            contested += int(np.count_nonzero(taken != -1))
+            owner[points[taken == -1]] = label
+        if contested:
+            self.log_info(
+                "%d shape-model point(s) sit on a boundary between structures; "
+                "each went to the lowest-numbered structure touching it.",
+                contested,
+            )
+        unclaimed = int(np.count_nonzero(owner == -1))
+        if unclaimed:
+            self.log_info(
+                "%d shape-model point(s) carry no scored structure id and are "
+                "left out of the displacement error.",
+                unclaimed,
+            )
+        return {label: np.flatnonzero(owner == label) for label in labels}
+
+    @staticmethod
+    def _nearest_label_points(
+        mesh: pv.DataSet, label_surfaces: dict[int, pv.PolyData]
+    ) -> dict[int, np.ndarray]:
+        """Point indices per structure, by nearest label surface.
+
+        Costs one implicit distance per structure over the mesh points, paid
+        once per case against :meth:`surface_rmse_mm`'s two per structure per
+        stage.
+        """
+        labels = sorted(label_surfaces)
+        distances = np.stack(
+            [
+                np.abs(
+                    np.asarray(
+                        mesh.copy().compute_implicit_distance(label_surfaces[label])[
+                            "implicit_distance"
+                        ],
+                        dtype=np.float64,
+                    )
+                )
+                for label in labels
+            ]
+        )
+        nearest = np.argmin(distances, axis=0)
+        return {
+            label: np.flatnonzero(nearest == position)
+            for position, label in enumerate(labels)
+        }
 
     def _provenance(self, case_id: str, shape_parameters: Path) -> dict[str, Any]:
         """Case name, shape parameters and network weights, with their dates."""
@@ -320,9 +756,16 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
         predicted_surfaces: dict[int, pv.PolyData],
         scored_labels: dict[int, str],
         provenance: dict[str, Any],
-        include_dice: bool = True,
+        report_dice: bool = True,
+        displacement_errors: Optional[np.ndarray] = None,
+        label_points: Optional[dict[int, np.ndarray]] = None,
     ) -> list[dict[str, Any]]:
-        """One metric row per scored label of one stage."""
+        """One metric row per scored label of one stage.
+
+        ``displacement_errors`` is every shape-model point's error at this
+        stage, reduced per structure over the point indices ``label_points``
+        gives it.
+        """
         truth_array = itk.GetArrayViewFromImage(truth)
         predicted_array = itk.GetArrayViewFromImage(predicted)
         voxel_volume_mm3 = float(np.prod(np.asarray(truth.GetSpacing())))
@@ -349,7 +792,7 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
                 "label_id": label,
                 "label_name": scored_labels[label],
             }
-            if include_dice:
+            if report_dice:
                 row["dice"] = self.dice(truth_array, predicted_array, label)
             row.update(
                 {
@@ -362,204 +805,33 @@ class WorkflowEvaluateMovement(PhysioTwin4DBase):
                     "surface_rmse_mm": rmse,
                 }
             )
+            if displacement_errors is not None:
+                points = (label_points or {}).get(label, np.array([], dtype=np.int64))
+                displacement = self.pool_displacement_error(
+                    [displacement_errors[points]] if points.size else []
+                )
+                row.update(
+                    {
+                        "displacement_rms_mm": displacement["rms_mm"],
+                        "displacement_95th_mm": displacement["p95_mm"],
+                        "displacement_max_mm": displacement["max_mm"],
+                    }
+                )
             row.update(
                 {key: value for key, value in provenance.items() if key != "case_id"}
             )
             rows.append(row)
             self.log_info(
-                "stage %.3f %-24s %sdV=%+.2f%%  rmse=%.3f mm",
+                "stage %.3f %-24s %sdV=%+.2f%%  rmse=%.3f mm%s",
                 stage,
                 scored_labels[label],
-                f"dice={row['dice']:.4f}  " if include_dice else "",
+                f"dice={row['dice']:.4f}  " if report_dice else "",
                 row["volume_difference_percent"],
                 rmse,
+                (
+                    f"  d95={row['displacement_95th_mm']:.3f} mm"
+                    if displacement_errors is not None
+                    else ""
+                ),
             )
         return rows
-
-    @staticmethod
-    def _write_csv(rows: list[dict[str, Any]], out_dir: Path) -> Path:
-        """Write every metric row, provenance included, to one CSV."""
-        csv_file = out_dir / "evaluation_metrics.csv"
-        with csv_file.open("w", newline="", encoding="utf-8") as fh:
-            writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
-            writer.writeheader()
-            writer.writerows(rows)
-        return csv_file
-
-    def _write_volume_plot(self, rows: list[dict[str, Any]], out_dir: Path) -> Path:
-        """Plot the acquired and predicted volume of every structure against stage.
-
-        One color per structure, taken in a fixed order from a hue set separable
-        under color-vision deficiency; the acquired volume is solid and the
-        predicted volume dashed, so the two never rest on color alone.
-        """
-        import matplotlib.pyplot as plt
-        from matplotlib.lines import Line2D
-
-        plot_file = out_dir / "volume_vs_stage.png"
-        fig, ax = plt.subplots(figsize=(8.0, 4.5))
-        try:
-            ends: list[tuple[float, float, str]] = []
-            for index, label in enumerate(
-                sorted({int(row["label_id"]) for row in rows})
-            ):
-                matching = sorted(
-                    (row for row in rows if row["label_id"] == label),
-                    key=lambda row: float(row["stage"]),
-                )
-                stages = [float(row["stage"]) for row in matching]
-                truth = [float(row["volume_truth_mm3"]) / 1000.0 for row in matching]
-                predicted = [
-                    float(row["volume_predicted_mm3"]) / 1000.0 for row in matching
-                ]
-                # More structures than hues reuses them; the end labels, not the
-                # color, are what name each line.
-                color = self._SERIES_COLORS[index % len(self._SERIES_COLORS)]
-                ax.plot(stages, truth, color=color, linewidth=2.0, marker="o", ms=5)
-                ax.plot(stages, predicted, color=color, linewidth=2.0, linestyle="--")
-                ends.append((stages[-1], truth[-1], str(matching[0]["label_name"])))
-
-            # Three of the hues fall below 3:1 against a white page, so each line
-            # is named where it ends rather than in a color key alone. Structures
-            # of similar size end on top of each other, so the names are pushed
-            # apart, largest first, before they are drawn.
-            span = float(np.ptp(ax.get_ylim()))
-            previous = float("inf")
-            for x_end, y_end, name in sorted(ends, key=lambda end: -end[1]):
-                text_y = min(y_end, previous - 0.05 * span)
-                ax.annotate(
-                    name,
-                    xy=(x_end, text_y),
-                    xytext=(6, 0),
-                    textcoords="offset points",
-                    color="#52514e",
-                    fontsize=9,
-                    va="center",
-                )
-                previous = text_y
-
-            ax.set_xlabel("Stage", color="#52514e")
-            ax.set_ylabel("Volume (mL)", color="#52514e")
-            ax.grid(True, color="#e1e0d9", linewidth=0.8)
-            ax.set_axisbelow(True)
-            ax.spines["top"].set_visible(False)
-            ax.spines["right"].set_visible(False)
-            ax.spines["left"].set_color("#c3c2b7")
-            ax.spines["bottom"].set_color("#c3c2b7")
-            ax.tick_params(colors="#898781", labelsize=9)
-            ax.legend(
-                handles=[
-                    Line2D([], [], color="#898781", linewidth=2.0, label="acquired"),
-                    Line2D(
-                        [],
-                        [],
-                        color="#898781",
-                        linewidth=2.0,
-                        linestyle="--",
-                        label="predicted",
-                    ),
-                ],
-                frameon=False,
-                loc="best",
-                fontsize=9,
-                labelcolor="#52514e",
-            )
-            fig.savefig(str(plot_file), bbox_inches="tight", dpi=150)
-        finally:
-            plt.close(fig)
-        self.log_info("Volume plot: %s", plot_file)
-        return plot_file
-
-    def _write_report(
-        self,
-        rows: list[dict[str, Any]],
-        provenance: dict[str, Any],
-        stages: list[float],
-        smoothing_sigma_mm: float,
-        evaluation_spacing_mm: float,
-        plot_file: Path,
-        out_dir: Path,
-    ) -> Path:
-        """Write the markdown report beside the CSV."""
-        coefficients = [
-            provenance[key] for key in sorted(provenance) if key.startswith("pca_c")
-        ]
-        # Both tables carry whichever metrics the rows were scored with.
-        has_dice = "dice" in rows[0]
-        lines = [
-            f"# Movement accuracy: {provenance['case_id']}",
-            "",
-            "## Run",
-            "",
-            f"- Hold-out case: `{provenance['case_id']}`",
-            f"- Stages evaluated: {len(stages)} "
-            f"({', '.join(f'{stage:.2f}' for stage in stages)})",
-            f"- Shape parameters: `{provenance['shape_parameters_file']}`",
-            "- Shape parameters (standard deviations): "
-            + json.dumps([round(value, 4) for value in coefficients]),
-            f"- Network weights: `{provenance['network_weights_file']}`",
-            f"- Network weights created: {provenance['network_weights_created']}",
-            f"- Network weights modified: {provenance['network_weights_modified']}",
-            f"- Network epoch: {provenance['network_epoch']}",
-            f"- Deformation smoothing sigma: {smoothing_sigma_mm:.1f} mm",
-            f"- Evaluation grid pitch: {evaluation_spacing_mm:.2f} mm isotropic",
-            "",
-            "Every score compares the reference frame carried into that stage "
-            "with the inferred deformation against the frame acquired there.",
-            "",
-            "## Volume over the stages",
-            "",
-            f"![Structure volume against stage]({plot_file.name})",
-            "",
-            "Solid: the volume acquired at that stage. Dashed: the volume the "
-            "prediction carries there.",
-            "",
-            "## Per structure, averaged over stages",
-            "",
-        ]
-        metrics = (["Dice"] if has_dice else []) + [
-            "Volume difference (%)",
-            "Surface RMSE (mm)",
-        ]
-        lines += self._table_header(["Structure"], metrics)
-        for label in sorted({int(row["label_id"]) for row in rows}):
-            matching = [row for row in rows if row["label_id"] == label]
-            cells = [str(matching[0]["label_name"])]
-            if has_dice:
-                cells.append(f"{self._mean(matching, 'dice'):.4f}")
-            cells += [
-                f"{self._mean(matching, 'volume_difference_percent'):+.2f}",
-                f"{self._mean(matching, 'surface_rmse_mm'):.3f}",
-            ]
-            lines.append("| " + " | ".join(cells) + " |")
-
-        lines += ["", "## Per stage", ""]
-        lines += self._table_header(["Stage", "Structure"], metrics)
-        for row in rows:
-            cells = [f"{row['stage']:.2f}", str(row["label_name"])]
-            if has_dice:
-                cells.append(f"{row['dice']:.4f}")
-            cells += [
-                f"{row['volume_difference_percent']:+.2f}",
-                f"{row['surface_rmse_mm']:.3f}",
-            ]
-            lines.append("| " + " | ".join(cells) + " |")
-
-        report_file = out_dir / "evaluation_report.md"
-        report_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        self.log_info("Report: %s", report_file)
-        return report_file
-
-    @staticmethod
-    def _table_header(keys: list[str], metrics: list[str]) -> list[str]:
-        """Markdown header and alignment rows: keys left, metrics right."""
-        return [
-            "| " + " | ".join(keys + metrics) + " |",
-            "| " + " | ".join(["---"] * len(keys) + ["---:"] * len(metrics)) + " |",
-        ]
-
-    @staticmethod
-    def _mean(rows: list[dict[str, Any]], key: str) -> float:
-        """Mean of one column, ignoring the rows where it could not be measured."""
-        values = [float(row[key]) for row in rows if not np.isnan(float(row[key]))]
-        return float(np.mean(values)) if values else float("nan")

--- a/src/physiotwin4d/workflow_fit_statistical_model_to_patient.py
+++ b/src/physiotwin4d/workflow_fit_statistical_model_to_patient.py
@@ -109,8 +109,8 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         l2i_template_model_surface: template model surface after labelmap-to-image
             registration
         l2i_template_labelmap: template labelmap after labelmap-to-image registration
-        registered_template_model: Final registered model
-        registered_template_model_surface: Final registered model surface
+        fitted_reference_model: Final registered model
+        fitted_reference_mesh: Final registered model surface
 
     Example:
         >>> # Initialize with minimal parameters (no labelmap; no patient image -> reference created from patient models)
@@ -246,6 +246,10 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         self.template_mask: Optional[itk.Image] = None
         self.patient_mask: Optional[itk.Image] = None
 
+        # Alignment applied before the PCA fit.  It must match the alignment
+        # the model was built with; see WorkflowCreateStatisticalModel.
+        self.icp_transform_type: str = "Affine"
+
         # Parameters for labelmap and mask generation
         self.mask_dilation_mm: float = 10.0  # For binary registration mask generation
         self.distancemap_squared_max: Optional[float] = None
@@ -291,9 +295,9 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         self.use_ICON_registration_refinement = False
 
         # Final result
-        self.registered_template_model: Optional[pv.DataSet] = None
-        self.registered_template_model_surface: Optional[pv.PolyData] = None
-        self.registered_template_labelmap: Optional[itk.Image] = None
+        self.fitted_reference_model: Optional[pv.DataSet] = None
+        self.fitted_reference_mesh: Optional[pv.PolyData] = None
+        self.fitted_reference_labelmap: Optional[itk.Image] = None
 
     def set_mask_dilation_mm(self, mask_dilation_mm: float) -> None:
         """Set dilation amount for binary registration masks.
@@ -303,6 +307,26 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
                 mask generation. Default: 10mm
         """
         self.mask_dilation_mm = mask_dilation_mm
+
+    def set_icp_transform_type(self, transform_type: str) -> None:
+        """Set the ICP alignment applied to the template before the PCA fit.
+
+        This has to match the alignment the model was built with -- see
+        ``WorkflowCreateStatisticalModel.set_icp_transform_type`` -- because
+        whatever the ICP absorbs here is variation the eigenmodes never saw.
+
+        Args:
+            transform_type: One of ``"Rigid"``, ``"Similarity"``, ``"Affine"``.
+
+        Raises:
+            ValueError: If transform_type is not one of those.
+        """
+        if transform_type not in ("Rigid", "Similarity", "Affine"):
+            raise ValueError(
+                f"Invalid ICP transform '{transform_type}'. "
+                "Must be 'Rigid', 'Similarity' or 'Affine'."
+            )
+        self.icp_transform_type = transform_type
 
     def set_distancemap_squared_max(self, distancemap_squared_max: float) -> None:
         """Set the saturation radius of the labelmap-to-labelmap distance maps.
@@ -477,7 +501,7 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
             dict: Dictionary containing:
                 - 'forward_transform': used to warp an image from model to patient space
                 - 'inverse_transform': used to warp an image from patient to model space
-                - 'registered_template_model_surface': Transformed model model surface
+                - 'fitted_reference_mesh': Transformed model model surface
         """
         self.log_section("Stage 1: ICP Alignment (RegisterModelsICP)", width=70)
 
@@ -487,7 +511,7 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         # Run rigid ICP registration
         icp_result = self.icp_registrar.register(
             moving_model=self.template_model_surface,
-            transform_type="Affine",
+            transform_type=self.icp_transform_type,
             max_iterations=2000,
         )
 
@@ -514,16 +538,16 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
 
         self.log_info("Stage 1 complete: ICP alignment finished.")
 
-        self.registered_template_model_surface = self.icp_template_model_surface
-        self.registered_template_model = self.icp_template_model
-        self.registered_template_labelmap = self.icp_template_labelmap
+        self.fitted_reference_mesh = self.icp_template_model_surface
+        self.fitted_reference_model = self.icp_template_model
+        self.fitted_reference_labelmap = self.icp_template_labelmap
 
         return {
             "inverse_point_transform": self.icp_inverse_point_transform,
             "forward_point_transform": self.icp_forward_point_transform,
-            "registered_template_model": self.icp_template_model,
-            "registered_template_model_surface": self.icp_template_model_surface,
-            "registered_template_labelmap": self.icp_template_labelmap,
+            "fitted_reference_model": self.icp_template_model,
+            "fitted_reference_mesh": self.icp_template_model_surface,
+            "fitted_reference_labelmap": self.icp_template_labelmap,
         }
 
     def register_model_to_model_pca(self) -> dict:
@@ -541,7 +565,7 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
                   It excludes the ICP alignment, which is applied separately.
                 - 'inverse_point_transform': its inverse
                 - 'pca_coefficients': PCA shape coefficients
-                - 'registered_template_model_surface': PCA-registered model surface
+                - 'fitted_reference_mesh': PCA-registered model surface
 
         Raises:
             ValueError: If PCA data has not been set
@@ -561,9 +585,9 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
             self.pca_inverse_point_transform = identity_transform
             return {
                 "pca_coefficients": None,
-                "registered_template_model": self.pca_template_model,
-                "registered_template_model_surface": self.pca_template_model_surface,
-                "registered_template_labelmap": self.pca_template_labelmap,
+                "fitted_reference_model": self.pca_template_model,
+                "fitted_reference_mesh": self.pca_template_model_surface,
+                "fitted_reference_labelmap": self.pca_template_labelmap,
                 "forward_point_transform": self.pca_forward_point_transform,
                 "inverse_point_transform": self.pca_inverse_point_transform,
             }
@@ -663,8 +687,8 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
 
         # Store results
 
-        self.registered_template_model = self.pca_template_model
-        self.registered_template_model_surface = self.pca_template_model_surface
+        self.fitted_reference_model = self.pca_template_model
+        self.fitted_reference_mesh = self.pca_template_model_surface
 
         if self.template_labelmap is not None:
             # Resampling pulls back: a patient-grid sample is mapped by the ICP
@@ -688,7 +712,7 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         else:
             self.pca_template_labelmap = None
 
-        self.registered_template_labelmap = self.pca_template_labelmap
+        self.fitted_reference_labelmap = self.pca_template_labelmap
 
         self.log_info("Stage 2 complete: PCA registration finished.")
 
@@ -696,9 +720,9 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
             "pca_coefficients": self.pca_coefficients,
             "forward_point_transform": self.pca_forward_point_transform,
             "inverse_point_transform": self.pca_inverse_point_transform,
-            "registered_template_model": self.pca_template_model,
-            "registered_template_model_surface": self.pca_template_model_surface,
-            "registered_template_labelmap": self.pca_template_labelmap,
+            "fitted_reference_model": self.pca_template_model,
+            "fitted_reference_mesh": self.pca_template_model_surface,
+            "fitted_reference_labelmap": self.pca_template_labelmap,
         }
 
     def register_labelmap_to_labelmap(self) -> Optional[dict]:
@@ -711,8 +735,8 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
             dict: Dictionary containing:
                 - 'forward_transform': template to patient space transform
                 - 'inverse_transform': patient to template space transform
-                - 'registered_template_model_surface': Transformed template model surface
-                - 'registered_template_labelmap': Transformed template labelmap
+                - 'fitted_reference_mesh': Transformed template model surface
+                - 'fitted_reference_labelmap': Transformed template labelmap
         """
         self.log_section(
             "Stage 3: Labelmap-to-Labelmap Deformable Registration",
@@ -759,7 +783,7 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         self.l2l_inverse_transform = l2l_result["inverse_transform"]
         self.l2l_template_model_surface = l2l_result["registered_model"]
 
-        self.registered_template_model_surface = self.l2l_template_model_surface
+        self.fitted_reference_mesh = self.l2l_template_model_surface
 
         if self.pca_template_labelmap is not None:
             self.l2l_template_labelmap = self.transform_tools.transform_image(
@@ -771,15 +795,15 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         else:
             self.l2l_template_labelmap = None
 
-        self.registered_template_labelmap = self.l2l_template_labelmap
+        self.fitted_reference_labelmap = self.l2l_template_labelmap
 
         self.log_info("Stage 3 complete: Labelmap-to-labelmap registration finished.")
 
         return {
             "forward_transform": self.l2l_forward_transform,
             "inverse_transform": self.l2l_inverse_transform,
-            "registered_template_model_surface": self.l2l_template_model_surface,
-            "registered_template_labelmap": self.l2l_template_labelmap,
+            "fitted_reference_mesh": self.l2l_template_model_surface,
+            "fitted_reference_labelmap": self.l2l_template_labelmap,
         }
 
     def register_labelmap_to_image(
@@ -794,8 +818,8 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
             dict: Dictionary containing:
                 - 'inverse_transform': patient to template space transform
                 - 'forward_transform': template to patient space transform
-                - 'registered_template_model_surface': Transformed template model surface
-                - 'registered_template_labelmap': Transformed template labelmap
+                - 'fitted_reference_mesh': Transformed template model surface
+                - 'fitted_reference_labelmap': Transformed template labelmap
         """
         self.log_section(
             "Stage 4: Labelmap-to-Image Refinement (Icon Registration)", width=70
@@ -910,15 +934,15 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
 
         self.log_info("Stage 4 complete: Labelmap-to-image registration finished.")
 
-        self.registered_template_model_surface = self.l2i_template_model_surface
+        self.fitted_reference_mesh = self.l2i_template_model_surface
 
-        self.registered_template_labelmap = self.l2i_template_labelmap
+        self.fitted_reference_labelmap = self.l2i_template_labelmap
 
         return {
             "inverse_transform": self.l2i_inverse_transform,
             "forward_transform": self.l2i_forward_transform,
-            "registered_template_model_surface": self.l2i_template_model_surface,
-            "registered_template_labelmap": self.l2i_template_labelmap,
+            "fitted_reference_mesh": self.l2i_template_model_surface,
+            "fitted_reference_labelmap": self.l2i_template_labelmap,
         }
 
     def transform_model(
@@ -938,11 +962,11 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         self.log_info("Applying transforms to model...")
 
         if base_model is None:
-            self.registered_template_model = self.template_model.copy(deep=True)
-            assert self.registered_template_model is not None, (
+            self.fitted_reference_model = self.template_model.copy(deep=True)
+            assert self.fitted_reference_model is not None, (
                 "Registered template model must be set"
             )
-            transformed_model = self.registered_template_model
+            transformed_model = self.fitted_reference_model
         else:
             transformed_model = base_model.copy(deep=True)
 
@@ -981,11 +1005,11 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         self.log_info("Transform application complete.")
 
         if base_model is None:
-            assert self.registered_template_model is not None, (
+            assert self.fitted_reference_model is not None, (
                 "Registered template model must be set"
             )
-            self.registered_template_model.points = new_points
-            return self.registered_template_model
+            self.fitted_reference_model.points = new_points
+            return self.fitted_reference_model
         transformed_model.points = new_points
         return transformed_model
 
@@ -1009,7 +1033,7 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
                 uses Greedy affine + ICON deformable. Default: False
 
         Returns:
-            dict with registered_template_model and registered_template_model_surface
+            dict with fitted_reference_model and fitted_reference_mesh
         """
         self.log_section("STARTING COMPLETE MODEL REGISTRATION WORKFLOW", width=70)
 
@@ -1034,16 +1058,16 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         _ = self.transform_model()
 
         self.log_section("REGISTRATION WORKFLOW COMPLETE", width=70)
-        assert self.registered_template_model_surface is not None, (
+        assert self.fitted_reference_mesh is not None, (
             "Registered template model surface must be set"
         )
         self.log_info(
             "Final registered patient model surface: %d points.",
-            self.registered_template_model_surface.n_points,
+            self.fitted_reference_mesh.n_points,
         )
 
         return {
-            "registered_template_model": self.registered_template_model,
-            "registered_template_model_surface": self.registered_template_model_surface,
-            "registered_template_labelmap": self.registered_template_labelmap,
+            "fitted_reference_model": self.fitted_reference_model,
+            "fitted_reference_mesh": self.fitted_reference_mesh,
+            "fitted_reference_labelmap": self.fitted_reference_labelmap,
         }

--- a/src/physiotwin4d/workflow_fit_statistical_model_to_patient.py
+++ b/src/physiotwin4d/workflow_fit_statistical_model_to_patient.py
@@ -54,12 +54,13 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
     This class provides a flexible workflow for registering generic anatomical models
     (e.g., cardiac models) to patient-specific surface models and images. The
     registration pipeline combines:
-    - Initial model alignment using RegisterModelsICP (centroid + affine ICP)
+    - Initial model alignment using RegisterModelsICP (centroid + configurable ICP)
     - Labelmap-based deformable registration using RegisterModelsDistanceMaps (Greedy/ICON)
     - Optional final labelmap-to-image refinement using Icon registration
 
     **Registration Pipeline:**
-        1. **ICP Alignment**: Rough affine alignment using RegisterModelsICP
+        1. **ICP Alignment**: Rough alignment using RegisterModelsICP, rigid,
+            similarity or affine per :attr:`icp_transform_type`
         2. **PCA Registration**: Performs PCA-based shape fitting using
             RegisterModelsPCA
         3. **Labelmap-to-Labelmap**: Deformable registration using RegisterModelsDistanceMaps
@@ -80,6 +81,9 @@ class WorkflowFitStatisticalModelToPatient(PhysioTwin4DBase):
         patient_labelmap (itk.Image): Multi-label labelmap for patient model
         patient_mask (itk.Image): Binary mask for patient registration region
         mask_dilation_mm (float): Dilation for binary mask generation
+        icp_transform_type (str): Alignment the Stage 1 ICP solves for, one of
+            "Rigid", "Similarity" or "Affine". It has to match the value the
+            statistical model was built with (set via set_icp_transform_type)
         distancemap_squared_max (Optional[float]): Saturation radius of the
             labelmap-to-labelmap distance maps, in squared millimeters. None
             means derive it from mask_dilation_mm as (1.25 * mask_dilation_mm)**2

--- a/src/physiotwin4d/workflow_infer_movement.py
+++ b/src/physiotwin4d/workflow_infer_movement.py
@@ -126,17 +126,14 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         requested = stages if stages is not None else [p.stage for p in manifest.phases]
         surfaces: list[Path] = []
 
-        for index, stage in enumerate(requested):
+        for stage in requested:
             pred_points = fitted_reference_points + workflow.predict(pca_coeffs, stage)
             pred_mesh = fitted_reference_mesh.copy(deep=True)
             pred_mesh.points = pred_points
             path = out_dir / f"{sid}_s{int(stage * 100):03d}_pred{suffix}"
             pred_mesh.save(str(path))
             surfaces.append(path)
-
-            if stages is not None:
-                self.log_info("stage %.3f -> %s", stage, path.name)
-                continue
+            self.log_info("stage %.3f -> %s", stage, path.name)
 
         return {"subject_id": sid, "predicted_surfaces": surfaces}
 
@@ -240,17 +237,6 @@ class WorkflowInferMovement(PhysioTwin4DBase):
             anatomy_type: Anatomy whose materials color that USD.
             separate_by_connectivity: Whether that USD splits each frame into
                 separate objects by connectivity.
-            report_displacement_data: Write ``displacement_per_point.csv``, one
-                row per mesh point per stage carrying that point's predicted and
-                true displacement and the error between them.
-            include_predicted_displacements: Carry
-                ``predicted_displacement_mm`` (``predicted - reference``) as
-                point data on every stage mesh.
-            include_true_displacements: Carry ``true_displacement_mm``
-                (``ground truth - reference``) as point data on every stage mesh.
-            include_displacement_error: Carry ``displacement_error_mm``, the
-                distance between the predicted and the true position, as point
-                data on every stage mesh.
 
         Returns:
             Dict with ``stages``, ``predicted_surfaces``, ``warped_images``,

--- a/src/physiotwin4d/workflow_infer_movement.py
+++ b/src/physiotwin4d/workflow_infer_movement.py
@@ -2,9 +2,11 @@
 
 :class:`WorkflowInferMovement` wraps a
 :class:`physiotwin4d.WorkflowInferPhysicsNeMo` whose targets are per-point
-displacements from the subject's reference mesh, and turns those raw predictions
-into geometry: deformed meshes (``reference + displacement``), error statistics
-in millimetres, and rasterized deformation / surface-normal fields.
+displacements from the subject's fitted reference mesh, and turns those raw
+predictions into geometry: deformed meshes (``fitted reference + displacement``)
+and rasterized deformation / surface-normal fields. Scoring those predictions is
+:class:`physiotwin4d.WorkflowEvaluateMovement`'s job, so no error statistic is
+computed here.
 
 The generic workflow stays target-agnostic; everything that assumes "the target
 is a 3-vector displacement in mm" lives here. Composition, not inheritance, so
@@ -13,7 +15,6 @@ one decoder serves both the MeshGraphNet and the MLP inference methods.
 
 from __future__ import annotations
 
-import csv
 import logging
 from collections.abc import Sequence
 from pathlib import Path
@@ -33,12 +34,14 @@ from .workflow_infer_physicsnemo import WorkflowInferPhysicsNeMo
 class WorkflowInferMovement(PhysioTwin4DBase):
     """Reconstruct geometry from displacement predictions.
 
-    The displacements are added to the caller's reference mesh when one is
-    available — the manifest's ``reference_mesh``, or the ``reference_mesh``
+    The displacements are added to the subject's fitted reference mesh — the
+    manifest's ``fitted_reference_mesh``, or the ``fitted_reference_mesh``
     argument of the single-subject methods — which keeps the result in that
-    mesh's world frame. With no reference mesh they are added to the mesh
-    reconstructed from the PCA coefficients alone, which stays in the model's
-    PCA frame.
+    mesh's world frame. That mesh is what
+    :class:`physiotwin4d.WorkflowFitStatisticalModelToPatient` produces: PCA
+    shape parameters *and* a deformable registration to the patient. A surface
+    reconstructed from the shape parameters alone is not a substitute and is not
+    accepted.
 
     Args:
         inference_workflow: A loaded :class:`WorkflowInferPhysicsNeMo` whose
@@ -64,23 +67,17 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         self.inference_workflow = inference_workflow
         self.model_directory = inference_workflow.model_directory
 
-    def _reference_points(
-        self, pca_coeffs: np.ndarray, reference_mesh: Optional[pv.DataSet]
-    ) -> np.ndarray:
+    def _fitted_reference_points(self, fitted_reference_mesh: pv.DataSet) -> np.ndarray:
         """Return the points the displacements are added to.
 
         Raises:
             ValueError: If the supplied mesh has the wrong point count.
         """
-        if reference_mesh is None:
-            return self.inference_workflow.reference_points_from_coefficients(
-                pca_coeffs
-            )
-        points = np.asarray(reference_mesh.points, dtype=np.float32)
+        points = np.asarray(fitted_reference_mesh.points, dtype=np.float32)
         n_expected = self.inference_workflow.template_mesh.n_points
         if points.shape[0] != n_expected:
             raise ValueError(
-                f"Reference mesh has {points.shape[0]} points, expected "
+                f"Fitted reference mesh has {points.shape[0]} points, expected "
                 f"{n_expected} (template topology)."
             )
         return points
@@ -94,11 +91,10 @@ class WorkflowInferMovement(PhysioTwin4DBase):
     ) -> dict[str, Any]:
         """Predict a subject's deformed meshes from a manifest.
 
-        When ``stages`` is ``None`` every phase in the manifest is predicted and
-        compared against its ground truth (``reference + stored displacement``);
-        when ``stages`` is given those arbitrary stages are predicted without
-        comparison. The displacements are added to the manifest's
-        ``reference_mesh`` points.
+        Every phase in the manifest is predicted, or the arbitrary ``stages``
+        given instead. The displacements are added to the manifest's
+        ``fitted_reference_mesh`` points. Scoring the result against a ground
+        truth belongs to :class:`physiotwin4d.WorkflowEvaluateMovement`.
 
         Args:
             subject_manifest: Path to the subject manifest JSON.
@@ -107,14 +103,15 @@ class WorkflowInferMovement(PhysioTwin4DBase):
                 ``<model_directory>/<subject_id>``.
 
         Returns:
-            Dict with ``subject_id``, ``predicted_surfaces`` (paths), and, in the
-            phase mode, ``statistics``, ``statistics_file`` and ``rmse_surface``.
+            Dict with ``subject_id`` and ``predicted_surfaces`` (paths).
         """
         workflow = self.inference_workflow
         manifest = pnt.parse_manifest(subject_manifest)
         pca_coeffs = pnt.load_pca_coefficients(manifest.pca_coefficients)
-        ref_mesh = cast(pv.DataSet, pv.read(str(manifest.reference_mesh)))
-        ref_points = self._reference_points(pca_coeffs, ref_mesh)
+        fitted_reference_mesh = cast(
+            pv.DataSet, pv.read(str(manifest.fitted_reference_mesh))
+        )
+        fitted_reference_points = self._fitted_reference_points(fitted_reference_mesh)
 
         out_dir = (
             Path(output_directory)
@@ -125,15 +122,13 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         sid = manifest.subject_id
         self.log_section("INFER MOVEMENT [%s]", sid)
 
-        suffix = ".vtp" if isinstance(ref_mesh, pv.PolyData) else ".vtu"
+        suffix = ".vtp" if isinstance(fitted_reference_mesh, pv.PolyData) else ".vtu"
         requested = stages if stages is not None else [p.stage for p in manifest.phases]
         surfaces: list[Path] = []
-        stats: list[dict] = []
-        sq_err_sum = np.zeros(ref_points.shape[0], dtype=np.float64)
 
         for index, stage in enumerate(requested):
-            pred_points = ref_points + workflow.predict(pca_coeffs, stage)
-            pred_mesh = ref_mesh.copy(deep=True)
+            pred_points = fitted_reference_points + workflow.predict(pca_coeffs, stage)
+            pred_mesh = fitted_reference_mesh.copy(deep=True)
             pred_mesh.points = pred_points
             path = out_dir / f"{sid}_s{int(stage * 100):03d}_pred{suffix}"
             pred_mesh.save(str(path))
@@ -143,84 +138,37 @@ class WorkflowInferMovement(PhysioTwin4DBase):
                 self.log_info("stage %.3f -> %s", stage, path.name)
                 continue
 
-            stored = pnt.load_target_array(
-                manifest.phases[index].mesh, manifest.target_array
-            )
-            if stored.shape != ref_points.shape:
-                raise ValueError(
-                    f"Stored '{manifest.target_array}' targets in "
-                    f"{manifest.phases[index].mesh} have shape {stored.shape}, "
-                    f"expected {ref_points.shape} to be displacements of the "
-                    "reference mesh."
-                )
-            actual = ref_points + stored
-            euclidean = np.linalg.norm(pred_points - actual, axis=1)
-            sq_err_sum += euclidean.astype(np.float64) ** 2
-            stats.append(self._error_row(sid, stage, pred_points, actual))
-            self.log_info(
-                "stage %.3f: mean=%.3f mm  max=%.3f mm",
-                stage,
-                stats[-1]["mean_error_mm"],
-                stats[-1]["max_error_mm"],
-            )
-
-        result: dict[str, Any] = {"subject_id": sid, "predicted_surfaces": surfaces}
-        if stages is None:
-            point_rmse = np.sqrt(sq_err_sum / len(requested)).astype(np.float32)
-            rmse_mesh = ref_mesh.copy(deep=True)
-            rmse_mesh.point_data["RMSE_mm"] = point_rmse
-            rmse_file = out_dir / f"{sid}_rmse{suffix}"
-            rmse_mesh.save(str(rmse_file))
-
-            stats_file = out_dir / "statistics_per_phase.csv"
-            with stats_file.open("w", newline="", encoding="utf-8") as fh:
-                writer = csv.DictWriter(fh, fieldnames=list(stats[0].keys()))
-                writer.writeheader()
-                writer.writerows(stats)
-            result["rmse_surface"] = rmse_file
-            result["statistics"] = stats
-            result["statistics_file"] = stats_file
-        return result
+        return {"subject_id": sid, "predicted_surfaces": surfaces}
 
     def predict_single(
         self,
         shape_parameters: Path,
         stage: float,
-        reference_mesh: Optional[Path] = None,
-        ground_truth: Optional[Path] = None,
+        fitted_reference_mesh: Path,
         output_directory: Optional[Path] = None,
     ) -> dict[str, Any]:
         """Predict one subject at one stage without a manifest.
 
-        Without ``reference_mesh`` the subject reference is reconstructed from
-        the PCA shape parameters (``P = mean + Σ b_i·std_i·eigenvector_i``) in
-        the SSM/PCA frame, so the prediction is self-consistent with no
-        reference mesh file at all; with one, the prediction stays in that
-        mesh's world frame.
+        The prediction stays in the fitted reference mesh's world frame, since
+        that is where the displacements are applied.
 
         Args:
             shape_parameters: JSON file with the subject PCA coefficient vector.
             stage: Target stage to predict.
-            reference_mesh: The subject's reference mesh; omit to displace the
-                PCA reconstruction instead.
-            ground_truth: Optional mesh whose points are the true stage
-                positions, for error reporting.
+            fitted_reference_mesh: The subject's fitted reference mesh, as
+                produced by
+                :class:`physiotwin4d.WorkflowFitStatisticalModelToPatient`.
             output_directory: Output directory; defaults to
                 ``<model_directory>/single_prediction``.
 
         Returns:
-            Dict with ``predicted_surface`` (path), ``predicted_points``, and,
-            when ``ground_truth`` is supplied, ``statistics``.
+            Dict with ``predicted_surface`` (path) and ``predicted_points``.
         """
         workflow = self.inference_workflow
         coeffs = pnt.load_pca_coefficients(shape_parameters)
-        ref_mesh = (
-            cast(pv.DataSet, pv.read(str(reference_mesh)))
-            if reference_mesh is not None
-            else None
-        )
-        ref_points = self._reference_points(coeffs, ref_mesh)
-        pred_points = ref_points + workflow.predict(coeffs, stage)
+        fitted_mesh = cast(pv.DataSet, pv.read(str(fitted_reference_mesh)))
+        fitted_reference_points = self._fitted_reference_points(fitted_mesh)
+        pred_points = fitted_reference_points + workflow.predict(coeffs, stage)
 
         out_dir = (
             Path(output_directory)
@@ -229,10 +177,9 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         )
         out_dir.mkdir(parents=True, exist_ok=True)
 
-        template = workflow.template_mesh
-        pred_mesh = template.copy(deep=True)
+        pred_mesh = fitted_mesh.copy(deep=True)
         pred_mesh.points = pred_points
-        suffix = ".vtp" if isinstance(template, pv.PolyData) else ".vtu"
+        suffix = ".vtp" if isinstance(fitted_mesh, pv.PolyData) else ".vtu"
         stem = Path(shape_parameters).stem
         path = out_dir / f"{stem}_pred_s{int(stage * 100):03d}{suffix}"
         pred_mesh.save(str(path))
@@ -242,14 +189,6 @@ class WorkflowInferMovement(PhysioTwin4DBase):
             "predicted_surface": path,
             "predicted_points": pred_points,
         }
-        if ground_truth is not None:
-            actual = np.asarray(pv.read(str(ground_truth)).points, dtype=np.float32)
-            result["statistics"] = self._error_row(stem, stage, pred_points, actual)
-            self.log_info(
-                "ground-truth error: mean=%.3f mm  max=%.3f mm",
-                result["statistics"]["mean_error_mm"],
-                result["statistics"]["max_error_mm"],
-            )
         return result
 
     def process_time_series(
@@ -257,8 +196,7 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         shape_parameters: Path,
         stages: Sequence[float],
         output_directory: Path,
-        reference_mesh: Optional[Path] = None,
-        ground_truth: Optional[Sequence[Path]] = None,
+        fitted_reference_mesh: Path,
         reference_image: Optional[itk.Image] = None,
         warp_interpolation: str = "linear",
         warp_background_value: float = 0.0,
@@ -281,10 +219,11 @@ class WorkflowInferMovement(PhysioTwin4DBase):
             shape_parameters: JSON file with the subject PCA coefficient vector.
             stages: Stages to predict, in the order they are to be animated.
             output_directory: Directory every artifact is written to.
-            reference_mesh: The subject's reference mesh; omit to displace the
-                PCA reconstruction instead.
-            ground_truth: One mesh per stage whose points are the true stage
-                positions, for error reporting. Must align with ``stages``.
+            fitted_reference_mesh: The subject's fitted reference mesh, as
+                produced by
+                :class:`physiotwin4d.WorkflowFitStatisticalModelToPatient`. The
+                displacements are added to its points and the result stays in
+                its world frame.
             reference_image: Image carried through each stage's deformation, and
                 the grid the deformation field is rasterized on. Omit to write
                 meshes only.
@@ -301,39 +240,44 @@ class WorkflowInferMovement(PhysioTwin4DBase):
             anatomy_type: Anatomy whose materials color that USD.
             separate_by_connectivity: Whether that USD splits each frame into
                 separate objects by connectivity.
+            report_displacement_data: Write ``displacement_per_point.csv``, one
+                row per mesh point per stage carrying that point's predicted and
+                true displacement and the error between them.
+            include_predicted_displacements: Carry
+                ``predicted_displacement_mm`` (``predicted - reference``) as
+                point data on every stage mesh.
+            include_true_displacements: Carry ``true_displacement_mm``
+                (``ground truth - reference``) as point data on every stage mesh.
+            include_displacement_error: Carry ``displacement_error_mm``, the
+                distance between the predicted and the true position, as point
+                data on every stage mesh.
 
         Returns:
             Dict with ``stages``, ``predicted_surfaces``, ``warped_images``,
-            ``transforms``, ``usd_file``, ``statistics`` and
-            ``statistics_file``. Entries that were not requested are empty
-            lists or ``None``.
+            ``transforms``, ``usd_file`` and ``stage_meshes``. Entries that were
+            not requested are empty lists or ``None``.
+
+            ``stage_meshes`` are the very objects written to
+            ``predicted_surfaces``, handed back so a caller that scores them ---
+            :class:`physiotwin4d.WorkflowEvaluateMovement` --- can annotate and
+            re-save them without re-reading. They are retained for the USD
+            writer regardless, so returning them costs nothing.
 
         Raises:
-            ValueError: If ``stages`` is empty, or ``ground_truth`` is given
-                with a different length.
+            ValueError: If ``stages`` is empty.
         """
         if not stages:
             raise ValueError("process_time_series needs at least one stage.")
-        if ground_truth is not None and len(ground_truth) != len(stages):
-            raise ValueError(
-                f"ground_truth has {len(ground_truth)} entries but there are "
-                f"{len(stages)} stages."
-            )
 
         workflow = self.inference_workflow
         coeffs = pnt.load_pca_coefficients(shape_parameters)
-        ref_mesh = (
-            cast(pv.DataSet, pv.read(str(reference_mesh)))
-            if reference_mesh is not None
-            else None
-        )
-        ref_points = self._reference_points(coeffs, ref_mesh)
-        template = ref_mesh if ref_mesh is not None else workflow.template_mesh
+        fitted_mesh = cast(pv.DataSet, pv.read(str(fitted_reference_mesh)))
+        fitted_reference_points = self._fitted_reference_points(fitted_mesh)
 
         out_dir = Path(output_directory)
         out_dir.mkdir(parents=True, exist_ok=True)
         stem = Path(shape_parameters).stem
-        suffix = ".vtp" if isinstance(template, pv.PolyData) else ".vtu"
+        suffix = ".vtp" if isinstance(fitted_mesh, pv.PolyData) else ".vtu"
         self.log_section("INFER MOVEMENT TIME SERIES [%s]", stem)
 
         transform_tools = TransformTools(log_level=self.log_level)
@@ -341,13 +285,17 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         surfaces: list[Path] = []
         warped_images: list[Path] = []
         transforms: list[itk.Transform] = []
-        stats: list[dict] = []
 
         for index, stage in enumerate(stages):
             tag = f"s{int(stage * 100):03d}"
-            pred_points = ref_points + workflow.predict(coeffs, stage)
-            pred_mesh = template.copy(deep=True)
+            pred_points = fitted_reference_points + workflow.predict(coeffs, stage)
+            pred_mesh = fitted_mesh.copy(deep=True)
             pred_mesh.points = pred_points
+            # The displacement the network itself predicted. Scoring it against
+            # a ground truth is the evaluation workflow's job, not this one's.
+            pred_mesh.point_data["predicted_displacement_mm"] = (
+                pred_points - fitted_reference_points
+            ).astype(np.float32)
             surface_file = out_dir / f"{stem}_{tag}_pred{suffix}"
             pred_mesh.save(str(surface_file))
             stage_meshes.append(pred_mesh)
@@ -358,7 +306,7 @@ class WorkflowInferMovement(PhysioTwin4DBase):
                     shape_parameters=shape_parameters,
                     stage=stage,
                     reference_image=reference_image,
-                    reference_mesh=reference_mesh,
+                    fitted_reference_mesh=fitted_reference_mesh,
                     direction="inverse",
                 )
                 transform = transform_tools.smooth_deformation_field_transform(
@@ -378,27 +326,7 @@ class WorkflowInferMovement(PhysioTwin4DBase):
                 itk.imwrite(warped, str(warped_file), compression=True)
                 warped_images.append(warped_file)
 
-            if ground_truth is not None:
-                actual = np.asarray(
-                    pv.read(str(ground_truth[index])).points, dtype=np.float32
-                )
-                stats.append(self._error_row(stem, stage, pred_points, actual))
-                self.log_info(
-                    "stage %.3f: mean=%.3f mm  max=%.3f mm",
-                    stage,
-                    stats[-1]["mean_error_mm"],
-                    stats[-1]["max_error_mm"],
-                )
-            else:
-                self.log_info("stage %.3f -> %s", stage, surface_file.name)
-
-        statistics_file: Optional[Path] = None
-        if stats:
-            statistics_file = out_dir / "statistics_per_stage.csv"
-            with statistics_file.open("w", newline="", encoding="utf-8") as fh:
-                writer = csv.DictWriter(fh, fieldnames=list(stats[0].keys()))
-                writer.writeheader()
-                writer.writerows(stats)
+            self.log_info("stage %.3f -> %s", stage, surface_file.name)
 
         usd_file: Optional[Path] = None
         if usd_project_name is not None:
@@ -420,8 +348,7 @@ class WorkflowInferMovement(PhysioTwin4DBase):
             "warped_images": warped_images,
             "transforms": transforms,
             "usd_file": usd_file,
-            "statistics": stats,
-            "statistics_file": statistics_file,
+            "stage_meshes": stage_meshes,
         }
 
     def create_deformation_field(
@@ -429,8 +356,8 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         shape_parameters: Path,
         stage: float,
         reference_image: itk.Image,
+        fitted_reference_mesh: Path,
         output_directory: Optional[Path] = None,
-        reference_mesh: Optional[Path] = None,
         direction: Literal["forward", "inverse"] = "forward",
     ) -> dict[str, Any]:
         """Rasterize the inferred deformation onto a reference image grid.
@@ -451,23 +378,24 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         binned by its **deformed** position ``reference + displacement`` and
         contributes ``-displacement``.
 
-        The binning positions come from ``reference_mesh``, so a patient scan
-        whose statistical-model fit applied a pose transform not captured by the
-        shape coefficients is binned where it actually aligns with
-        ``reference_image``. Omit it to bin at the PCA reconstruction instead,
-        in the model's own frame. The network displacements themselves depend
-        only on the coefficients and stage, not on the binning positions.
+        The binning positions come from ``fitted_reference_mesh``, so a patient
+        scan whose statistical-model fit applied a pose transform not captured
+        by the shape coefficients is binned where it actually aligns with
+        ``reference_image``. The network displacements themselves depend only on
+        the coefficients and stage, not on the binning positions.
 
         Args:
             shape_parameters: JSON file with the subject PCA coefficient vector.
             stage: Target stage for the deformation.
             reference_image: The frame's image; defines the output grid geometry
                 (size, spacing, origin, direction).
+            fitted_reference_mesh: The subject's fitted reference mesh, as
+                produced by
+                :class:`physiotwin4d.WorkflowFitStatisticalModelToPatient`. Its
+                points supply the binning positions and normals, and must share
+                the template topology (same point count and ordering).
             output_directory: If given, the three images are written there as
                 compressed ``.mha`` files.
-            reference_mesh: Mesh whose points supply the binning positions and
-                normals; omit to use the PCA reconstruction. Must share the
-                template topology (same point count and ordering).
             direction: ``"forward"`` for the reference-to-stage field that
                 deforms meshes, ``"inverse"`` for the stage-to-reference field
                 that resamples images into the stage frame.
@@ -482,24 +410,19 @@ class WorkflowInferMovement(PhysioTwin4DBase):
             when written, their paths.
         """
         workflow = self.inference_workflow
-        template = workflow.template_mesh
         coeffs = pnt.load_pca_coefficients(shape_parameters)
-        patient_mesh = (
-            cast(pv.DataSet, pv.read(str(reference_mesh)))
-            if reference_mesh is not None
-            else None
-        )
-        ref_points = self._reference_points(coeffs, patient_mesh)
+        fitted_mesh = cast(pv.DataSet, pv.read(str(fitted_reference_mesh)))
+        fitted_reference_points = self._fitted_reference_points(fitted_mesh)
         disps = workflow.predict(coeffs, stage)
 
         # Reference (undeformed) surface normals. Extraction drops the interior
         # points of a volumetric template, so the normals come back on a subset
         # of the points in a different order; ``vtkOriginalPointIds`` scatters
-        # them back into ``ref_points`` order. Interior points keep a zero
+        # them back into ``fitted_reference_points`` order. Interior points keep a zero
         # normal, which contributes nothing to a voxel's mean.
-        ref_mesh = template.copy(deep=True)
-        ref_mesh.points = ref_points
-        surface = ref_mesh.extract_surface(
+        normals_mesh = fitted_mesh.copy(deep=True)
+        normals_mesh.points = fitted_reference_points
+        surface = normals_mesh.extract_surface(
             pass_pointid=True, algorithm="dataset_surface"
         ).compute_normals(
             point_normals=True, cell_normals=False, auto_orient_normals=True
@@ -508,7 +431,7 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         original_ids = np.asarray(
             surface.point_data["vtkOriginalPointIds"], dtype=np.intp
         )
-        normals = np.zeros((ref_points.shape[0], 3), dtype=np.float64)
+        normals = np.zeros((fitted_reference_points.shape[0], 3), dtype=np.float64)
         normals[original_ids] = surface_normals
 
         size = itk.size(reference_image)  # x, y, z
@@ -518,10 +441,10 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         count = np.zeros((sz, sy, sx), dtype=np.float64)
 
         if direction == "inverse":
-            bin_points = ref_points + disps
+            bin_points = fitted_reference_points + disps
             bin_disps = -disps
         else:
-            bin_points = ref_points
+            bin_points = fitted_reference_points
             bin_disps = disps
 
         for i in range(bin_points.shape[0]):
@@ -558,8 +481,8 @@ class WorkflowInferMovement(PhysioTwin4DBase):
 
         # Deformed (stage) mesh: reference positions displaced by the network,
         # keeping the template topology.
-        deformed_surface = template.copy(deep=True)
-        deformed_surface.points = (ref_points + disps).astype(np.float32)
+        deformed_surface = fitted_mesh.copy(deep=True)
+        deformed_surface.points = (fitted_reference_points + disps).astype(np.float32)
 
         result: dict[str, Any] = {
             "deformation_field": deformation_image,
@@ -570,7 +493,7 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         if output_directory is not None:
             out_dir = Path(output_directory)
             out_dir.mkdir(parents=True, exist_ok=True)
-            suffix = ".vtp" if isinstance(template, pv.PolyData) else ".vtu"
+            suffix = ".vtp" if isinstance(fitted_mesh, pv.PolyData) else ".vtu"
             field_path = out_dir / "deformation_field.mha"
             normal_path = out_dir / "surface_normal_field.mha"
             weight_path = out_dir / "deformation_weight.mha"
@@ -602,24 +525,3 @@ class WorkflowInferMovement(PhysioTwin4DBase):
         image.SetOrigin(reference_image.GetOrigin())
         image.SetDirection(reference_image.GetDirection())
         return image
-
-    @staticmethod
-    def _error_row(
-        subject_id: str, stage: float, pred: np.ndarray, actual: np.ndarray
-    ) -> dict:
-        """Per-phase error statistics between predicted and actual points."""
-        errors = pred - actual
-        euclidean = np.linalg.norm(errors, axis=1)
-        return {
-            "subject_id": subject_id,
-            "stage": stage,
-            "n_points": int(len(euclidean)),
-            "mean_error_mm": float(euclidean.mean()),
-            "median_error_mm": float(np.median(euclidean)),
-            "max_error_mm": float(euclidean.max()),
-            "rms_error_mm": float(np.sqrt(np.mean(euclidean**2))),
-            "std_error_mm": float(euclidean.std()),
-            "mean_abs_error_x_mm": float(np.abs(errors[:, 0]).mean()),
-            "mean_abs_error_y_mm": float(np.abs(errors[:, 1]).mean()),
-            "mean_abs_error_z_mm": float(np.abs(errors[:, 2]).mean()),
-        }

--- a/src/physiotwin4d/workflow_infer_physicsnemo.py
+++ b/src/physiotwin4d/workflow_infer_physicsnemo.py
@@ -128,8 +128,6 @@ class WorkflowInferPhysicsNeMo(PhysioTwin4DBase):
         model.eval()
         self.inference_method.set_model(model, self._device)
 
-        # Optional PCA reconstruction assets (manifest-free inference).
-
     # ─────────────────────────── Shared assets ─────────────────────────────
     @property
     def template_mesh(self) -> pv.DataSet:
@@ -193,8 +191,7 @@ class WorkflowInferPhysicsNeMo(PhysioTwin4DBase):
                 ``<model_directory>/<subject_id>``.
 
         Returns:
-            Dict with ``subject_id``, ``predicted_meshes`` (paths) and, in the
-            ``predicted_meshes`` (paths).
+            Dict with ``subject_id`` and ``predicted_meshes`` (paths).
         """
         manifest = pnt.parse_manifest(subject_manifest)
         pca_coeffs = pnt.load_pca_coefficients(manifest.pca_coefficients)
@@ -213,7 +210,7 @@ class WorkflowInferPhysicsNeMo(PhysioTwin4DBase):
         meshes: list[Path] = []
 
         requested = stages if stages is not None else [p.stage for p in manifest.phases]
-        for index, stage in enumerate(requested):
+        for stage in requested:
             predicted = self.predict(pca_coeffs, stage)
             path = out_dir / f"{sid}_pred_s{int(stage * 100):03d}{suffix}"
             self.predicted_mesh(predicted).save(str(path))

--- a/src/physiotwin4d/workflow_infer_physicsnemo.py
+++ b/src/physiotwin4d/workflow_infer_physicsnemo.py
@@ -2,7 +2,8 @@
 
 The workflow owns everything around the network: the checkpoint and its
 normalization statistics, the shared PCA template mesh, manifests, and the
-writing of predicted meshes and error statistics. The network itself is supplied
+writing of predicted meshes. Scoring those predictions belongs to
+:class:`physiotwin4d.WorkflowEvaluateMovement`. The network itself is supplied
 as an inference method (:class:`physiotwin4d.InferPhysicsNeMoMGN` or
 :class:`physiotwin4d.InferPhysicsNeMoMLP`).
 
@@ -10,7 +11,7 @@ Predictions are the targets the model was trained on, whatever those are — the
 manifest's ``target_array`` values at each template point. For the common case
 where those targets are displacements from the subject's reference mesh, wrap
 this workflow in :class:`physiotwin4d.WorkflowInferMovement` to get
-reconstructed surfaces, mm error statistics and deformation fields.
+reconstructed surfaces and deformation fields.
 
 PhysicsNeMo (and, for the MGN, PyTorch Geometric) are optional dependencies,
 imported lazily so ``import physiotwin4d`` works without them.
@@ -18,8 +19,6 @@ imported lazily so ``import physiotwin4d`` works without them.
 
 from __future__ import annotations
 
-import csv
-import json
 import logging
 from pathlib import Path
 from typing import Any, Optional, cast
@@ -130,8 +129,6 @@ class WorkflowInferPhysicsNeMo(PhysioTwin4DBase):
         self.inference_method.set_model(model, self._device)
 
         # Optional PCA reconstruction assets (manifest-free inference).
-        self._pca_model: Optional[dict] = None
-        self._pca_mean_dataset: Optional[pv.DataSet] = None
 
     # ─────────────────────────── Shared assets ─────────────────────────────
     @property
@@ -164,64 +161,6 @@ class WorkflowInferPhysicsNeMo(PhysioTwin4DBase):
         # bare/legacy epoch checkpoints are the state dict itself.
         return cast(dict, ckpt.get("model_state_dict", ckpt))
 
-    def load_pca_assets(self) -> tuple[pv.DataSet, dict]:
-        """Load (and cache) the PCA template mesh and model for reconstruction."""
-        if self._pca_mean_dataset is not None and self._pca_model is not None:
-            return self._pca_mean_dataset, self._pca_model
-
-        pca_model_file = self.model_directory / "pca_model.json"
-        if not pca_model_file.exists():
-            raise FileNotFoundError(
-                f"pca_model.json not found in {self.model_directory}; it is "
-                "required for manifest-free reconstruction. Re-run training with a "
-                "pca_mean_mesh whose directory contains pca_model.json."
-            )
-        # The PCA template mesh (volume) was copied next to pca_model.json.
-        mesh_candidates = [
-            p
-            for p in self.model_directory.glob("*")
-            if p.suffix in (".vtu", ".vtk", ".vtp")
-            and not p.name.startswith("pca_mean_template")
-        ]
-        pca_model = json.loads(pca_model_file.read_text(encoding="utf-8"))
-        expected = int(np.asarray(pca_model["components"]).shape[1]) // 3
-        mesh: Optional[pv.DataSet] = None
-        for candidate in mesh_candidates:
-            dataset = pv.read(str(candidate))
-            if dataset.n_points == expected:
-                mesh = dataset
-                break
-        if mesh is None:
-            raise FileNotFoundError(
-                f"No PCA template mesh with {expected} points found in "
-                f"{self.model_directory} to match pca_model.json."
-            )
-        self._pca_mean_dataset = mesh
-        self._pca_model = pca_model
-        return mesh, pca_model
-
-    def reference_points_from_coefficients(self, pca_coeffs: np.ndarray) -> np.ndarray:
-        """Reconstruct a subject's reference points in the template's domain.
-
-        The PCA model may be volumetric while the model was trained on the
-        template's surface (``use_template_surface``), so the reconstruction is
-        surface-extracted when its point count does not match the template's.
-        """
-        mean_mesh, pca_model = self.load_pca_assets()
-        points = pnt.reconstruct_reference_points(mean_mesh, pca_model, pca_coeffs)
-        if points.shape[0] == self._template_mesh.n_points:
-            return points
-        deformed = mean_mesh.copy(deep=True)
-        deformed.points = points
-        surface = deformed.extract_surface(algorithm="dataset_surface")
-        if surface.n_points != self._template_mesh.n_points:
-            raise ValueError(
-                f"PCA reconstruction yields {points.shape[0]} points "
-                f"({surface.n_points} on its surface), but the template has "
-                f"{self._template_mesh.n_points}."
-            )
-        return np.asarray(surface.points, dtype=np.float32)
-
     # ─────────────────────────── Core predictor ────────────────────────────
     def predict(self, pca_coeffs: np.ndarray, stage: float) -> np.ndarray:
         """Predict ``(n_points, n_target)`` targets for a subject at a stage."""
@@ -244,10 +183,8 @@ class WorkflowInferPhysicsNeMo(PhysioTwin4DBase):
     ) -> dict[str, Any]:
         """Predict a subject's targets from a manifest.
 
-        When ``stages`` is ``None`` every phase in the manifest is predicted and,
-        because the stored target array is available, per-phase error statistics
-        are computed and written. When ``stages`` is given those arbitrary stages
-        are predicted without comparison.
+        Every phase in the manifest is predicted, or the arbitrary ``stages``
+        given instead.
 
         Args:
             subject_manifest: Path to the subject manifest JSON.
@@ -257,7 +194,7 @@ class WorkflowInferPhysicsNeMo(PhysioTwin4DBase):
 
         Returns:
             Dict with ``subject_id``, ``predicted_meshes`` (paths) and, in the
-            phase mode, ``statistics`` and ``statistics_file``.
+            ``predicted_meshes`` (paths).
         """
         manifest = pnt.parse_manifest(subject_manifest)
         pca_coeffs = pnt.load_pca_coefficients(manifest.pca_coefficients)
@@ -274,7 +211,6 @@ class WorkflowInferPhysicsNeMo(PhysioTwin4DBase):
         suffix = ".vtp" if isinstance(self._template_mesh, pv.PolyData) else ".vtu"
         sid = manifest.subject_id
         meshes: list[Path] = []
-        stats: list[dict] = []
 
         requested = stages if stages is not None else [p.stage for p in manifest.phases]
         for index, stage in enumerate(requested):
@@ -283,51 +219,6 @@ class WorkflowInferPhysicsNeMo(PhysioTwin4DBase):
             self.predicted_mesh(predicted).save(str(path))
             meshes.append(path)
 
-            if stages is not None:
-                self.log_info("stage %.3f -> %s", stage, path.name)
-                continue
+            self.log_info("stage %.3f -> %s", stage, path.name)
 
-            actual = pnt.load_target_array(
-                manifest.phases[index].mesh, manifest.target_array
-            )
-            if actual.shape != predicted.shape:
-                raise ValueError(
-                    f"Stored '{manifest.target_array}' targets in "
-                    f"{manifest.phases[index].mesh} have shape {actual.shape}, "
-                    f"but the model predicts {predicted.shape}."
-                )
-            stats.append(self._error_row(sid, stage, predicted, actual))
-            self.log_info(
-                "stage %.3f: mean abs error=%.4f  max abs error=%.4f",
-                stage,
-                stats[-1]["mean_abs_error"],
-                stats[-1]["max_abs_error"],
-            )
-
-        result: dict[str, Any] = {"subject_id": sid, "predicted_meshes": meshes}
-        if stages is None:
-            stats_file = out_dir / "statistics_per_phase.csv"
-            with stats_file.open("w", newline="", encoding="utf-8") as fh:
-                writer = csv.DictWriter(fh, fieldnames=list(stats[0].keys()))
-                writer.writeheader()
-                writer.writerows(stats)
-            result["statistics"] = stats
-            result["statistics_file"] = stats_file
-        return result
-
-    @staticmethod
-    def _error_row(
-        subject_id: str, stage: float, pred: np.ndarray, actual: np.ndarray
-    ) -> dict:
-        """Per-phase error statistics between predicted and stored targets."""
-        errors = np.abs(pred - actual)
-        return {
-            "subject_id": subject_id,
-            "stage": stage,
-            "n_points": int(pred.shape[0]),
-            "n_target": int(pred.shape[1]),
-            "mean_abs_error": float(errors.mean()),
-            "median_abs_error": float(np.median(errors)),
-            "max_abs_error": float(errors.max()),
-            "rms_error": float(np.sqrt(np.mean((pred - actual) ** 2))),
-        }
+        return {"subject_id": sid, "predicted_meshes": meshes}

--- a/src/physiotwin4d/workflow_train_physicsnemo.py
+++ b/src/physiotwin4d/workflow_train_physicsnemo.py
@@ -156,23 +156,31 @@ class WorkflowTrainPhysicsNeMo(PhysioTwin4DBase):
     def process(self) -> dict[str, Any]:
         """Train the model and write checkpoints, metadata and logs.
 
+        Under a distributed launcher every rank calls this and they train one
+        model together; rank 0 alone writes to ``output_directory``, so on the
+        other ranks ``checkpoint`` and ``metadata`` come back unset.
+
         Returns:
             Dict with ``output_directory``, ``checkpoint``, ``metadata``,
             ``training_loss`` and ``val_rmse_log``.
         """
-        import torch
-
         model_tag = self.training_method.model_tag
         self.log_section("STARTING PHYSICSNEMO %s TRAINING WORKFLOW", model_tag.upper())
 
         epochs = self.training_method.epochs
 
-        output_dir = self._resolve_output_dir()
-        output_dir.mkdir(parents=True, exist_ok=True)
-        self.log_info("Output directory: %s", output_dir)
+        # Picks up torchrun, SLURM or OpenMPI, and reports one rank of one when
+        # the process was started without any of them.
+        context = pnt.distributed_context()
 
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        self.log_info("Device: %s", device.type)
+        output_dir = self._resolve_output_dir(context)
+        if context.is_main:
+            output_dir.mkdir(parents=True, exist_ok=True)
+        context.barrier()
+        self.log_info("Output directory: %s", output_dir)
+        self.log_info(
+            "Device: %s  rank %d/%d", context.device, context.rank, context.world_size
+        )
 
         subjects = self._load_subjects()
         resume_ckpt = self._load_resume_checkpoint()
@@ -191,21 +199,26 @@ class WorkflowTrainPhysicsNeMo(PhysioTwin4DBase):
 
         # Everything inference needs except the weights, written before the
         # first epoch so a run in progress can be evaluated from one of its
-        # intermittent checkpoints.
-        self._save_shared_assets(subjects, stats, output_dir, epochs)
+        # intermittent checkpoints.  The barrier is what stops another rank
+        # reading a half-written shared_edge_index.pt.
+        if context.is_main:
+            self._save_shared_assets(subjects, stats, output_dir, epochs)
+        context.barrier()
 
         model, losses, rmse_log = self.training_method.train(
             train_dataset,
             val_dataset,
             stats,
-            device,
+            context,
             epochs,
             output_dir,
             self._template_mesh,
             self._template_coords,
             resume_from=self.resume_from,
         )
-        self._save_model(model, subjects, stats, losses, rmse_log, output_dir)
+        if context.is_main:
+            self._save_model(model, subjects, stats, losses, rmse_log, output_dir)
+        context.barrier()
 
         self.log_section("PHYSICSNEMO %s TRAINING COMPLETE", model_tag.upper())
         return {
@@ -217,17 +230,26 @@ class WorkflowTrainPhysicsNeMo(PhysioTwin4DBase):
         }
 
     # ─────────────────────────── Internal steps ────────────────────────────
-    def _resolve_output_dir(self) -> Path:
-        """Return the output directory, using a fresh sibling when resuming."""
+    def _resolve_output_dir(self, context: pnt.DistributedContext) -> Path:
+        """Return the output directory, using a fresh sibling when resuming.
+
+        The sibling search races when several ranks run it at once, so rank 0
+        picks the directory and hands the answer to the others.
+        """
         base = self.output_directory
         if self.resume_from is None or not base.exists():
             return base
-        n = 1
-        while True:
-            candidate = base.parent / f"{base.name}_{n}"
-            if not candidate.exists():
-                return candidate
-            n += 1
+        resolved: list[Any] = [None]
+        if context.is_main:
+            n = 1
+            while (base.parent / f"{base.name}_{n}").exists():
+                n += 1
+            resolved[0] = base.parent / f"{base.name}_{n}"
+        if context.is_distributed:
+            import torch
+
+            torch.distributed.broadcast_object_list(resolved, src=0)
+        return cast(Path, resolved[0])
 
     def _load_subjects(self) -> dict[str, dict]:
         """Parse every manifest and load PCA coefficients + target-array names."""
@@ -244,10 +266,10 @@ class WorkflowTrainPhysicsNeMo(PhysioTwin4DBase):
                         f"split, seen again in the '{split}' split. Each subject "
                         "must appear in exactly one manifest."
                     )
-                ref_mesh = pv.read(str(manifest.reference_mesh))
-                if ref_mesh.n_points != n_points:
+                fitted_reference_mesh = pv.read(str(manifest.fitted_reference_mesh))
+                if fitted_reference_mesh.n_points != n_points:
                     raise ValueError(
-                        f"{manifest.reference_mesh} has {ref_mesh.n_points} "
+                        f"{manifest.fitted_reference_mesh} has {fitted_reference_mesh.n_points} "
                         f"points, expected {n_points} (template topology)."
                     )
                 subjects[manifest.subject_id] = {

--- a/tests/test_contour_tools.py
+++ b/tests/test_contour_tools.py
@@ -6,7 +6,7 @@ segmentation results to test contour extraction and manipulation.
 """
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import itk
 import numpy as np
@@ -386,6 +386,56 @@ class TestSaveCombinedSurfaces:
 
         merged = pv.read(str(output_file))
         assert set(np.unique(merged.cell_data["SegmentationLabelIds"])) == {0}
+
+
+class TestRemeshCarriesCellLabels:
+    """Remeshing rebuilds the topology, so the cell labels have to be carried."""
+
+    @staticmethod
+    def _two_label_sphere() -> pv.PolyData:
+        """A sphere whose cells carry two structure ids and their label pairs.
+
+        Split by the sign of the cell centre's x, so both labels own a large,
+        contiguous patch that uniform re-tiling cannot absorb.
+        """
+        surface = cast(
+            pv.PolyData,
+            pv.Sphere(
+                radius=10.0, theta_resolution=40, phi_resolution=40
+            ).triangulate(),
+        )
+        left = np.asarray(surface.cell_centers().points)[:, 0] < 0.0
+        surface.cell_data["SegmentationLabelIds"] = np.where(left, 141, 142).astype(
+            np.int32
+        )
+        surface.cell_data["boundary_labels"] = np.column_stack(
+            (np.where(left, 141, 142), np.zeros(surface.n_cells))
+        ).astype(np.int32)
+        return surface
+
+    def test_remeshing_carries_both_cell_arrays(
+        self, contour_tools: ContourTools
+    ) -> None:
+        """Anatomy splitting downstream reads these off the remeshed surface."""
+        original = self._two_label_sphere()
+
+        remeshed = contour_tools.remesh_and_smooth_surface(
+            original, surface_reduction_rate=0.5
+        )
+
+        assert remeshed.n_cells < original.n_cells
+        for name in ("SegmentationLabelIds", "boundary_labels"):
+            assert name in remeshed.cell_data, f"{name} did not survive remeshing"
+            carried = np.asarray(remeshed.cell_data[name])
+            assert len(carried) == remeshed.n_cells
+            # Nearest-cell transfer, so every value is one the source carried
+            # rather than an interpolation between two of them.
+            source = np.asarray(original.cell_data[name])
+            assert set(np.unique(carried).tolist()) <= set(np.unique(source).tolist())
+
+        # Both structures survive: a transfer that collapsed onto one label
+        # would still satisfy the membership check above.
+        assert set(np.unique(remeshed.cell_data["SegmentationLabelIds"])) == {141, 142}
 
 
 if __name__ == "__main__":

--- a/tests/test_evaluate_movement_cohorts.py
+++ b/tests/test_evaluate_movement_cohorts.py
@@ -1,0 +1,87 @@
+"""The cohort strategies a movement evaluation is parameterized by.
+
+Each cohort owns three things the evaluation workflow deliberately does not
+know: which structures to score, how a stage is read off a filename, and how
+that cohort's ground truth is assembled.  The first two are checked here against
+the real taxonomies and real filename shapes, which needs no image and no
+network.  Assembling ground truth reads whole gated series, so it is exercised
+by the tutorial tests instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from physiotwin4d import (
+    EvaluateMovementBase,
+    EvaluateMovementDukeHeart,
+    EvaluateMovementLung,
+)
+
+
+def test_lung_scores_the_five_lobes() -> None:
+    """The lobe ids resolve to the segmenter's own names, not restated ones."""
+    names = EvaluateMovementLung().label_names()
+
+    assert list(names) == [28, 29, 30, 31, 32]
+    assert names[28] == "lung_upper_lobe_left"
+    assert all("lobe" in name for name in names.values())
+
+
+def test_heart_renames_the_structure_the_model_represents() -> None:
+    """The taxonomy's "heart" is the muscle, not the sum of the chambers."""
+    names = EvaluateMovementDukeHeart().label_names()
+
+    assert list(names) == [1, 2, 3, 4, 5, 6]
+    assert names[6] == "heart muscle"
+    assert names[1] == "left_ventricle"
+
+
+def test_a_cohort_that_names_no_segmenter_cannot_name_its_structures() -> None:
+    """The base is a seam, not a usable cohort."""
+    with pytest.raises(NotImplementedError, match="segmenter_class"):
+        EvaluateMovementBase().label_names()
+
+
+def test_lung_reads_the_respiratory_phase_tag() -> None:
+    """``T{PP}`` of a ``.mha`` frame or a ``.vtp`` fit, as a fraction."""
+    lung = EvaluateMovementLung()
+
+    assert lung.stage_from_filename(Path("Case1Pack_T00.mha")) == 0.0
+    assert lung.stage_from_filename(Path("Case1Pack_T70.mha")) == 0.7
+    assert lung.stage_from_filename(Path("Case1Pack_T50_ssm_surface.vtp")) == 0.5
+    with pytest.raises(ValueError, match="respiratory phase"):
+        lung.stage_from_filename(Path("Case1Pack.mha"))
+
+
+def test_heart_reads_the_cardiac_gate_through_a_double_suffix() -> None:
+    """``.nii.gz`` is two suffixes, so the gate has to be read off the full name."""
+    heart = EvaluateMovementDukeHeart()
+    frame = Path("pm0002_dupr_111_4700_g020_s1.500_n0338_8_labelmap.nii.gz")
+
+    assert heart.stage_from_filename(frame) == 0.2
+    # A gate past end-systole exceeds 1.0; three digits, still divided by 100.
+    assert heart.stage_from_filename(Path("pm0002_g120_x_labelmap.nii.gz")) == 1.2
+    with pytest.raises(ValueError, match="cardiac gate"):
+        heart.stage_from_filename(Path("pm0002_labelmap.nii.gz"))
+
+
+def test_the_cohorts_carry_the_settings_their_anatomy_needs() -> None:
+    """Dice is dropped for lobes and kept for chambers; the pitches differ."""
+    lung, heart = EvaluateMovementLung(), EvaluateMovementDukeHeart()
+
+    assert lung.report_dice is False
+    assert heart.report_dice is True
+    assert (lung.evaluation_spacing_mm, heart.evaluation_spacing_mm) == (2.0, 1.0)
+
+
+def test_the_lung_refuses_to_segment_without_somewhere_to_cache_it(
+    tmp_path: Path,
+) -> None:
+    """A segmentation pass per phase is too expensive to repeat every run."""
+    with pytest.raises(ValueError, match="cache_directory"):
+        EvaluateMovementLung().assemble_ground_truth(
+            "Case1Pack", tmp_path, tmp_path, cache_directory=None
+        )

--- a/tests/test_physicsnemo_tools.py
+++ b/tests/test_physicsnemo_tools.py
@@ -7,6 +7,7 @@ run in the default fast suite.
 
 from __future__ import annotations
 
+import builtins
 import json
 from pathlib import Path
 
@@ -60,6 +61,73 @@ def _targets(n_points: int, n_target: int, offset: float) -> np.ndarray:
         n_points, n_target
     )
     return values / 100.0 + offset
+
+
+def test_parse_manifest_rejects_a_manifest_without_a_fitted_reference_mesh(
+    tmp_path: Path,
+) -> None:
+    """The fitted mesh is what the displacements are defined against.
+
+    Shape parameters alone do not reconstruct it, so a manifest that omits it
+    has to fail rather than fall back to anything.
+    """
+    n_points = _sphere().n_points
+    manifest_path = _write_subject(tmp_path, [_targets(n_points, 3, 0.0)])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del manifest["fitted_reference_mesh"]
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="fitted_reference_mesh"):
+        pnt.parse_manifest(manifest_path)
+
+
+def _without_physicsnemo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every ``physicsnemo`` import raise, as an install without the extra."""
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "physicsnemo" or name.startswith("physicsnemo."):
+            raise ImportError("No module named 'physicsnemo'")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+@pytest.mark.parametrize(
+    "variable", ["WORLD_SIZE", "SLURM_NTASKS", "OMPI_COMM_WORLD_SIZE"]
+)
+def test_multi_process_launch_without_physicsnemo_is_refused(
+    monkeypatch: pytest.MonkeyPatch, variable: str
+) -> None:
+    """Eight ranks with no rank assigner is eight processes overwriting each other.
+
+    The refusal has to happen here, before the training workflow creates its
+    output directory, because by then the damage is already on disk.
+    """
+    for name in ("WORLD_SIZE", "SLURM_NTASKS", "OMPI_COMM_WORLD_SIZE"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(variable, "8")
+    _without_physicsnemo(monkeypatch)
+
+    with pytest.raises(ImportError, match="1 of 8"):
+        pnt.distributed_context()
+
+
+def test_a_single_process_without_physicsnemo_still_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MLP path never needed the extra, so one process is not an error."""
+    for name in ("WORLD_SIZE", "SLURM_NTASKS", "OMPI_COMM_WORLD_SIZE"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("WORLD_SIZE", "1")
+    _without_physicsnemo(monkeypatch)
+
+    context = pnt.distributed_context()
+
+    assert context.world_size == 1
+    assert context.rank == 0
+    assert context.is_main
+    assert not context.is_distributed
 
 
 def test_parse_manifest_round_trips_the_new_schema(tmp_path: Path) -> None:

--- a/tests/test_physicsnemo_tools.py
+++ b/tests/test_physicsnemo_tools.py
@@ -44,7 +44,7 @@ def _write_subject(tmp_path: Path, targets: list[np.ndarray]) -> Path:
 
     manifest = {
         "subject_id": "subject_01",
-        "reference_mesh": str(tmp_path / "reference.vtp"),
+        "fitted_reference_mesh": str(tmp_path / "reference.vtp"),
         "pca_coefficients": str(tmp_path / "coefficients.json"),
         "target_array": _TARGET_ARRAY,
         "phases": phases,
@@ -72,7 +72,7 @@ def test_parse_manifest_round_trips_the_new_schema(tmp_path: Path) -> None:
 
     assert manifest.subject_id == "subject_01"
     assert manifest.target_array == _TARGET_ARRAY
-    assert manifest.reference_mesh.name == "reference.vtp"
+    assert manifest.fitted_reference_mesh.name == "reference.vtp"
     assert [phase.stage for phase in manifest.phases] == list(_STAGES)
     assert [phase.mesh.name for phase in manifest.phases] == [
         "phase_0.vtp",

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -682,7 +682,7 @@ class TestTutorial08DukeHeartFitModelTo4DPatients:
         )
         assert results["cases"], "At least one case should be fitted"
         for case_id, case in results["cases"].items():
-            assert case["ssm_surface_file"].exists(), (
+            assert case["fitted_reference_mesh_file"].exists(), (
                 f"{case_id}: fitted SSM surface should exist"
             )
 
@@ -716,7 +716,7 @@ class TestTutorial08LungFitModelTo4DPatients:
         results = _run_tutorial_script("tutorial_08_lung_fit_model_to_4d_patients.py")
         assert results["cases"], "At least one case should be fitted"
         for case_id, case in results["cases"].items():
-            assert case["ssm_surface_file"].exists(), (
+            assert case["fitted_reference_mesh_file"].exists(), (
                 f"{case_id}: fitted SSM surface should exist"
             )
 
@@ -848,7 +848,8 @@ class TestTutorial10LungInferPhysicsNeMoMGN:
             )
 
         results = _run_tutorial_script("tutorial_10_lung_infer_physicsnemo_mgn.py")
-        assert Path(results["predicted_surface"]).exists(), (
+        assert results["predicted_surfaces"], "At least one predicted surface expected"
+        assert Path(results["predicted_surfaces"][0]).exists(), (
             "Predicted surface should exist"
         )
         assert Path(results["usd_file"]).exists(), "USD file should exist"
@@ -928,6 +929,9 @@ class TestTutorial11DukeHeartEvaluatePhysicsNeMo:
         assert results["rows"], "At least one structure should be scored"
         assert results["csv_file"].exists(), "Metrics CSV should exist"
         assert results["report_file"].exists(), "Markdown report should exist"
+        assert results["displacement_statistics"], (
+            "Per-point displacement error should be reported"
+        )
 
         out_dir = _TUTORIAL_OUTPUT / "tutorial_11_duke_heart" / "pm0027"
         _compare_screenshots(
@@ -962,6 +966,9 @@ class TestTutorial11LungEvaluatePhysicsNeMo:
         assert results["rows"], "At least one structure should be scored"
         assert results["csv_file"].exists(), "Metrics CSV should exist"
         assert results["report_file"].exists(), "Markdown report should exist"
+        assert results["displacement_statistics"], (
+            "Per-point displacement error should be reported"
+        )
 
         # ParametersLungCTDirLab.mgn_hold_out_case names the output subdirectory.
         out_dir = _TUTORIAL_OUTPUT / "tutorial_11_lung" / "Case1Pack"
@@ -1109,6 +1116,169 @@ class TestTutorial13HeartAndLungMotion:
         assert Path(results["usd_file"]).exists(), "Combined 4D USD should exist"
 
         out_dir = _TUTORIAL_OUTPUT / "tutorial_13_heart_and_lung"
+        _compare_screenshots(
+            results["screenshots"],
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+        )
+
+
+# -----------------------------------------------------------------------------
+# Tutorial 14 - Sweep the shape parameters and score every combination
+#
+# In test mode the tutorials vary one mode over three offsets, so the sweep is
+# three evaluations rather than the twenty-five of the default grid.
+# -----------------------------------------------------------------------------
+
+_TUTORIAL_14_TEST_MODE_COMBINATIONS = 3
+
+
+@pytest.mark.tutorial
+@pytest.mark.slow
+@pytest.mark.requires_physicsnemo
+class TestTutorial14DukeHeartShapeParameterSweep:
+    """End-to-end test for tutorial_14_duke_heart_shape_parameter_sweep.py."""
+
+    _class_name = "tutorial_14_duke_heart_shape_parameter_sweep"
+
+    def test_run(self, test_directories: dict[str, Path]) -> None:
+        _require_physicsnemo_and_tutorial_08_duke()
+        # The acquired labelmaps every metric is measured against.
+        _require_files(
+            test_directories["data"] / "Duke-Heart-4DLabelmaps",
+            "pm*",
+            "Duke-Heart-4DLabelmaps is not yet public; see its data/ README.",
+        )
+        _require_files(
+            _TUTORIAL_WEIGHTS / "physicsnemo_mgn_duke_heart_motion",
+            "mgn_stage_model.pt",
+            "Run tutorial_09_duke_heart_train_physicsnemo_mgn.py first.",
+        )
+
+        results = _run_tutorial_script(
+            "tutorial_14_duke_heart_shape_parameter_sweep.py"
+        )
+        assert results["rows"], "At least one structure should be scored"
+        assert results["metrics_csv_file"].exists(), "Sweep metrics CSV should exist"
+        assert results["summary_csv_file"].exists(), "Sweep summary CSV should exist"
+        combinations = {row["combination"] for row in results["rows"]}
+        assert len(combinations) == _TUTORIAL_14_TEST_MODE_COMBINATIONS, (
+            "Every combination of the test-mode grid should reach the CSV"
+        )
+
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_14_duke_heart" / "pm0027"
+        _compare_screenshots(
+            results["screenshots"],
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+        )
+
+
+@pytest.mark.tutorial
+@pytest.mark.slow
+@pytest.mark.requires_physicsnemo
+class TestTutorial14LungShapeParameterSweep:
+    """End-to-end test for tutorial_14_lung_shape_parameter_sweep.py."""
+
+    _class_name = "tutorial_14_lung_shape_parameter_sweep"
+
+    def test_run(self, test_directories: dict[str, Path]) -> None:
+        _require_physicsnemo_and_tutorial_08()
+        # The acquired phases this variant segments to get its ground truth.
+        _require_files(
+            test_directories["data"] / "DirLab-4DCT",
+            "Case1Pack_T??.mha",
+            "DirLab-4DCT is acquired manually; see data/README.md.",
+        )
+        _require_files(
+            _TUTORIAL_WEIGHTS / "physicsnemo_mgn_lung_motion",
+            "mgn_stage_model.pt",
+            "Run tutorial_09_lung_train_physicsnemo_mgn.py first.",
+        )
+
+        results = _run_tutorial_script("tutorial_14_lung_shape_parameter_sweep.py")
+        assert results["rows"], "At least one structure should be scored"
+        assert results["metrics_csv_file"].exists(), "Sweep metrics CSV should exist"
+        assert results["summary_csv_file"].exists(), "Sweep summary CSV should exist"
+        combinations = {row["combination"] for row in results["rows"]}
+        assert len(combinations) == _TUTORIAL_14_TEST_MODE_COMBINATIONS, (
+            "Every combination of the test-mode grid should reach the CSV"
+        )
+
+        # ParametersLungCTDirLab.mgn_hold_out_case names the output subdirectory.
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_14_lung" / "Case1Pack"
+        _compare_screenshots(
+            results["screenshots"],
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+        )
+
+
+# Both Tutorial 15 variants clamp themselves to this many folds under
+# TestTools.running_as_test, which the autouse fixture above turns on.
+_TUTORIAL_15_TEST_MODE_FOLDS = 2
+
+
+@pytest.mark.tutorial
+@pytest.mark.slow
+@pytest.mark.requires_physicsnemo
+class TestTutorial15LungLeaveOneOut:
+    """End-to-end test for tutorial_15_lung_leave_one_out.py."""
+
+    _class_name = "tutorial_15_lung_leave_one_out"
+
+    def test_run(self, test_directories: dict[str, Path]) -> None:
+        _require_physicsnemo()
+        # Nothing from Tutorials 6, 8 or 9 is needed: every fold builds its own
+        # shape model, fits and network. The cohort itself is the only input.
+        _require_files(
+            test_directories["data"] / "DirLab-4DCT",
+            "Case*_T70.mha",
+            "DirLab-4DCT is acquired manually; see data/README.md.",
+        )
+
+        results = _run_tutorial_script("tutorial_15_lung_leave_one_out.py")
+        assert results["rows"], "At least one structure should be scored"
+        assert results["metrics_file"].exists(), "Pooled metrics CSV should exist"
+        assert results["report_file"].exists(), "Cross-fold report should exist"
+        assert len(results["held_out_cases"]) == _TUTORIAL_15_TEST_MODE_FOLDS
+        scored = {row["held_out_case"] for row in results["rows"]}
+        assert scored == set(results["held_out_cases"]), (
+            "Every fold's held-out case should reach the pooled metrics"
+        )
+
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_15_lung"
+        _compare_screenshots(
+            results["screenshots"],
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+        )
+
+
+@pytest.mark.tutorial
+@pytest.mark.slow
+@pytest.mark.requires_physicsnemo
+class TestTutorial15DukeHeartLeaveOneOut:
+    """End-to-end test for tutorial_15_duke_heart_leave_one_out.py."""
+
+    _class_name = "tutorial_15_duke_heart_leave_one_out"
+
+    def test_run(self, test_directories: dict[str, Path]) -> None:
+        _require_physicsnemo()
+        _require_files(
+            test_directories["data"] / "Duke-Heart-4DLabelmaps",
+            "pm*/*_ref_labelmap.nii.gz",
+            "Duke-Heart-4DLabelmaps is not public yet; "
+            "see data/Duke-Heart-4DLabelmaps/README.md.",
+        )
+
+        results = _run_tutorial_script("tutorial_15_duke_heart_leave_one_out.py")
+        assert results["rows"], "At least one structure should be scored"
+        assert results["metrics_file"].exists(), "Pooled metrics CSV should exist"
+        assert results["report_file"].exists(), "Cross-fold report should exist"
+        assert len(results["held_out_cases"]) == _TUTORIAL_15_TEST_MODE_FOLDS
+        scored = {row["held_out_case"] for row in results["rows"]}
+        assert scored == set(results["held_out_cases"]), (
+            "Every fold's held-out case should reach the pooled metrics"
+        )
+
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_15_duke_heart"
         _compare_screenshots(
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),

--- a/tests/test_usd_merge.py
+++ b/tests/test_usd_merge.py
@@ -73,7 +73,8 @@ class TestUSDMerge:
     """Test suite for USD file merging."""
 
     @pytest.fixture(scope="class")
-    def test_data_files(self) -> dict[str, str]:
+    @staticmethod
+    def test_data_files() -> dict[str, str]:
         """Locate test USD files with materials and time-varying data."""
         dynamic_file = Path(
             "experiments/Heart-GatedCT_To_USD/results/Slicer_CardiacGatedCT.dynamic_anatomy_painted.usd"
@@ -88,13 +89,15 @@ class TestUSDMerge:
         return {"dynamic": str(dynamic_file), "static": str(static_file)}
 
     @pytest.fixture(scope="class")
-    def output_dir(self, tmp_path_factory: pytest.TempPathFactory) -> Path:
+    @staticmethod
+    def output_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
         """Create temporary output directory for test results."""
         output_dir = tmp_path_factory.mktemp("usd_merge_tests")
         return output_dir
 
     @pytest.fixture(scope="class")
-    def input_stats(self, test_data_files: dict[str, str]) -> dict[str, dict[str, Any]]:
+    @staticmethod
+    def input_stats(test_data_files: dict[str, str]) -> dict[str, dict[str, Any]]:
         """Analyze input USD files."""
         dynamic_stats = analyze_usd_file(test_data_files["dynamic"])
         static_stats = analyze_usd_file(test_data_files["static"])

--- a/tests/test_usd_time_preservation.py
+++ b/tests/test_usd_time_preservation.py
@@ -88,7 +88,8 @@ class TestUSDTimePreservation:
     """Test suite for USD time-varying data preservation."""
 
     @pytest.fixture(scope="class")
-    def test_data_files(self) -> dict[str, str]:
+    @staticmethod
+    def test_data_files() -> dict[str, str]:
         """Locate test USD files with time-varying data."""
         dynamic_file = Path(
             "experiments/Heart-GatedCT_To_USD/results/Slicer_CardiacGatedCT.dynamic_anatomy_painted.usd"
@@ -103,19 +104,22 @@ class TestUSDTimePreservation:
         return {"dynamic": str(dynamic_file), "static": str(static_file)}
 
     @pytest.fixture(scope="class")
-    def output_dir(self, tmp_path_factory: pytest.TempPathFactory) -> Path:
+    @staticmethod
+    def output_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
         """Create temporary output directory for test results."""
         output_dir = tmp_path_factory.mktemp("usd_time_tests")
         return output_dir
 
     @pytest.fixture(scope="class")
-    def source_metadata(self, test_data_files: dict[str, str]) -> dict[str, Any]:
+    @staticmethod
+    def source_metadata(test_data_files: dict[str, str]) -> dict[str, Any]:
         """Get time metadata from source file."""
         return get_time_metadata(test_data_files["dynamic"])
 
     @pytest.fixture(scope="class")
+    @staticmethod
     def source_time_samples(
-        self, test_data_files: dict[str, str]
+        test_data_files: dict[str, str],
     ) -> Optional[dict[str, Any]]:
         """Get time sample data from source file."""
         return get_mesh_time_samples(test_data_files["dynamic"])

--- a/tests/test_workflow_create_mean_surface.py
+++ b/tests/test_workflow_create_mean_surface.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Any, Optional
+
+import itk
 import numpy as np
 import pytest
 import pyvista as pv
 
 from physiotwin4d import WorkflowCreateMeanSurface
+from physiotwin4d import workflow_create_mean_surface as wcms
 
 # Spheres of differing radii AND differing point counts: the population this
 # workflow exists for. Radii mean is 12.0 mm.
@@ -108,3 +112,45 @@ def test_converged_run_stops_early() -> None:
 
     assert result["number_of_iterations_run"] == 1
     assert len(result["iteration_rms_mm"]) == 1
+
+
+def test_distance_squared_max_defaults_to_the_mask_radius() -> None:
+    """An unset saturation radius is sized to the mask, as the fit workflow does."""
+    workflow = _make_workflow(_sphere(*_SPHERES[1]), iterations=1)
+    workflow.set_mask_dilation_mm(10.0)
+    assert workflow._distance_squared_max() == (1.25 * 10.0) ** 2
+
+    workflow.set_distance_squared_max(50.0)
+    assert workflow._distance_squared_max() == 50.0
+
+
+def test_correspondence_tuning_reaches_the_registrar(monkeypatch: Any) -> None:
+    """Stock distance maps and stock ICON weights under-fit, so both are tunable."""
+    seen: list[_Registrar] = []
+
+    class _Registrar:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+            self.weights_path: Optional[str] = None
+            seen.append(self)
+
+        def set_icon_weights_path(self, weights_path: str) -> None:
+            self.weights_path = weights_path
+
+        def register(self, transform_type: str) -> dict[str, Any]:
+            identity = itk.AffineTransform[itk.D, 3].New()
+            identity.SetIdentity()
+            return {"forward_transform": identity}
+
+    monkeypatch.setattr(wcms, "RegisterModelsDistanceMaps", _Registrar)
+
+    workflow = _make_workflow(_sphere(*_SPHERES[1]), iterations=1)
+    workflow.set_mask_dilation_mm(10.0)
+    workflow.set_icon_weights_path("finetuned.trch")
+    workflow.process()
+
+    assert len(seen) == len(_SPHERES)
+    for registrar in seen:
+        assert registrar.kwargs["mask_dilation_mm"] == 10.0
+        assert registrar.kwargs["distance_squared_max"] == (1.25 * 10.0) ** 2
+        assert registrar.weights_path == "finetuned.trch"

--- a/tests/test_workflow_create_statistical_model.py
+++ b/tests/test_workflow_create_statistical_model.py
@@ -66,9 +66,11 @@ class _IdentityRegistrar:
         }
 
 
-def _run(monkeypatch: Any, **kwargs: Any) -> WorkflowCreateStatisticalModel:
+def _run(
+    monkeypatch: Any, registrar: type = _IdentityRegistrar, **kwargs: Any
+) -> WorkflowCreateStatisticalModel:
     """Run the workflow over three bumpy spheres with registration stubbed out."""
-    monkeypatch.setattr(wcsm, "RegisterModelsDistanceMaps", _IdentityRegistrar)
+    monkeypatch.setattr(wcsm, "RegisterModelsDistanceMaps", registrar)
     _IdentityRegistrar.reference_images = []
     samples = [_bumpy_sphere(a) for a in (-0.15, 0.0, 0.15)]
     workflow = WorkflowCreateStatisticalModel(
@@ -165,12 +167,45 @@ def test_reference_image_covers_every_aligned_sample(monkeypatch: Any) -> None:
 
 
 def test_aligned_models_stay_the_measured_inputs(monkeypatch: Any) -> None:
-    """Step 4 measures against these, so the deformable stage must not eat them."""
-    workflow = _run(monkeypatch, project_to_measured_surfaces=False)
+    """Step 4 measures against these, so the deformable stage must not eat them.
+
+    The registrar here has to *move* its input: one that hands the same object
+    back would satisfy this test whether the workflow kept the ICP-aligned
+    model or replaced it with the registration output.
+    """
+    offset = np.array([3.0, -2.0, 1.0])
+    handed_in: list[pv.PolyData] = []
+    handed_back: list[pv.PolyData] = []
+
+    class _DisplacingRegistrar(_IdentityRegistrar):
+        def register(self, transform_type: str) -> dict[str, Any]:
+            result = super().register(transform_type)
+            moved = self.moving_model.copy(deep=True)
+            moved.points = np.asarray(moved.points) + offset
+            result["registered_model"] = moved
+            handed_in.append(self.moving_model)
+            handed_back.append(moved)
+            return result
+
+    workflow = _run(
+        monkeypatch,
+        registrar=_DisplacingRegistrar,
+        project_to_measured_surfaces=False,
+    )
 
     assert len(workflow.aligned_models) == 3
-    for aligned, sample in zip(workflow.aligned_models, workflow.sample_models):
+    assert len(handed_back) == 3
+    for aligned, sample, given, returned in zip(
+        workflow.aligned_models, workflow.sample_models, handed_in, handed_back
+    ):
         assert aligned.n_points == sample.n_points
+        # The ICP-aligned model is what the registrar was handed...
+        np.testing.assert_allclose(aligned.points, given.points)
+        # ...and it is not what the registrar handed back.
+        np.testing.assert_allclose(
+            np.asarray(returned.points) - np.asarray(aligned.points),
+            np.broadcast_to(offset, (aligned.n_points, 3)),
+        )
 
 
 def test_icp_transform_type_defaults_to_affine_and_validates() -> None:
@@ -186,6 +221,32 @@ def test_icp_transform_type_defaults_to_affine_and_validates() -> None:
 
     with pytest.raises(ValueError, match="Invalid ICP transform"):
         workflow.set_icp_transform_type("Deformable")
+
+
+def test_the_constructor_validates_what_the_setters_validate() -> None:
+    """A constructor that skips the setters accepts what the setter refuses."""
+    with pytest.raises(ValueError, match="Invalid ICP transform"):
+        WorkflowCreateStatisticalModel(
+            sample_meshes=[pv.Sphere()],
+            reference_mesh=pv.Sphere(),
+            icp_transform_type="Deformable",
+        )
+
+    with pytest.raises(ValueError, match="distance_squared_max must be positive"):
+        WorkflowCreateStatisticalModel(
+            sample_meshes=[pv.Sphere()],
+            reference_mesh=pv.Sphere(),
+            distance_squared_max=0.0,
+        )
+
+    # None still means "derive it from the dilation", not "reject it".
+    derived = WorkflowCreateStatisticalModel(
+        sample_meshes=[pv.Sphere()],
+        reference_mesh=pv.Sphere(),
+        mask_dilation_mm=20.0,
+        distance_squared_max=None,
+    )
+    assert derived.distance_squared_max == pytest.approx((1.25 * 20.0) ** 2)
 
 
 def test_icp_transform_type_reaches_the_registrar(monkeypatch: Any) -> None:

--- a/tests/test_workflow_create_statistical_model.py
+++ b/tests/test_workflow_create_statistical_model.py
@@ -1,0 +1,207 @@
+"""Synthetic tests for the statistical-model workflow's PCA inputs.
+
+The deformable registration is replaced by an identity transform, which is the
+worst case of the under-fit these tests are about: the correspondence lands the
+template exactly on itself and records none of the subject's shape.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, cast
+
+import itk
+import numpy as np
+import pytest
+import pyvista as pv
+
+from physiotwin4d import workflow_create_statistical_model as wcsm
+from physiotwin4d.workflow_create_statistical_model import (
+    WorkflowCreateStatisticalModel,
+)
+
+
+def _bumpy_sphere(amplitude: float) -> pv.PolyData:
+    """Return a sphere whose radius varies quadratically along Z.
+
+    The modulation is quadratic so that it survives the workflow's affine ICP:
+    a linear one would be a shear, which the alignment removes, leaving nothing
+    for the PCA to find.
+    """
+    sphere = pv.Sphere(radius=10.0, theta_resolution=20, phi_resolution=20)
+    points = np.asarray(sphere.points, dtype=np.float64)
+    scale = 1.0 + amplitude * (points[:, 2] / 10.0) ** 2
+    sphere.points = points * scale[:, np.newaxis]
+    return sphere
+
+
+class _IdentityRegistrar:
+    """Stand-in for RegisterModelsDistanceMaps that never deforms anything."""
+
+    reference_images: list[itk.Image] = []
+
+    def __init__(
+        self,
+        moving_model: pv.PolyData,
+        fixed_model: pv.PolyData,
+        reference_image: itk.Image,
+        distance_squared_max: float = 50.0,
+        mask_dilation_mm: float = 20.0,
+    ) -> None:
+        self.moving_model = moving_model
+        self.distance_squared_max = distance_squared_max
+        self.mask_dilation_mm = mask_dilation_mm
+        _IdentityRegistrar.reference_images.append(reference_image)
+
+    def set_icon_weights_path(self, weights_path: str) -> None:
+        self.weights_path = weights_path
+
+    def register(self, transform_type: str) -> dict[str, Any]:
+        identity = itk.AffineTransform[itk.D, 3].New()
+        identity.SetIdentity()
+        return {
+            "forward_transform": identity,
+            "inverse_transform": identity,
+            "registered_model": self.moving_model,
+        }
+
+
+def _run(monkeypatch: Any, **kwargs: Any) -> WorkflowCreateStatisticalModel:
+    """Run the workflow over three bumpy spheres with registration stubbed out."""
+    monkeypatch.setattr(wcsm, "RegisterModelsDistanceMaps", _IdentityRegistrar)
+    _IdentityRegistrar.reference_images = []
+    samples = [_bumpy_sphere(a) for a in (-0.15, 0.0, 0.15)]
+    workflow = WorkflowCreateStatisticalModel(
+        sample_meshes=list(samples),
+        reference_mesh=_bumpy_sphere(0.0),
+        number_of_pca_components=2,
+        **kwargs,
+    )
+    workflow.process()
+    return workflow
+
+
+def test_distance_squared_max_defaults_to_the_mask_radius() -> None:
+    """An unset saturation radius is sized to the mask, as the fit workflow does."""
+    workflow = WorkflowCreateStatisticalModel(
+        sample_meshes=[pv.Sphere()],
+        reference_mesh=pv.Sphere(),
+        mask_dilation_mm=10.0,
+    )
+    assert workflow.distance_squared_max == (1.25 * 10.0) ** 2
+
+    explicit = WorkflowCreateStatisticalModel(
+        sample_meshes=[pv.Sphere()],
+        reference_mesh=pv.Sphere(),
+        mask_dilation_mm=10.0,
+        distance_squared_max=50.0,
+    )
+    assert explicit.distance_squared_max == 50.0
+
+
+def test_projection_is_on_by_default() -> None:
+    """The measured surfaces, not the registration's output, define the modes."""
+    default = (
+        inspect.signature(WorkflowCreateStatisticalModel.__init__)
+        .parameters["project_to_measured_surfaces"]
+        .default
+    )
+    assert default is True
+
+
+def test_residual_to_the_measured_surface_is_reported(monkeypatch: Any) -> None:
+    """A registration that does not deform must be reported as a full residual."""
+    workflow = _run(monkeypatch, project_to_measured_surfaces=False)
+
+    assert len(workflow.pca_input_residual_rms) == 3
+    # The outer samples differ from the template, so the identity correspondence
+    # leaves a residual; the middle one is the template itself.
+    assert (
+        min(workflow.pca_input_residual_rms[0], workflow.pca_input_residual_rms[2])
+        > 0.01
+    )
+    assert workflow.pca_input_residual_rms[1] < 1.0e-6
+
+
+def test_projection_recovers_the_population_variance(monkeypatch: Any) -> None:
+    """Without projection an under-fitting registration collapses the modes."""
+    unprojected = _run(monkeypatch, project_to_measured_surfaces=False)
+    projected = _run(monkeypatch, project_to_measured_surfaces=True)
+
+    assert unprojected.pca_fitted is not None and projected.pca_fitted is not None
+    # Every corresponded shape is the template, so there is nothing to explain.
+    assert unprojected.pca_fitted.explained_variance_.sum() < 1.0e-6
+    assert projected.pca_fitted.explained_variance_.sum() > 1.0
+
+    # The residual reports what the registration achieved, so projecting must
+    # not flatter it.
+    np.testing.assert_allclose(
+        projected.pca_input_residual_rms, unprojected.pca_input_residual_rms
+    )
+
+
+def test_projection_threshold_leaves_distant_points_alone(monkeypatch: Any) -> None:
+    """Points further than the threshold keep their registered position."""
+    projected = _run(monkeypatch, projection_max_distance_mm=0.0)
+
+    assert projected.pca_fitted is not None
+    assert projected.pca_fitted.explained_variance_.sum() < 1.0e-6
+
+
+def test_reference_image_covers_every_aligned_sample(monkeypatch: Any) -> None:
+    """A sample clipped by the grid would register as if it were smaller."""
+    workflow = _run(monkeypatch, project_to_measured_surfaces=False)
+
+    image = _IdentityRegistrar.reference_images[0]
+    origin = np.asarray(image.GetOrigin())
+    spacing = np.asarray(image.GetSpacing())
+    size = np.asarray(image.GetLargestPossibleRegion().GetSize())
+    upper = origin + (size - 1) * spacing
+
+    for aligned in workflow.aligned_models:
+        points = np.asarray(aligned.points)
+        assert np.all(points.min(axis=0) >= origin)
+        assert np.all(points.max(axis=0) <= upper)
+
+
+def test_aligned_models_stay_the_measured_inputs(monkeypatch: Any) -> None:
+    """Step 4 measures against these, so the deformable stage must not eat them."""
+    workflow = _run(monkeypatch, project_to_measured_surfaces=False)
+
+    assert len(workflow.aligned_models) == 3
+    for aligned, sample in zip(workflow.aligned_models, workflow.sample_models):
+        assert aligned.n_points == sample.n_points
+
+
+def test_icp_transform_type_defaults_to_affine_and_validates() -> None:
+    """Affine strips size and gross proportion; the fit side must match it."""
+    workflow = WorkflowCreateStatisticalModel(
+        sample_meshes=[pv.Sphere()],
+        reference_mesh=pv.Sphere(),
+    )
+    assert workflow.icp_transform_type == "Affine"
+
+    workflow.set_icp_transform_type("Rigid")
+    assert workflow.icp_transform_type == "Rigid"
+
+    with pytest.raises(ValueError, match="Invalid ICP transform"):
+        workflow.set_icp_transform_type("Deformable")
+
+
+def test_icp_transform_type_reaches_the_registrar(monkeypatch: Any) -> None:
+    """The alignment the caller asked for is the one every sample gets."""
+    seen: list[str] = []
+    real = wcsm.RegisterModelsICP
+
+    class _Recorder:
+        def __init__(self, **kwargs: Any) -> None:
+            self._inner = real(**kwargs)
+
+        def register(self, **kwargs: Any) -> dict[str, Any]:
+            seen.append(kwargs["transform_type"])
+            return cast(dict[str, Any], self._inner.register(**kwargs))
+
+    monkeypatch.setattr(wcsm, "RegisterModelsICP", _Recorder)
+    _run(monkeypatch, icp_transform_type="Rigid", project_to_measured_surfaces=False)
+
+    assert seen == ["Rigid", "Rigid", "Rigid"]

--- a/tests/test_workflow_evaluate_movement.py
+++ b/tests/test_workflow_evaluate_movement.py
@@ -508,3 +508,31 @@ def test_every_stage_and_structure_reaches_the_report(tmp_path: Path) -> None:
     # Pooled over both stages, so neither can exceed the worst single point.
     assert result["displacement_95th_mm"] <= result["displacement_max_mm"]
     assert result["displacement_rms_mm"] <= result["displacement_max_mm"]
+
+    # The same case with none of the displacement options asked for. The true
+    # surfaces are still on hand, so nothing stops the error being measured ---
+    # but the pooled figures are only reported when the error was asked for, so
+    # measuring it here would put per-stage rows in the report beside a pooled
+    # RMS of nan.
+    plain = workflow.process(
+        case_id="synthetic_case",
+        shape_parameters=shape_parameters,
+        fitted_reference_mesh=fitted_reference_mesh_file,
+        ground_truth=MovementGroundTruth(
+            labelmaps=ground_truth,
+            reference_labelmap=reference_labelmap,
+            reference_stage=0.0,
+            meshes=ground_truth_meshes,
+        ),
+        output_directory=tmp_path / "evaluation_plain",
+        smoothing_sigma_mm=2.0,
+        evaluation_spacing_mm=_SPACING_MM,
+    )
+    assert plain["displacement_statistics"] == []
+    assert np.isnan(plain["displacement_rms_mm"])
+    assert plain["displacement_data_file"] is None
+    assert "Displacement error" not in Path(plain["report_file"]).read_text(
+        encoding="utf-8"
+    )
+    # The labelmap metrics do not depend on any of it.
+    assert len(plain["rows"]) == 2

--- a/tests/test_workflow_evaluate_movement.py
+++ b/tests/test_workflow_evaluate_movement.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import csv
 import json
+import logging
 from pathlib import Path
 
 import itk
@@ -17,7 +18,8 @@ import numpy as np
 import pytest
 import pyvista as pv
 
-from physiotwin4d import WorkflowEvaluateMovement
+from physiotwin4d import MovementGroundTruth, WorkflowEvaluateMovement
+from physiotwin4d.physiotwin4d_base import PhysioTwin4DBase
 
 _SPACING_MM = 1.0
 _GRID_SIZE = 40
@@ -72,6 +74,199 @@ def test_surface_rmse_of_two_concentric_spheres_is_their_radius_gap() -> None:
     )
 
 
+def _evaluator(label_names: dict) -> WorkflowEvaluateMovement:
+    """A workflow whose geometry helpers can be exercised without a network."""
+    workflow = WorkflowEvaluateMovement.__new__(WorkflowEvaluateMovement)
+    PhysioTwin4DBase.__init__(
+        workflow, class_name="WorkflowEvaluateMovement", log_level=logging.WARNING
+    )
+    workflow.label_names = label_names
+    return workflow
+
+
+def _labelled_mesh() -> pv.PolyData:
+    """Two disjoint triangles, each tagged with a different structure id."""
+    mesh = pv.PolyData(
+        np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [10.0, 0.0, 0.0],
+                [11.0, 0.0, 0.0],
+                [10.0, 1.0, 0.0],
+            ]
+        ),
+        faces=np.array([3, 0, 1, 2, 3, 3, 4, 5]),
+    )
+    mesh.cell_data["SegmentationLabelIds"] = np.array([28, 29], dtype=np.int32)
+    return mesh
+
+
+def test_a_mesh_that_names_its_structures_is_taken_at_its_word() -> None:
+    """No inference beats the model's own per-cell ids."""
+    workflow = _evaluator({28: "upper", 29: "lower"})
+
+    indices = workflow._mesh_label_points(_labelled_mesh(), [28, 29])
+
+    assert indices is not None
+    assert indices[28].tolist() == [0, 1, 2]
+    assert indices[29].tolist() == [3, 4, 5]
+
+
+def test_a_mesh_without_the_ids_falls_back() -> None:
+    """The heart's single surface names nothing, so the caller must infer."""
+    workflow = _evaluator({1: "heart"})
+    bare = pv.Sphere(radius=5.0)
+
+    assert workflow._mesh_label_points(bare, [1]) is None
+    # Carrying ids that are not the ones being scored is the same situation.
+    assert workflow._mesh_label_points(_labelled_mesh(), [1, 2]) is None
+
+
+def test_a_point_shared_by_two_structures_is_counted_once() -> None:
+    """Two triangles meeting at a fissure must not both claim the shared points."""
+    workflow = _evaluator({28: "upper", 29: "lower"})
+    mesh = pv.PolyData(
+        np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 1.0, 0.0],
+            ]
+        ),
+        faces=np.array([3, 0, 1, 2, 3, 1, 2, 3]),
+    )
+    mesh.cell_data["SegmentationLabelIds"] = np.array([28, 29], dtype=np.int32)
+
+    indices = workflow._mesh_label_points(mesh, [28, 29])
+
+    assert indices is not None
+    # Points 1 and 2 touch both triangles; the lower id keeps them.
+    assert indices[28].tolist() == [0, 1, 2]
+    assert indices[29].tolist() == [3]
+
+
+def test_every_mesh_point_goes_to_the_structure_it_is_nearest() -> None:
+    """The fallback: the nearest-label partition the labelmap metrics use."""
+    workflow = _evaluator({1: "left", 2: "right"})
+    # Two spheres 100 mm apart, and a mesh straddling them: the points around
+    # x = -50 belong to one, those around x = +50 to the other.
+    surfaces = {
+        1: pv.Sphere(radius=5.0, center=(-50.0, 0.0, 0.0)),
+        2: pv.Sphere(radius=5.0, center=(50.0, 0.0, 0.0)),
+    }
+    mesh = pv.PolyData(
+        np.array(
+            [
+                [-50.0, 0.0, 0.0],
+                [-40.0, 1.0, 0.0],
+                [40.0, 0.0, 1.0],
+                [50.0, 0.0, 0.0],
+                [60.0, 0.0, 0.0],
+            ]
+        )
+    )
+
+    indices = workflow._nearest_label_points(mesh, surfaces)
+
+    assert indices[1].tolist() == [0, 1]
+    assert indices[2].tolist() == [2, 3, 4]
+    # A partition: every point claimed once, none left over.
+    assert sorted(np.concatenate(list(indices.values())).tolist()) == list(range(5))
+
+
+def test_a_structure_no_point_is_nearest_to_gets_no_points() -> None:
+    """It is scored on nothing, which the caller turns into nan rather than 0."""
+    workflow = _evaluator({1: "near", 2: "far"})
+    surfaces = {
+        1: pv.Sphere(radius=5.0, center=(0.0, 0.0, 0.0)),
+        2: pv.Sphere(radius=5.0, center=(500.0, 0.0, 0.0)),
+    }
+    mesh = pv.PolyData(np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]))
+
+    indices = workflow._nearest_label_points(mesh, surfaces)
+
+    assert indices[1].tolist() == [0, 1]
+    assert indices[2].size == 0
+
+
+def test_pooled_displacement_error_pools_the_points_not_the_stages() -> None:
+    """A percentile of the whole, which a percentile of percentiles is not."""
+    # Stage 0 holds the 90 smallest errors, stage 1 the 10 largest, so the 95th
+    # percentile of the pooled 100 lies inside the second stage and neither
+    # stage's own 95th percentile is anywhere near it.
+    stage_errors = [
+        np.arange(90, dtype=np.float32),
+        np.arange(90, 100, dtype=np.float32),
+    ]
+
+    pooled = WorkflowEvaluateMovement.pool_displacement_error(stage_errors)
+
+    assert pooled["p95_mm"] == pytest.approx(
+        float(np.percentile(np.arange(100, dtype=np.float32), 95.0))
+    )
+    assert pooled["max_mm"] == 99.0
+    assert pooled["rms_mm"] == pytest.approx(
+        float(np.sqrt(np.mean(np.arange(100, dtype=np.float64) ** 2)))
+    )
+
+
+def test_pooled_displacement_error_is_not_a_number_without_stages() -> None:
+    """No stage was scored point by point, so there is no error to report."""
+    pooled = WorkflowEvaluateMovement.pool_displacement_error([])
+
+    assert np.isnan(pooled["rms_mm"])
+    assert np.isnan(pooled["p95_mm"])
+    assert np.isnan(pooled["max_mm"])
+
+
+def test_displacement_rows_carry_both_displacements_and_their_error() -> None:
+    """Each row is the point's own predicted and true displacement, and the gap."""
+    reference = np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]])
+    predicted = np.array([[1.0, 0.0, 0.0], [1.0, 2.0, 6.0]])
+    true = np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 5.0]])
+    errors = np.linalg.norm(predicted - true, axis=1)
+
+    rows = WorkflowEvaluateMovement._displacement_rows(
+        "subject", 0.5, reference, predicted, true, errors
+    )
+
+    assert len(rows) == 2
+    # Point 0 was predicted to move 1 mm in x and did not move at all: the
+    # predicted displacement, the true displacement and the error all say so.
+    assert rows[0] == [
+        "subject",
+        0.5,
+        0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+    assert rows[1][-4:] == [0.0, 0.0, 2.0, 1.0]
+
+
+def test_the_fitted_reference_mesh_cannot_be_omitted() -> None:
+    """A PCA-only reconstruction must never stand in for the patient's fit."""
+    import inspect
+
+    from physiotwin4d import WorkflowInferMovement
+
+    for name in ("predict_single", "process_time_series", "create_deformation_field"):
+        parameter = inspect.signature(getattr(WorkflowInferMovement, name)).parameters[
+            "fitted_reference_mesh"
+        ]
+        assert parameter.default is inspect.Parameter.empty, name
+
+
 def _trained_model_directory(tmp_path: Path) -> Path:
     """Train a two-epoch MeshGraphNet on two synthetic subjects."""
     from physiotwin4d import TrainPhysicsNeMoMGN, WorkflowTrainPhysicsNeMo
@@ -113,7 +308,7 @@ def _trained_model_directory(tmp_path: Path) -> Path:
             json.dumps(
                 {
                     "subject_id": f"subject_{index:02d}",
-                    "reference_mesh": str(subject_dir / "reference.vtp"),
+                    "fitted_reference_mesh": str(subject_dir / "reference.vtp"),
                     "pca_coefficients": str(subject_dir / "coefficients.json"),
                     "target_array": "displacement",
                     "phases": phases,
@@ -153,13 +348,24 @@ def test_every_stage_and_structure_reaches_the_report(tmp_path: Path) -> None:
 
     case_dir = tmp_path / "case"
     case_dir.mkdir(parents=True, exist_ok=True)
-    reference_mesh_file = case_dir / "reference.vtp"
-    _sphere().save(str(reference_mesh_file))
+    fitted_reference_mesh_file = case_dir / "reference.vtp"
+    _sphere().save(str(fitted_reference_mesh_file))
     shape_parameters = case_dir / "coefficients.json"
     shape_parameters.write_text(json.dumps([0.25, -0.25]), encoding="utf-8")
 
     reference_labelmap = _ball_labelmap(_RADIUS_MM)
     ground_truth = {0.0: _ball_labelmap(_RADIUS_MM), 1.0: _ball_labelmap(9.0)}
+
+    # The true surface of each stage, sharing the reference mesh's topology:
+    # the sphere itself at stage 0, shrunk by a tenth at stage 1, matching what
+    # the two ground-truth labelmaps say.
+    ground_truth_meshes = {}
+    for stage, radius in ((0.0, _RADIUS_MM), (1.0, 9.0)):
+        stage_mesh = _sphere()
+        stage_mesh.points = np.asarray(stage_mesh.points) * (radius / _RADIUS_MM)
+        stage_file = case_dir / f"truth_{int(stage * 100):03d}.vtp"
+        stage_mesh.save(str(stage_file))
+        ground_truth_meshes[stage] = stage_file
 
     output_directory = tmp_path / "evaluation"
     workflow = WorkflowEvaluateMovement(
@@ -168,15 +374,41 @@ def test_every_stage_and_structure_reaches_the_report(tmp_path: Path) -> None:
         ),
         label_names={1: "ball"},
     )
+
+    # A stage with a labelmap but no fitted surface has nothing to measure a
+    # per-point displacement against.
+    with pytest.raises(ValueError, match="fitted surface for every stage"):
+        workflow.process(
+            case_id="synthetic_case",
+            shape_parameters=shape_parameters,
+            fitted_reference_mesh=fitted_reference_mesh_file,
+            ground_truth=MovementGroundTruth(
+                labelmaps=ground_truth,
+                reference_labelmap=reference_labelmap,
+                reference_stage=0.0,
+                meshes={0.0: ground_truth_meshes[0.0]},
+            ),
+            output_directory=output_directory,
+            include_displacement_error=True,
+        )
+
     result = workflow.process(
         case_id="synthetic_case",
         shape_parameters=shape_parameters,
-        reference_mesh=reference_mesh_file,
-        reference_labelmap=reference_labelmap,
-        ground_truth_labelmaps=ground_truth,
+        fitted_reference_mesh=fitted_reference_mesh_file,
+        ground_truth=MovementGroundTruth(
+            labelmaps=ground_truth,
+            reference_labelmap=reference_labelmap,
+            reference_stage=0.0,
+            meshes=ground_truth_meshes,
+        ),
         output_directory=output_directory,
         smoothing_sigma_mm=2.0,
         evaluation_spacing_mm=_SPACING_MM,
+        report_displacement_data=True,
+        include_predicted_displacements=True,
+        include_true_displacements=True,
+        include_displacement_error=True,
     )
 
     # Two stages, one structure.
@@ -205,8 +437,20 @@ def test_every_stage_and_structure_reaches_the_report(tmp_path: Path) -> None:
         "network_weights_created",
         "network_weights_modified",
         "network_epoch",
+        "displacement_rms_mm",
+        "displacement_95th_mm",
+        "displacement_max_mm",
     } <= set(rows[0])
     assert all(0.0 <= float(row["dice"]) <= 1.0 for row in rows)
+    # One structure owns every mesh point here, so its per-structure figures are
+    # the whole-model ones; an indexing slip would break that.
+    assert [float(row["displacement_max_mm"]) for row in rows] == [
+        pytest.approx(float(entry["max_error_mm"]))
+        for entry in result["displacement_statistics"]
+    ]
+    assert max(float(row["displacement_95th_mm"]) for row in rows) == pytest.approx(
+        max(float(entry["p95_error_mm"]) for entry in result["displacement_statistics"])
+    )
 
     report = Path(result["report_file"]).read_text(encoding="utf-8")
     assert "synthetic_case" in report
@@ -214,3 +458,53 @@ def test_every_stage_and_structure_reaches_the_report(tmp_path: Path) -> None:
     assert "ball" in report
     assert Path(result["volume_plot_file"]).name in report
     assert Path(result["volume_plot_file"]).exists()
+    # Mean alone would hide the stage a structure is predicted worst at.
+    assert "Worst case, over every structure and stage" in report
+    assert "Dice (min)" in report
+    assert "## Displacement error" in report
+    assert "Displacement 95th (mean mm)" in report
+    assert "Worst Displacement 95th percentile" in report
+
+    # The per-point CSV, the mesh arrays and the error statistics all describe
+    # the same displacements, so they have to agree.
+    n_points = _sphere().n_points
+    with Path(result["displacement_data_file"]).open(
+        newline="", encoding="utf-8"
+    ) as fh:
+        displacement_rows = list(csv.DictReader(fh))
+    assert len(displacement_rows) == 2 * n_points
+    assert {
+        "subject_id",
+        "stage",
+        "point_id",
+        "fitted_reference_x_mm",
+        "predicted_dx_mm",
+        "true_dx_mm",
+        "error_mm",
+    } <= set(displacement_rows[0])
+
+    predicted_surface = pv.read(str(result["predicted_surfaces"][0]))
+    predicted = np.asarray(predicted_surface["predicted_displacement_mm"])
+    true = np.asarray(predicted_surface["true_displacement_mm"])
+    error = np.asarray(predicted_surface["displacement_error_mm"])
+    assert predicted.shape == (n_points, 3)
+    assert true.shape == (n_points, 3)
+    assert error.shape == (n_points,)
+    assert error == pytest.approx(np.linalg.norm(predicted - true, axis=1), abs=1e-4)
+
+    # The first stage's rows describe the first stage's mesh.
+    first_stage = [row for row in displacement_rows if float(row["stage"]) == 0.0]
+    assert [float(row["error_mm"]) for row in first_stage] == pytest.approx(
+        error, abs=1e-4
+    )
+
+    statistics = result["displacement_statistics"]
+    assert len(statistics) == 2
+    assert statistics[0]["max_error_mm"] == pytest.approx(float(error.max()), abs=1e-4)
+    assert result["displacement_max_mm"] == max(
+        float(row["max_error_mm"]) for row in statistics
+    )
+    assert result["displacement_rms_mm"] > 0.0
+    # Pooled over both stages, so neither can exceed the worst single point.
+    assert result["displacement_95th_mm"] <= result["displacement_max_mm"]
+    assert result["displacement_rms_mm"] <= result["displacement_max_mm"]

--- a/tests/test_workflow_fit_statistical_model_to_patient.py
+++ b/tests/test_workflow_fit_statistical_model_to_patient.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import itk
 import numpy as np
+import pytest
 import pyvista as pv
 
 from physiotwin4d.segment_heart_simpleware import SegmentHeartSimpleware
@@ -181,3 +182,21 @@ def test_transform_model_preserves_unstructured_grid_topology() -> None:
         output.point_data["weights"], model.point_data["weights"]
     )
     np.testing.assert_allclose(output.points, points + np.array([1.0, 2.0, 3.0]))
+
+
+def test_fit_icp_transform_type_defaults_to_affine_and_validates() -> None:
+    """The fit must align the way the model was built, so this is tunable."""
+    image = itk.image_from_array(np.zeros((3, 3, 3), dtype=np.float32))
+    model = pv.PolyData(np.zeros((3, 3), dtype=np.float64))
+    workflow = WorkflowFitStatisticalModelToPatient(
+        template_model=model,
+        patient_models=[model],
+        patient_image=image,
+    )
+    assert workflow.icp_transform_type == "Affine"
+
+    workflow.set_icp_transform_type("Rigid")
+    assert workflow.icp_transform_type == "Rigid"
+
+    with pytest.raises(ValueError, match="Invalid ICP transform"):
+        workflow.set_icp_transform_type("Deformable")

--- a/tests/test_workflow_train_physicsnemo.py
+++ b/tests/test_workflow_train_physicsnemo.py
@@ -22,13 +22,46 @@ pytest.importorskip("physicsnemo")
 pytest.importorskip("torch_geometric")
 
 from physiotwin4d import (  # noqa: E402
+    DistributedContext,
     TrainPhysicsNeMoMGN,
     WorkflowInferPhysicsNeMo,
     WorkflowTrainPhysicsNeMo,
 )
+from physiotwin4d.physicsnemo_tools import uncompiled_state_dict  # noqa: E402
 
 _TARGET_ARRAY = "displacement"
 _STAGES = (0.0, 1.0)
+
+
+class _IndexDataset:
+    """Stands in for PhaseSampleDataset, one identifiable row per sample.
+
+    Each sample is a single node feature row carrying its own index, so a
+    batch's first column is the list of samples that went into it.
+    """
+
+    def __init__(self, n_samples: int) -> None:
+        self._n_samples = n_samples
+
+    def __len__(self) -> int:
+        return self._n_samples
+
+    def __getitem__(self, index: int) -> tuple[np.ndarray, np.ndarray]:
+        return (
+            np.full((1, 2), index, dtype=np.float32),
+            np.zeros((1, 3), dtype=np.float32),
+        )
+
+
+class _FakeDDP:
+    """The one attribute of DistributedDataParallel checkpointing cares about.
+
+    Constructing the real thing needs an initialized process group, which a
+    unit test has no reason to stand up just to check a prefix.
+    """
+
+    def __init__(self, module: Any) -> None:
+        self.module = module
 
 
 def _sphere() -> pv.PolyData:
@@ -60,7 +93,7 @@ def _write_subject(subject_id: str, directory: Path, offset: float) -> Path:
         json.dumps(
             {
                 "subject_id": subject_id,
-                "reference_mesh": str(directory / "reference.vtp"),
+                "fitted_reference_mesh": str(directory / "reference.vtp"),
                 "pca_coefficients": str(directory / "coefficients.json"),
                 "target_array": _TARGET_ARRAY,
                 "phases": phases,
@@ -158,3 +191,68 @@ def test_an_intermittent_checkpoint_can_be_inferred_from(tmp_path: Path) -> None
 
     assert targets.shape == (infer.template_mesh.n_points, 3)
     assert np.all(np.isfinite(targets))
+
+
+def test_ranks_split_the_samples_without_overlapping() -> None:
+    """Every sample lands on exactly one rank, and the ranks take equal steps.
+
+    A rank that yielded one batch more than its peers would hang them all at
+    the gradient all-reduce of the step they never take, so the equal-length
+    assertion below is the one that keeps a distributed run from deadlocking.
+    """
+    import torch
+
+    method = TrainPhysicsNeMoMGN()
+    method.set_batch_size(2)
+    dataset = cast(Any, _IndexDataset(11))
+    world_size = 3
+
+    per_rank = []
+    for rank in range(world_size):
+        context = DistributedContext(
+            device=torch.device("cpu"),
+            rank=rank,
+            local_rank=rank,
+            world_size=world_size,
+        )
+        batches = list(
+            method._iter_batches(
+                dataset, np.random.default_rng(0), shuffle=True, context=context
+            )
+        )
+        per_rank.append([int(value) for batch in batches for value in batch[0][:, 0]])
+
+    assert all(len(indices) == len(per_rank[0]) for indices in per_rank)
+    # 11 samples over 3 ranks at batch_size 2 is one whole batch each; the
+    # remainder is dropped rather than handed to whichever rank happens to
+    # have it.
+    assert len(per_rank[0]) == 2
+    seen = [index for indices in per_rank for index in indices]
+    assert len(seen) == len(set(seen))
+
+
+def test_one_rank_iterates_the_whole_dataset() -> None:
+    """Without a distributed context, nothing is sharded and nothing is dropped."""
+    method = TrainPhysicsNeMoMGN()
+    method.set_batch_size(2)
+    dataset = cast(Any, _IndexDataset(11))
+
+    batches = list(
+        method._iter_batches(dataset, np.random.default_rng(0), shuffle=True)
+    )
+    seen = sorted(int(value) for batch in batches for value in batch[0][:, 0])
+
+    assert seen == list(range(11))
+
+
+def test_a_ddp_wrapped_model_checkpoints_without_its_prefix() -> None:
+    """``module.`` never reaches a checkpoint, so inference loads it unchanged."""
+    import torch
+
+    inner = torch.nn.Linear(2, 2)
+    wrapped = _FakeDDP(inner)
+
+    state = uncompiled_state_dict(wrapped)
+
+    assert set(state) == set(inner.state_dict())
+    assert not any(key.startswith("module.") for key in state)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -119,12 +119,14 @@ its own anatomy's earlier tutorials, never the other's.
 6. **Tutorial 6** creates the PCA statistical model; the heart variant from KCL-Heart-Model, the lung variant from the DirLab-4DCT `Case*T70.mha` phases, which it segments itself. Both write `pca_model.json` and `pca_mean_surface.vtp` under their own output directory.
 7. **Tutorial 7** applies the statistical model, consuming its own anatomy's Tutorial 6 output; the heart variant fits the Tutorial 6 (heart) model, the lung variant fits the Tutorial 6 (lung) model to the ungated `Chest-CT` scan (`physiotwin4d-download-data Chest-CT`; see `data/Chest-CT/README.md` for the data source and required citation).
 
-The AI-surrogate pipeline (Tutorials 8 -> 9 -> 10 -> 11 -> 12 -> 14) runs on DIR-Lab
-and the Tutorial 6 lung model, in order:
+The AI-surrogate pipeline (Tutorials 8 -> 9 -> 10 -> 11 -> 12, plus 14 and 15)
+runs on DIR-Lab and the Tutorial 6 lung model, in order. Tutorials 14 and 15
+branch off the chain rather than continuing it: 14 needs only the Tutorial 8 fit
+and the Tutorial 9 checkpoint, and 15 needs neither, rebuilding both per fold:
 
 8. **Tutorial 8** fits the lung PCA model to each case's reference phase and propagates the fitted SSM surface through every respiratory phase (output feeds Tutorial 9). It uses the Tutorial 2 ICON weights when they exist.
 9. **Tutorial 9** trains a PhysicsNeMo MeshGraphNet to predict the per-vertex motion at any stage. PhysicsNeMo is an optional extra: install with `pip install "physiotwin4d[physicsnemo]"` (requires Python >= 3.11); the MeshGraphNet also needs `torch-geometric`. A `TrainPhysicsNeMoMLP` method exists as a drop-in alternative, without its own tutorial.
-10. **Tutorial 10** loads that checkpoint and predicts the held-out case's surface at every acquired stage, scoring each against its acquired phase, warping the reference-phase CT through the inferred deformation, and exporting one animated USD. The case and checkpoint epoch are constants near the top of the script; for command-line runs with path arguments, use the installed `physiotwin4d-infer-physicsnemo` CLI.
+10. **Tutorial 10** loads that checkpoint and predicts the held-out case's surface at every acquired stage, warping the reference-phase CT through the inferred deformation and exporting one animated USD. It renders the acquired frame surface beside the prediction for visual comparison but does not score it; scoring is Tutorial 11's job. The case and checkpoint epoch are constants near the top of the script; for command-line runs with path arguments, use the installed `physiotwin4d-infer-physicsnemo` CLI.
 11. **Tutorial 11** scores the same prediction against the images rather than against the registration: it segments every gated frame independently, then reports volume difference and surface RMSE per lung lobe (per heart chamber, with Dice, in the duke variant) as `evaluation_report.md` and `evaluation_metrics.csv`. The lung variant leaves Dice out: a lobe moves little compared to its own size, so the overlap fraction describes the lobe rather than the motion.
 12. **Tutorial 12** collapses the whole chain into one script: it segments the reference frame, fits the Tutorial 6 model to that patient itself, and infers every stage - so nothing is read from Tutorial 8 and no phase is ever registered. It needs only the gated series plus the Tutorial 6 model and the Tutorial 9 checkpoint, and it wipes its output directory on every run so the reported runtimes in `<case>_runtimes.csv` cover the entire pipeline.
 
@@ -162,8 +164,10 @@ data-parallel across ranks and the per-case loops are split across them.
 
 The `duke_heart` variants form their own chain on Duke-Heart-4DLabelmaps,
 which no step above shares: Tutorial 4 (duke heart) -> 5 -> 6 -> 7 -> 8 -> 9 ->
-10 -> 11 -> 12 -> 14, each reading the previous one's output, with Tutorial 2 (heart
+10 -> 11 -> 12, each reading the previous one's output, with Tutorial 2 (heart
 distancemap variant) supplying optional finetuned weights to Tutorials 7 and 8.
+Tutorials 14 and 15 (duke heart) branch off the same chain on the same dataset,
+14 from Tutorials 8 and 9, 15 from the cohort alone.
 That dataset is being released soon; until then this chain cannot be run, and
 access can be requested from Stephen Aylward (<saylward@nvidia.com>). See
 [../data/Duke-Heart-4DLabelmaps/README.md](../data/Duke-Heart-4DLabelmaps/README.md).

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -54,6 +54,10 @@ current working directory.
 | 12 | [tutorial_12_lung_end_to_end_inference.py](tutorial_12_lung_end_to_end_inference.py) | `WorkflowConvertImageToVTK`, `WorkflowFitStatisticalModelToPatient`, `WorkflowInferMovement` (requires `[physicsnemo]` extra + `torch-geometric`) | DirLab-4DCT plus Tutorial 6 and 9 (lung) output |
 | 12 | [duke heart variant](tutorial_12_duke_heart_end_to_end_inference.py) | `ContourTools`, `WorkflowFitStatisticalModelToPatient`, `WorkflowInferMovement` (requires `[physicsnemo]` extra + `torch-geometric`) | Duke-Heart-4DLabelmaps plus Tutorial 6 and 9 (duke heart) output |
 | 13 | [tutorial_13_heart_and_lung_motion.py](tutorial_13_heart_and_lung_motion.py) | `WorkflowInferMovement`, `WorkflowFitStatisticalModelToPatient`, `ConvertVTKToUSD` (requires `[physicsnemo]` extra + `torch-geometric` + Simpleware Medical) | Chest-CT plus Tutorial 7 (lung) and Tutorial 9 (lung and duke heart) output |
+| 14 | [tutorial_14_lung_shape_parameter_sweep.py](tutorial_14_lung_shape_parameter_sweep.py) | `WorkflowEvaluateMovement`, `SegmentNVSegmentCTMRI` (requires `[physicsnemo]` extra + `torch-geometric`) | DirLab-4DCT plus Tutorial 8 and 9 (lung) output |
+| 14 | [duke heart variant](tutorial_14_duke_heart_shape_parameter_sweep.py) | `WorkflowEvaluateMovement` (requires `[physicsnemo]` extra + `torch-geometric`) | Duke-Heart-4DLabelmaps plus Tutorial 8 and 9 (duke heart) output |
+| 15 | [tutorial_15_lung_leave_one_out.py](tutorial_15_lung_leave_one_out.py) | `WorkflowCreateStatisticalModel`, `WorkflowFitStatisticalModelToPatient`, `WorkflowTrainPhysicsNeMo`, `WorkflowEvaluateMovement` (requires `[physicsnemo]` extra + `torch-geometric`) | DirLab-4DCT |
+| 15 | [duke heart variant](tutorial_15_duke_heart_leave_one_out.py) | `WorkflowCreateStatisticalModel`, `WorkflowFitStatisticalModelToPatient`, `WorkflowTrainPhysicsNeMo`, `WorkflowEvaluateMovement` (requires `[physicsnemo]` extra + `torch-geometric`) | Duke-Heart-4DLabelmaps |
 
 The [tutorials page](https://project-monai.github.io/physiotwin4d/tutorials.html)
 covers the same set with previews of what each one produces and per-tutorial
@@ -115,7 +119,7 @@ its own anatomy's earlier tutorials, never the other's.
 6. **Tutorial 6** creates the PCA statistical model; the heart variant from KCL-Heart-Model, the lung variant from the DirLab-4DCT `Case*T70.mha` phases, which it segments itself. Both write `pca_model.json` and `pca_mean_surface.vtp` under their own output directory.
 7. **Tutorial 7** applies the statistical model, consuming its own anatomy's Tutorial 6 output; the heart variant fits the Tutorial 6 (heart) model, the lung variant fits the Tutorial 6 (lung) model to the ungated `Chest-CT` scan (`physiotwin4d-download-data Chest-CT`; see `data/Chest-CT/README.md` for the data source and required citation).
 
-The AI-surrogate pipeline (Tutorials 8 -> 9 -> 10 -> 11 -> 12) runs on DIR-Lab
+The AI-surrogate pipeline (Tutorials 8 -> 9 -> 10 -> 11 -> 12 -> 14) runs on DIR-Lab
 and the Tutorial 6 lung model, in order:
 
 8. **Tutorial 8** fits the lung PCA model to each case's reference phase and propagates the fitted SSM surface through every respiratory phase (output feeds Tutorial 9). It uses the Tutorial 2 ICON weights when they exist.
@@ -132,9 +136,33 @@ model it fits to the same scan. Nothing in it registers anything or needs a 4D
 acquisition. Each model is fitted through the segmenter that built it, so the
 heart step calls Simpleware Medical.
 
+**Tutorial 14** asks how much the shape parameters matter. It re-runs the
+Tutorial 11 scoring for the same hold-out case over a grid of PCA coefficient
+offsets - the first few modes, swept from -1 to +1 standard deviations in steps
+of 0.5 - feeding each perturbed vector to the Tutorial 9 network while holding
+the patient's fitted surface fixed, so the only thing that changes is the motion
+the network infers. Dice, volume difference and surface RMSE for every
+combination land in `shape_sweep_metrics.csv`, averaged per combination in
+`shape_sweep_summary.csv`. The default grid is 25 combinations, each costing one
+Tutorial 11 run; `number_of_modes_to_vary`, `perturbation_range` and
+`perturbation_step` near the top of the script set its size.
+
+**Tutorial 15** stops trusting a single hold-out. It re-runs the whole chain -
+shape model, cohort fit, MeshGraphNet training, inference and scoring - once per
+fold, holding out a different case each time, and reports Dice, volume
+difference and surface RMSE as a mean and a spread across folds rather than as
+one number. `number_of_leave_one_out_runs` near the top of the script sets the
+fold count and defaults to 5. Nothing from Tutorials 6, 8 or 9 is required: it
+builds its own model per fold, because a model built once from everyone has
+already seen every case. Segmentations and, for the lung, the phase
+registrations do not depend on which case is held out, so they are cached under
+`shared/` and reused. Written for a multi-GPU Linux host:
+under `torchrun --standalone --nproc_per_node=<gpus>` the training is
+data-parallel across ranks and the per-case loops are split across them.
+
 The `duke_heart` variants form their own chain on Duke-Heart-4DLabelmaps,
 which no step above shares: Tutorial 4 (duke heart) -> 5 -> 6 -> 7 -> 8 -> 9 ->
-10 -> 11 -> 12, each reading the previous one's output, with Tutorial 2 (heart
+10 -> 11 -> 12 -> 14, each reading the previous one's output, with Tutorial 2 (heart
 distancemap variant) supplying optional finetuned weights to Tutorials 7 and 8.
 That dataset is being released soon; until then this chain cannot be run, and
 access can be requested from Stephen Aylward (<saylward@nvidia.com>). See

--- a/tutorials/parameters_duke_heart_labelmaps.py
+++ b/tutorials/parameters_duke_heart_labelmaps.py
@@ -29,6 +29,12 @@ class ParametersDukeHeartLabelmaps:
     """Settings shared by the Duke heart tutorials.
 
     Attributes:
+        icp_transform_type: Alignment applied to a surface before the shape
+            model corresponds or fits it, one of ``"Rigid"``, ``"Similarity"``
+            or ``"Affine"``.  Model building and model fitting must use the
+            same value: whatever the ICP absorbs is variation the eigenmodes
+            never see, so a mismatch makes the fit ask the modes to explain
+            shape that has already been removed.
         mask_dilation_mm: Dilation of the binary registration masks, in
             millimeters.
         distancemap_squared_max: Saturation radius of every heart distance map,
@@ -84,6 +90,8 @@ class ParametersDukeHeartLabelmaps:
             measures generalization rather than reconstruction.  Tutorial 2
             scores its registrations on the same case.
     """
+
+    icp_transform_type: str = "Similarity"
 
     mask_dilation_mm: float = 10.0
     distancemap_squared_max: float = (1.25 * 10.0) ** 2

--- a/tutorials/parameters_heart_ct_kcl.py
+++ b/tutorials/parameters_heart_ct_kcl.py
@@ -28,6 +28,12 @@ class ParametersHeartCTKCL:
     """Settings shared by the heart tutorials.
 
     Attributes:
+        icp_transform_type: Alignment applied to a surface before the shape
+            model corresponds or fits it, one of ``"Rigid"``, ``"Similarity"``
+            or ``"Affine"``.  Model building and model fitting must use the
+            same value: whatever the ICP absorbs is variation the eigenmodes
+            never see, so a mismatch makes the fit ask the modes to explain
+            shape that has already been removed.
         mask_dilation_mm: Dilation of the binary registration masks, in
             millimeters.  Tighter than the lungs': the heart is a compact organ
             whose neighbours are not part of the model.
@@ -71,6 +77,8 @@ class ParametersHeartCTKCL:
             The Duke heart tutorials name their own in
             ``parameters_duke_heart_labelmaps.py``.
     """
+
+    icp_transform_type: str = "Affine"
 
     mask_dilation_mm: float = 10.0
     distancemap_squared_max: float = (1.25 * 10.0) ** 2

--- a/tutorials/parameters_lung_ct_dirlab.py
+++ b/tutorials/parameters_lung_ct_dirlab.py
@@ -28,6 +28,12 @@ class ParametersLungCTDirLab:
     """Settings shared by the DIR-Lab lung tutorials.
 
     Attributes:
+        icp_transform_type: Alignment applied to a surface before the shape
+            model corresponds or fits it, one of ``"Rigid"``, ``"Similarity"``
+            or ``"Affine"``.  Model building and model fitting must use the
+            same value: whatever the ICP absorbs is variation the eigenmodes
+            never see, so a mismatch makes the fit ask the modes to explain
+            shape that has already been removed.
         mask_dilation_mm: Dilation of the binary registration masks, in
             millimeters.  Also sets how far outside the lung surface the
             registration is allowed to look.
@@ -82,6 +88,8 @@ class ParametersLungCTDirLab:
     chamber ids: the lung labels are the lobes, and every one of them is on the
     surface a distance map is measured to.
     """
+
+    icp_transform_type: str = "Affine"
 
     mask_dilation_mm: float = 40.0
     distancemap_squared_max: float = (1.25 * 40.0) ** 2

--- a/tutorials/tutorial_06_duke_heart_create_statistical_model.py
+++ b/tutorials/tutorial_06_duke_heart_create_statistical_model.py
@@ -75,6 +75,21 @@ if __name__ == "__main__":
     # Points kept per surface; see the parameters module.
     model_points = DUKE_HEART.model_points
 
+    # Distance-map weights finetuned by
+    # tutorial_02_duke_heart_distancemap_finetune_icon.py.  Stock uniGradICON weights
+    # are out of distribution for distance maps, so without these the
+    # correspondences this model is built from barely move off the template,
+    # and the modes come out far too tight.  Tutorial 7 fits with the same
+    # checkpoint.
+    icon_weights_path = (
+        tutorials_dir
+        / "network_weights"
+        / "icon_duke_heart_distancemap"
+        / "icon_duke_heart_distancemap_model"
+        / "checkpoints"
+        / "network_weights_final.trch"
+    )
+
     log_level = logging.INFO
 
     # Directory setup and data reading
@@ -120,6 +135,12 @@ if __name__ == "__main__":
             log_level=log_level,
         )
         mean_workflow.set_number_of_iterations(mean_surface_iterations)
+        # Correspond the atlas with the same settings the model below uses, so
+        # the template is not itself built from under-fitting registrations.
+        mean_workflow.set_mask_dilation_mm(DUKE_HEART.mask_dilation_mm)
+        mean_workflow.set_distance_squared_max(DUKE_HEART.distancemap_squared_max)
+        if icon_weights_path.exists():
+            mean_workflow.set_icon_weights_path(str(icon_weights_path))
         mean_result = mean_workflow.process()
         mean_result["mean_surface"].save(str(reference_surface_file))
     reference_surface = pv.read(str(reference_surface_file))
@@ -130,8 +151,26 @@ if __name__ == "__main__":
         sample_meshes=sample_surfaces,
         reference_mesh=reference_surface,
         number_of_pca_components=number_of_pca_components,
+        icp_transform_type=DUKE_HEART.icp_transform_type,
+        mask_dilation_mm=DUKE_HEART.mask_dilation_mm,
+        distance_squared_max=DUKE_HEART.distancemap_squared_max,
         log_level=log_level,
     )
+
+    # Build the correspondences with the same distance-map scaling and weights
+    # Tutorial 7 fits with, so the model and the fit measure shape alike.
+    if icon_weights_path.exists():
+        workflow.set_icon_weights_path(str(icon_weights_path))
+    else:
+        workflow.log_warning(
+            "Finetuned distance-map ICON weights not found at %s; building the "
+            "model with the stock uniGradICON weights, which are out of "
+            "distribution for distance maps and will understate the "
+            "population's variance. Run "
+            "tutorials/tutorial_02_duke_heart_distancemap_finetune_icon.py "
+            "to create them.",
+            icon_weights_path,
+        )
 
     # Workflow execution
     result = workflow.process()

--- a/tutorials/tutorial_06_duke_heart_create_statistical_model.py
+++ b/tutorials/tutorial_06_duke_heart_create_statistical_model.py
@@ -128,7 +128,27 @@ if __name__ == "__main__":
     # unbiased mean of the population instead. Cached: it costs one deformable
     # registration per case per atlas iteration.
     reference_surface_file = output_dir / "reference_mean_surface.vtp"
-    if not reference_surface_file.exists():
+    # Keyed on the settings the atlas was corresponded with, not on the file
+    # merely being there: reusing an atlas built at one dilation, saturation
+    # radius or checkpoint while the model below corresponds its samples at
+    # another is the one way the two can disagree without saying so.
+    mean_surface_settings = {
+        "iterations": mean_surface_iterations,
+        "mask_dilation_mm": DUKE_HEART.mask_dilation_mm,
+        "distance_squared_max": DUKE_HEART.distancemap_squared_max,
+        "icon_weights": (
+            [str(icon_weights_path), icon_weights_path.stat().st_mtime_ns]
+            if icon_weights_path.exists()
+            else None
+        ),
+    }
+    settings_file = output_dir / "reference_mean_surface_settings.json"
+    cached_settings = (
+        json.loads(settings_file.read_text(encoding="utf-8"))
+        if reference_surface_file.exists() and settings_file.exists()
+        else None
+    )
+    if cached_settings != mean_surface_settings:
         mean_workflow = WorkflowCreateMeanSurface(
             surfaces=sample_surfaces,
             template_surface=sample_surfaces[len(sample_surfaces) // 2],
@@ -143,6 +163,9 @@ if __name__ == "__main__":
             mean_workflow.set_icon_weights_path(str(icon_weights_path))
         mean_result = mean_workflow.process()
         mean_result["mean_surface"].save(str(reference_surface_file))
+        settings_file.write_text(
+            json.dumps(mean_surface_settings, indent=2), encoding="utf-8"
+        )
     reference_surface = pv.read(str(reference_surface_file))
 
     # Workflow initialization

--- a/tutorials/tutorial_06_heart_create_statistical_model.py
+++ b/tutorials/tutorial_06_heart_create_statistical_model.py
@@ -51,6 +51,21 @@ if __name__ == "__main__":
     data_dir = HEART_CT_KCL.input_directory(test_mode)
     number_of_pca_components = HEART_CT_KCL.pca_components(test_mode)
 
+    # Distance-map weights finetuned by
+    # tutorial_02_duke_heart_distancemap_finetune_icon.py.  Stock uniGradICON weights
+    # are out of distribution for distance maps, so without these the
+    # correspondences this model is built from barely move off the template,
+    # and the modes come out far too tight.  Tutorial 7 fits with the same
+    # checkpoint.
+    icon_weights_path = (
+        tutorials_dir
+        / "network_weights"
+        / "icon_duke_heart_distancemap"
+        / "icon_duke_heart_distancemap_model"
+        / "checkpoints"
+        / "network_weights_final.trch"
+    )
+
     log_level = logging.INFO
 
     # Directory setup and data reading
@@ -92,8 +107,26 @@ if __name__ == "__main__":
         sample_meshes=sample_meshes,
         reference_mesh=reference_mesh,
         number_of_pca_components=number_of_pca_components,
+        icp_transform_type=HEART_CT_KCL.icp_transform_type,
+        mask_dilation_mm=HEART_CT_KCL.mask_dilation_mm,
+        distance_squared_max=HEART_CT_KCL.distancemap_squared_max,
         log_level=log_level,
     )
+
+    # Build the correspondences with the same distance-map scaling and weights
+    # Tutorial 7 fits with, so the model and the fit measure shape alike.
+    if icon_weights_path.exists():
+        workflow.set_icon_weights_path(str(icon_weights_path))
+    else:
+        workflow.log_warning(
+            "Finetuned distance-map ICON weights not found at %s; building the "
+            "model with the stock uniGradICON weights, which are out of "
+            "distribution for distance maps and will understate the "
+            "population's variance. Run "
+            "tutorials/tutorial_02_duke_heart_distancemap_finetune_icon.py "
+            "to create them.",
+            icon_weights_path,
+        )
 
     # Workflow execution
     result = workflow.process()

--- a/tutorials/tutorial_06_lung_create_statistical_model.py
+++ b/tutorials/tutorial_06_lung_create_statistical_model.py
@@ -77,6 +77,21 @@ if __name__ == "__main__":
     # template-biased pass.
     mean_surface_iterations = 3
 
+    # Distance-map weights finetuned by
+    # tutorial_02_lung_distancemap_finetune_icon.py.  Stock uniGradICON weights
+    # are out of distribution for distance maps, so without these the
+    # correspondences this model is built from barely move off the template,
+    # and the modes come out far too tight.  Tutorial 7 fits with the same
+    # checkpoint.
+    icon_weights_path = (
+        tutorials_dir
+        / "network_weights"
+        / "icon_dirlab_4dct_distancemap"
+        / "icon_dirlab_4dct_distancemap_model"
+        / "checkpoints"
+        / "network_weights_final.trch"
+    )
+
     log_level = logging.INFO
 
     # Directory setup and data reading
@@ -129,6 +144,12 @@ if __name__ == "__main__":
             surfaces=sample_surfaces, log_level=log_level
         )
         mean_workflow.set_number_of_iterations(mean_surface_iterations)
+        # Correspond the atlas with the same settings the model below uses, so
+        # the template is not itself built from under-fitting registrations.
+        mean_workflow.set_mask_dilation_mm(LUNG_CT_DIRLAB.mask_dilation_mm)
+        mean_workflow.set_distance_squared_max(LUNG_CT_DIRLAB.distancemap_squared_max)
+        if icon_weights_path.exists():
+            mean_workflow.set_icon_weights_path(str(icon_weights_path))
         mean_result = mean_workflow.process()
         mean_result["mean_surface"].save(str(reference_surface_file))
     reference_surface = pv.read(str(reference_surface_file))
@@ -139,8 +160,26 @@ if __name__ == "__main__":
         sample_meshes=sample_surfaces,
         reference_mesh=reference_surface,
         number_of_pca_components=number_of_pca_components,
+        icp_transform_type=LUNG_CT_DIRLAB.icp_transform_type,
+        mask_dilation_mm=LUNG_CT_DIRLAB.mask_dilation_mm,
+        distance_squared_max=LUNG_CT_DIRLAB.distancemap_squared_max,
         log_level=log_level,
     )
+
+    # Build the correspondences with the same distance-map scaling and weights
+    # Tutorial 7 fits with, so the model and the fit measure shape alike.
+    if icon_weights_path.exists():
+        workflow.set_icon_weights_path(str(icon_weights_path))
+    else:
+        workflow.log_warning(
+            "Finetuned distance-map ICON weights not found at %s; building the "
+            "model with the stock uniGradICON weights, which are out of "
+            "distribution for distance maps and will understate the "
+            "population's variance. Run "
+            "tutorials/tutorial_02_lung_distancemap_finetune_icon.py "
+            "to create them.",
+            icon_weights_path,
+        )
 
     # Workflow execution
     result = workflow.process()

--- a/tutorials/tutorial_06_lung_create_statistical_model.py
+++ b/tutorials/tutorial_06_lung_create_statistical_model.py
@@ -139,7 +139,27 @@ if __name__ == "__main__":
     # unbiased mean of the population instead. Cached: it costs one deformable
     # registration per case per atlas iteration.
     reference_surface_file = output_dir / "reference_mean_surface.vtp"
-    if not reference_surface_file.exists():
+    # Keyed on the settings the atlas was corresponded with, not on the file
+    # merely being there: reusing an atlas built at one dilation, saturation
+    # radius or checkpoint while the model below corresponds its samples at
+    # another is the one way the two can disagree without saying so.
+    mean_surface_settings = {
+        "iterations": mean_surface_iterations,
+        "mask_dilation_mm": LUNG_CT_DIRLAB.mask_dilation_mm,
+        "distance_squared_max": LUNG_CT_DIRLAB.distancemap_squared_max,
+        "icon_weights": (
+            [str(icon_weights_path), icon_weights_path.stat().st_mtime_ns]
+            if icon_weights_path.exists()
+            else None
+        ),
+    }
+    settings_file = output_dir / "reference_mean_surface_settings.json"
+    cached_settings = (
+        json.loads(settings_file.read_text(encoding="utf-8"))
+        if reference_surface_file.exists() and settings_file.exists()
+        else None
+    )
+    if cached_settings != mean_surface_settings:
         mean_workflow = WorkflowCreateMeanSurface(
             surfaces=sample_surfaces, log_level=log_level
         )
@@ -152,6 +172,9 @@ if __name__ == "__main__":
             mean_workflow.set_icon_weights_path(str(icon_weights_path))
         mean_result = mean_workflow.process()
         mean_result["mean_surface"].save(str(reference_surface_file))
+        settings_file.write_text(
+            json.dumps(mean_surface_settings, indent=2), encoding="utf-8"
+        )
     reference_surface = pv.read(str(reference_surface_file))
 
     # Workflow initialization

--- a/tutorials/tutorial_07_duke_heart_fit_statistical_model_to_patient.py
+++ b/tutorials/tutorial_07_duke_heart_fit_statistical_model_to_patient.py
@@ -165,6 +165,7 @@ if __name__ == "__main__":
         # map must not measure to either.
         labelmap_interior_object_ids=interior_object_ids,
     )
+    workflow.set_icp_transform_type(DUKE_HEART.icp_transform_type)
     workflow.set_mask_dilation_mm(DUKE_HEART.mask_dilation_mm)
     workflow.set_distancemap_squared_max(DUKE_HEART.distancemap_squared_max)
     workflow.set_use_pca_registration(
@@ -209,7 +210,7 @@ if __name__ == "__main__":
     )
     template_surface.save(str(output_dir / f"{project_name}_template_surface.vtp"))
 
-    registered_surface = workflow_results["registered_template_model_surface"]
+    registered_surface = workflow_results["fitted_reference_mesh"]
     registered_surface.save(
         str(output_dir / f"{project_name}_template_surface_registered.vtp")
     )

--- a/tutorials/tutorial_07_heart_fit_statistical_model_to_patient.py
+++ b/tutorials/tutorial_07_heart_fit_statistical_model_to_patient.py
@@ -158,6 +158,7 @@ if __name__ == "__main__":
         # are the ones to keep out of the distance map.
         labelmap_interior_object_ids=HEART_CT_KCL.interior_object_ids_totalsegmentator,
     )
+    workflow.set_icp_transform_type(HEART_CT_KCL.icp_transform_type)
     workflow.set_mask_dilation_mm(HEART_CT_KCL.mask_dilation_mm)
     workflow.set_distancemap_squared_max(HEART_CT_KCL.distancemap_squared_max)
     if pca_model is not None:
@@ -204,12 +205,12 @@ if __name__ == "__main__":
     )
     template_surface.save(str(output_dir / f"{project_name}_template_surface.vtp"))
 
-    registered_mesh = workflow_results["registered_template_model"]
+    registered_mesh = workflow_results["fitted_reference_model"]
     registered_mesh.save(
         str(output_dir / f"{project_name}_template_mesh_registered.vtp")
     )
 
-    registered_surface = workflow_results["registered_template_model_surface"]
+    registered_surface = workflow_results["fitted_reference_mesh"]
     registered_surface.save(
         str(output_dir / f"{project_name}_template_surface_registered.vtp")
     )

--- a/tutorials/tutorial_07_lung_fit_statistical_model_to_patient.py
+++ b/tutorials/tutorial_07_lung_fit_statistical_model_to_patient.py
@@ -150,6 +150,7 @@ if __name__ == "__main__":
             use_surface=False,
         )
 
+    workflow.set_icp_transform_type(LUNG_CT_DIRLAB.icp_transform_type)
     workflow.set_mask_dilation_mm(LUNG_CT_DIRLAB.mask_dilation_mm)
     workflow.set_distancemap_squared_max(LUNG_CT_DIRLAB.distancemap_squared_max)
 
@@ -188,7 +189,7 @@ if __name__ == "__main__":
     )
     template_surface.save(str(output_dir / f"{project_name}_template_surface.vtp"))
 
-    registered_surface = workflow_results["registered_template_model_surface"]
+    registered_surface = workflow_results["fitted_reference_mesh"]
     registered_surface.save(
         str(output_dir / f"{project_name}_template_surface_registered.vtp")
     )

--- a/tutorials/tutorial_08_duke_heart_fit_model_to_4d_patients.py
+++ b/tutorials/tutorial_08_duke_heart_fit_model_to_4d_patients.py
@@ -253,6 +253,7 @@ if __name__ == "__main__":
             number_of_pca_components=number_of_pca_components,
             use_surface=False,
         )
+        fit_workflow.set_icp_transform_type(DUKE_HEART.icp_transform_type)
         fit_workflow.set_mask_dilation_mm(DUKE_HEART.mask_dilation_mm)
         fit_workflow.set_distancemap_squared_max(DUKE_HEART.distancemap_squared_max)
         if use_finetuned_weights:
@@ -276,12 +277,12 @@ if __name__ == "__main__":
         # Typically the SSM is a dense tetrahedral volume mesh, saved as .vtu,
         # and its bounding surface is saved separately as .vtp.  The heart PCA
         # model from Tutorial 6 (Duke Heart) is built from surfaces only, so
-        # here the model *is* a surface: "registered_template_model" and
-        # "registered_template_model_surface" are the same geometry, and only
+        # here the model *is* a surface: "fitted_reference_model" and
+        # "fitted_reference_mesh" are the same geometry, and only
         # the .vtp surface is written.
-        ssm_surface_fitted = fit_result["registered_template_model_surface"]
-        ssm_surface_file = case_output_dir / f"{case_id}_ssm_surface.vtp"
-        ssm_surface_fitted.save(str(ssm_surface_file))
+        fitted_reference_mesh = fit_result["fitted_reference_mesh"]
+        fitted_reference_mesh_file = case_output_dir / f"{case_id}_ssm_surface.vtp"
+        fitted_reference_mesh.save(str(fitted_reference_mesh_file))
 
         # Step 3: warp the fitted SSM surface onto every gated frame.  One grid
         # is built around the reference frame's heart and reused by every frame,
@@ -300,11 +301,11 @@ if __name__ == "__main__":
             if frame_file == reference_file:
                 # The fit already placed the SSM on this frame.
                 logger.info("Case %s: reference frame %s", case_id, stem)
-                phase_surface = ssm_surface_fitted
+                phase_surface = fitted_reference_mesh
             else:
                 logger.info("Case %s: warping to frame %s", case_id, stem)
                 registrar = RegisterModelsDistanceMaps(
-                    moving_model=ssm_surface_fitted,
+                    moving_model=fitted_reference_mesh,
                     fixed_model=heart_surface_for(frame_file, case_output_dir),
                     reference_image=registration_grid,
                     distance_squared_max=DUKE_HEART.distancemap_squared_max,
@@ -323,7 +324,7 @@ if __name__ == "__main__":
 
         tutorial_results["cases"][case_id] = {
             "pca_coefficients_file": pca_coefficients_file,
-            "ssm_surface_file": ssm_surface_file,
+            "fitted_reference_mesh_file": fitted_reference_mesh_file,
             "phase_outputs": phase_outputs,
         }
 
@@ -343,7 +344,7 @@ if __name__ == "__main__":
     last_case = list(tutorial_results["cases"].values())[-1]
     tutorial_results["screenshots"] = [
         tt.save_screenshot_mesh(
-            cast(pv.DataSet, pv.read(str(last_case["ssm_surface_file"]))),
+            cast(pv.DataSet, pv.read(str(last_case["fitted_reference_mesh_file"]))),
             "ssm_surface_reference.png",
             camera_position="iso",
             color="steelblue",

--- a/tutorials/tutorial_08_lung_fit_model_to_4d_patients.py
+++ b/tutorials/tutorial_08_lung_fit_model_to_4d_patients.py
@@ -215,6 +215,7 @@ if __name__ == "__main__":
             number_of_pca_components=number_of_pca_components,
             use_surface=False,
         )
+        fit_workflow.set_icp_transform_type(LUNG_CT_DIRLAB.icp_transform_type)
         fit_workflow.set_mask_dilation_mm(LUNG_CT_DIRLAB.mask_dilation_mm)
         fit_workflow.set_distancemap_squared_max(LUNG_CT_DIRLAB.distancemap_squared_max)
         if use_finetuned_distancemap_weights:
@@ -238,11 +239,11 @@ if __name__ == "__main__":
         # Typically the SSM is a dense tetrahedral volume mesh, saved as .vtu, and
         # its bounding surface is saved separately as .vtp. The lung PCA model from
         # Tutorial 6 is built from surfaces only, so here the model *is* a surface:
-        # "registered_template_model" and "registered_template_model_surface" are
+        # "fitted_reference_model" and "fitted_reference_mesh" are
         # the same geometry, and only the .vtp surface is written.
-        ssm_surface_fitted = fit_result["registered_template_model_surface"]
-        ssm_surface_file = case_output_dir / f"{case_id}_ssm_surface.vtp"
-        ssm_surface_fitted.save(str(ssm_surface_file))
+        fitted_reference_mesh = fit_result["fitted_reference_mesh"]
+        fitted_reference_mesh_file = case_output_dir / f"{case_id}_ssm_surface.vtp"
+        fitted_reference_mesh.save(str(fitted_reference_mesh_file))
 
         # Step 3: register every respiratory phase to the reference phase
         phase_files = sorted(data_dir.glob(f"{case_id}_T??.mha"))
@@ -284,7 +285,9 @@ if __name__ == "__main__":
             )
 
             surface = transform_tools.transform_pvcontour(
-                ssm_surface_fitted, forward_transform, with_deformation_magnitude=True
+                fitted_reference_mesh,
+                forward_transform,
+                with_deformation_magnitude=True,
             )
             surface_file = case_output_dir / f"{case_id}_{phase_id}_ssm_surface.vtp"
             surface.save(str(surface_file))
@@ -293,7 +296,7 @@ if __name__ == "__main__":
 
         tutorial_results["cases"][case_id] = {
             "pca_coefficients_file": pca_coefficients_file,
-            "ssm_surface_file": ssm_surface_file,
+            "fitted_reference_mesh_file": fitted_reference_mesh_file,
             "phase_outputs": phase_outputs,
         }
 
@@ -308,7 +311,7 @@ if __name__ == "__main__":
     last_case = tutorial_results["cases"][case_id]
     tutorial_results["screenshots"] = [
         tt.save_screenshot_mesh(
-            cast(pv.DataSet, pv.read(str(last_case["ssm_surface_file"]))),
+            cast(pv.DataSet, pv.read(str(last_case["fitted_reference_mesh_file"]))),
             "ssm_surface_reference.png",
             camera_position="iso",
             color="steelblue",

--- a/tutorials/tutorial_09_duke_heart_train_physicsnemo_mgn.py
+++ b/tutorials/tutorial_09_duke_heart_train_physicsnemo_mgn.py
@@ -143,12 +143,12 @@ def _write_case_manifest(
     from one that never ran.
     """
     case_id = case_dir.name
-    ref_file = case_dir / f"{case_id}_ssm_surface.vtp"
+    fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
     pca_file = case_dir / f"{case_id}_ssm_pca_coefficients.json"
     phase_files = sorted(case_dir.glob(PHASE_SURFACE_PATTERN))
     missing = []
-    if not ref_file.exists():
-        missing.append(f"reference surface {ref_file.name}")
+    if not fitted_reference_mesh_file.exists():
+        missing.append(f"reference surface {fitted_reference_mesh_file.name}")
     if not pca_file.exists():
         missing.append(f"PCA coefficients {pca_file.name}")
     if len(phase_files) < 2:
@@ -158,10 +158,12 @@ def _write_case_manifest(
         return None
 
     manifests_dir.mkdir(parents=True, exist_ok=True)
-    ref_points = np.asarray(pv.read(str(ref_file)).points, dtype=np.float32)
+    ref_points = np.asarray(
+        pv.read(str(fitted_reference_mesh_file)).points, dtype=np.float32
+    )
     manifest = {
         "subject_id": case_id,
-        "reference_mesh": str(ref_file),
+        "fitted_reference_mesh": str(fitted_reference_mesh_file),
         "pca_coefficients": str(pca_file),
         "target_array": TARGET_ARRAY,
         "phases": [
@@ -319,8 +321,7 @@ if __name__ == "__main__":
             output_directory=eval_dir / case_id,
         )
 
-    # Testing: render the first predicted surface of the last held-out case and
-    # the RMSE-colored reference surface beside it.
+    # Testing: render the first predicted surface of the last held-out case.
     tt = TestTools(
         class_name=class_name,
         results_dir=output_dir,
@@ -334,11 +335,5 @@ if __name__ == "__main__":
             "predicted_surface.png",
             camera_position="iso",
             color="limegreen",
-        ),
-        tt.save_screenshot_mesh(
-            cast(pv.DataSet, pv.read(str(last_case["rmse_surface"]))),
-            "rmse_surface.png",
-            camera_position="iso",
-            color="orange",
         ),
     ]

--- a/tutorials/tutorial_09_lung_train_physicsnemo_mgn.py
+++ b/tutorials/tutorial_09_lung_train_physicsnemo_mgn.py
@@ -64,7 +64,7 @@ Manifests, the held-out evaluation and the screenshots are written under
   * ``manifests_mgn/Case*Pack_manifest.json``  - per-case training manifest
   * ``manifests_mgn/Case*Pack_T??_ssm_surface_target.vtp`` - displacement targets
   * ``eval_mgn/Case*Pack/``     - predicted surfaces per held-out case
-  * ``predicted_surface.png`` / ``rmse_surface.png`` - screenshots
+  * ``predicted_surface.png``   - screenshot of the held-out prediction
 
 The model lands in ``ParametersLungCTDirLab.mgn_weights_dir``
 (``network_weights/physicsnemo_mgn_lung_motion/``), where Tutorial 10 reads it:
@@ -145,12 +145,12 @@ def _write_case_manifest(
     from one that never ran.
     """
     case_id = case_dir.name
-    ref_file = case_dir / f"{case_id}_ssm_surface.vtp"
+    fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
     pca_file = case_dir / f"{case_id}_ssm_pca_coefficients.json"
     phase_files = sorted(case_dir.glob(f"{case_id}_T??_ssm_surface.vtp"))
     missing = []
-    if not ref_file.exists():
-        missing.append(f"reference surface {ref_file.name}")
+    if not fitted_reference_mesh_file.exists():
+        missing.append(f"reference surface {fitted_reference_mesh_file.name}")
     if not pca_file.exists():
         missing.append(f"PCA coefficients {pca_file.name}")
     if len(phase_files) < 2:
@@ -160,10 +160,12 @@ def _write_case_manifest(
         return None
 
     manifests_dir.mkdir(parents=True, exist_ok=True)
-    ref_points = np.asarray(pv.read(str(ref_file)).points, dtype=np.float32)
+    ref_points = np.asarray(
+        pv.read(str(fitted_reference_mesh_file)).points, dtype=np.float32
+    )
     manifest = {
         "subject_id": case_id,
-        "reference_mesh": str(ref_file),
+        "fitted_reference_mesh": str(fitted_reference_mesh_file),
         "pca_coefficients": str(pca_file),
         "target_array": TARGET_ARRAY,
         "phases": [
@@ -319,8 +321,7 @@ if __name__ == "__main__":
             output_directory=output_dir / "eval_mgn" / case_id,
         )
 
-    # Testing: render the first predicted surface of the last held-out case and
-    # the RMSE-colored reference surface beside it.
+    # Testing: render the first predicted surface of the last held-out case.
     tt = TestTools(
         class_name=class_name,
         results_dir=output_dir,
@@ -334,11 +335,5 @@ if __name__ == "__main__":
             "predicted_surface.png",
             camera_position="iso",
             color="limegreen",
-        ),
-        tt.save_screenshot_mesh(
-            cast(pv.DataSet, pv.read(str(last_case["rmse_surface"]))),
-            "rmse_surface.png",
-            camera_position="iso",
-            color="orange",
         ),
     ]

--- a/tutorials/tutorial_10_duke_heart_infer_physicsnemo_mgn.py
+++ b/tutorials/tutorial_10_duke_heart_infer_physicsnemo_mgn.py
@@ -16,8 +16,9 @@ displacement decoder :class:`physiotwin4d.WorkflowInferMovement`:
 2. Predict that case's surface at *every* cardiac stage with the MeshGraphNet
    trained by Tutorial 9 (``tutorial_09_duke_heart_train_physicsnemo_mgn.py``).
    The network predicts per-vertex displacements, so the decoder adds them to
-   the case's reference SSM surface and scores each stage in millimetres
-   against the ground-truth frame surface.
+   the case's fitted reference SSM surface.  Scoring the result is Tutorial
+   11's job, not this one's; here the acquired frame surface is only rendered
+   beside the prediction so the two can be compared by eye.
 
 3. Rasterize each stage's displacements into a deformation field and carry the
    reference frame through it, and write the whole series as one animated USD.
@@ -51,7 +52,6 @@ Outputs (under ``output/tutorial_10_duke_heart_mgn/<case>/``)
   * ``<case>_ssm_pca_coefficients_s{TTT}_pred.vtp``   - predicted surface
   * ``<case>_ssm_pca_coefficients_s{TTT}_warped.mha`` - labelmap at that stage
   * ``<case>_mgn_motion.usd``                         - animated predicted motion
-  * ``statistics_per_stage.csv``                      - mm error per stage
 """
 
 # Imports
@@ -129,10 +129,10 @@ if __name__ == "__main__":
         )
 
     case_dir = data_dir / case_id
-    reference_file = case_dir / f"{case_id}_ssm_surface.vtp"
+    fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
     pca_file = case_dir / f"{case_id}_ssm_pca_coefficients.json"
     phase_files = sorted(case_dir.glob(PHASE_SURFACE_PATTERN))
-    for required_file in (reference_file, pca_file):
+    for required_file in (fitted_reference_mesh_file, pca_file):
         if not required_file.exists():
             raise FileNotFoundError(
                 f"Tutorial 8 output not found: {required_file}\n"
@@ -167,8 +167,7 @@ if __name__ == "__main__":
         shape_parameters=pca_file,
         stages=stages,
         output_directory=output_dir,
-        reference_mesh=reference_file,
-        ground_truth=phase_files,
+        fitted_reference_mesh=fitted_reference_mesh_file,
         reference_image=itk.imread(str(reference_labelmaps[0])),
         warp_interpolation="nearest",
         warp_background_value=0.0,

--- a/tutorials/tutorial_10_lung_infer_physicsnemo_mgn.py
+++ b/tutorials/tutorial_10_lung_infer_physicsnemo_mgn.py
@@ -16,9 +16,10 @@ displacement decoder :class:`physiotwin4d.WorkflowInferMovement`:
 2. Predict that case's surface at *every* respiratory stage with the
    MeshGraphNet trained by Tutorial 9
    (``tutorial_09_lung_train_physicsnemo_mgn.py``). The network predicts
-   per-vertex displacements, so the decoder adds them to the case's reference
-   SSM surface and scores each stage in millimetres against the ground-truth
-   phase surface.
+   per-vertex displacements, so the decoder adds them to the case's fitted
+   reference SSM surface.  Scoring the result is Tutorial 11's job, not this
+   one's; here the acquired phase surface is only rendered beside the
+   prediction so the two can be compared by eye.
 
 3. Rasterize each stage's displacements into a deformation field and carry the
    reference-phase CT through it, giving one warped CT per stage, and write the
@@ -48,7 +49,6 @@ Outputs (under ``output/tutorial_10_lung_mgn/<case>/``)
   * ``<case>_ssm_pca_coefficients_s{TTT}_pred.vtp``   - predicted surface
   * ``<case>_ssm_pca_coefficients_s{TTT}_warped.mha`` - CT carried to that stage
   * ``<case>_mgn_motion.usd``                         - animated predicted motion
-  * ``statistics_per_stage.csv``                      - mm error per stage
 """
 
 # Imports
@@ -126,13 +126,13 @@ if __name__ == "__main__":
         )
 
     case_dir = data_dir / case_id
-    reference_file = case_dir / f"{case_id}_ssm_surface.vtp"
+    fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
     pca_file = case_dir / f"{case_id}_ssm_pca_coefficients.json"
     reference_ct_file = (
         repo_root / "data" / "DirLab-4DCT" / (f"{case_id}_{reference_phase}.mha")
     )
     phase_files = sorted(case_dir.glob(f"{case_id}_T??_ssm_surface.vtp"))
-    for required_file in (reference_file, pca_file):
+    for required_file in (fitted_reference_mesh_file, pca_file):
         if not required_file.exists():
             raise FileNotFoundError(
                 f"Tutorial 8 output not found: {required_file}\n"
@@ -154,8 +154,7 @@ if __name__ == "__main__":
     # Step 2 and 3: predict the whole cycle, warp the reference CT through each
     # stage's deformation, and write the animated USD. The network predicts
     # displacements, so the decoder adds them to the case's reference SSM
-    # surface and scores each stage against its ground-truth phase surface in
-    # millimetres. -1000 HU is air, the value a CT grid samples outside itself.
+    # surface. -1000 HU is air, the value a CT grid samples outside itself.
     infer_workflow = WorkflowInferPhysicsNeMo(
         model_directory=model_dir, epoch=epoch, log_level=log_level
     )
@@ -165,8 +164,7 @@ if __name__ == "__main__":
         shape_parameters=pca_file,
         stages=stages,
         output_directory=output_dir,
-        reference_mesh=reference_file,
-        ground_truth=phase_files,
+        fitted_reference_mesh=fitted_reference_mesh_file,
         reference_image=itk.imread(str(reference_ct_file)),
         warp_interpolation="linear",
         warp_background_value=-1000.0,

--- a/tutorials/tutorial_11_duke_heart_evaluate_physicsnemo.py
+++ b/tutorials/tutorial_11_duke_heart_evaluate_physicsnemo.py
@@ -55,7 +55,6 @@ Outputs (under ``output/tutorial_11_duke_heart/<case>/``)
     and worst case, with the per-point displacement error per frame
   * ``evaluation_metrics.csv``  - one row per stage and structure, each
     carrying that structure's displacement error (RMS, 95th percentile, maximum)
-  * ``statistics_per_stage.csv`` - displacement error statistics per frame
   * ``volume_vs_stage.png``     - each structure's volume across the stages
   * ``<case>_ssm_pca_coefficients_s{TTT}_pred.vtp`` - predicted surface per stage,
     carrying the displacement point-data arrays the ``include_*`` switches ask for

--- a/tutorials/tutorial_11_duke_heart_evaluate_physicsnemo.py
+++ b/tutorials/tutorial_11_duke_heart_evaluate_physicsnemo.py
@@ -23,9 +23,19 @@ chain, so this scores generalization rather than recall.
    Going through the labelmaps rather than through the model's surface is what
    makes per-chamber scores possible at all.
 
-3. Write ``evaluation_report.md`` and ``evaluation_metrics.csv``, both carrying
+3. Score the motion point by point: with Tutorial 8's per-frame SSM surfaces as
+   the ground truth, the report also carries the distance between where the
+   network puts each mesh point and where the shape model fitted it --- RMS,
+   95th percentile and maximum, per structure and per frame.  The shape model
+   has no chamber geometry of its own, so a mesh point counts toward the
+   structure whose reference-frame surface is nearest: a chamber is scored on
+   the piece of wall that bounds it.  A chamber whose predicted motion is right on average can
+   still be wrong everywhere, and only this measure says so.
+
+4. Write ``evaluation_report.md`` and ``evaluation_metrics.csv``, both carrying
    the hold-out case name, the case's shape parameters, and the network weights
-   path with its dates.
+   path with its dates.  Each metric is reported both averaged over the frames
+   and at the frame it is worst at.
 
 Extra Install Required
 ----------------------
@@ -41,10 +51,16 @@ Data Required
 
 Outputs (under ``output/tutorial_11_duke_heart/<case>/``)
 ---------------------------------------------------------
-  * ``evaluation_report.md``    - per-chamber accuracy of the prediction
-  * ``evaluation_metrics.csv``  - one row per stage and structure
+  * ``evaluation_report.md``    - per-chamber accuracy of the prediction, mean
+    and worst case, with the per-point displacement error per frame
+  * ``evaluation_metrics.csv``  - one row per stage and structure, each
+    carrying that structure's displacement error (RMS, 95th percentile, maximum)
+  * ``statistics_per_stage.csv`` - displacement error statistics per frame
   * ``volume_vs_stage.png``     - each structure's volume across the stages
-  * ``<case>_ssm_pca_coefficients_s{TTT}_pred.vtp`` - predicted surface per stage
+  * ``<case>_ssm_pca_coefficients_s{TTT}_pred.vtp`` - predicted surface per stage,
+    carrying the displacement point-data arrays the ``include_*`` switches ask for
+  * ``displacement_per_point.csv`` - every mesh point's predicted and true
+    displacement at every frame; written only when ``report_displacement_data``
 """
 
 # Imports
@@ -59,28 +75,12 @@ import pyvista as pv
 from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from physiotwin4d import (
-    SegmentHeartSimplewareTrimmedBranches,
+    EvaluateMovementDukeHeart,
     TestTools,
     WorkflowEvaluateMovement,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
 )
-
-LABELMAP_SUFFIX = "_labelmap.nii.gz"
-
-# The four chambers, plus the myocardium and the whole heart for context: 5 and
-# 6 are what the shape model itself represents, 1-4 are the cavities it does
-# not.  The great vessels and coronaries (7-10) are left out; they come and go
-# between frames and are not part of the model.
-HEART_LABEL_IDS = [1, 2, 3, 4, 5, 6]
-
-
-def _cardiac_stage_from_filename(labelmap_file: Path) -> float:
-    """Extract the normalized cardiac stage [0, 1] from a ``g{PPP}`` filename stem."""
-    for part in labelmap_file.name.split("_"):
-        if part.startswith("g") and part[1:].isdigit():
-            return int(part[1:]) / 100.0
-    raise ValueError(f"Cannot parse cardiac gate from filename: {labelmap_file}")
 
 
 # Only run if this script is not imported as a module
@@ -114,6 +114,18 @@ if __name__ == "__main__":
     # and still below the thinnest wall of the heart.
     evaluation_spacing_mm = 1.0
 
+    # Per-point displacement reporting, all off by default.  The first writes
+    # one CSV row per mesh point per frame; the rest carry the same quantities
+    # as point data on each frame's predicted surface.  Every one of them except
+    # the predicted displacement is measured against Tutorial 8's per-frame SSM
+    # surfaces, the only geometry that shares this mesh's point ordering.
+    report_displacement_data = False
+    include_predicted_displacements = False
+    include_true_displacements = False
+    # On: the point-by-point error is the one measure a displacement predicted
+    # in the wrong direction cannot hide in, and it costs one mesh read a frame.
+    include_displacement_error = True
+
     output_dir = tutorials_dir / "output" / "tutorial_11_duke_heart" / case_id
     log_level = logging.INFO
 
@@ -127,9 +139,9 @@ if __name__ == "__main__":
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
+    fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
     pca_file = case_dir / f"{case_id}_ssm_pca_coefficients.json"
-    for required_file in (reference_mesh_file, pca_file):
+    for required_file in (fitted_reference_mesh_file, pca_file):
         if not required_file.exists():
             raise FileNotFoundError(
                 f"Tutorial 8 output not found: {required_file}\n"
@@ -137,62 +149,50 @@ if __name__ == "__main__":
                 "first."
             )
 
-    frame_files = sorted(labelmap_dir.glob(f"*{LABELMAP_SUFFIX}"))
-    if not frame_files:
-        raise FileNotFoundError(
-            f"No gated labelmaps found in {labelmap_dir}.\n"
-            "See data/Duke-Heart-4DLabelmaps/README.md."
-        )
-    reference_files = [
-        path for path in frame_files if path.name.endswith(f"_ref{LABELMAP_SUFFIX}")
-    ]
-    if not reference_files:
-        raise FileNotFoundError(
-            f"No *_ref{LABELMAP_SUFFIX} frame in {labelmap_dir}; Tutorial 8 fitted "
-            "the SSM to that frame, so it is the one the deformations start from."
-        )
-
-    # Step 1: ground truth, one labelmap per gated frame, as acquired.
-    ground_truth_labelmaps: dict[float, itk.Image] = {
-        _cardiac_stage_from_filename(frame_file): itk.imread(str(frame_file))
-        for frame_file in frame_files
-    }
-    logger.info("Case %s: %d gated frames", case_id, len(ground_truth_labelmaps))
-
-    # Step 2: score every frame, per chamber, against its own labelmap.  The
-    # segmenter is instantiated for its taxonomy alone; no model is loaded.
-    all_labels = SegmentHeartSimplewareTrimmedBranches(
-        log_level=logging.WARNING
-    ).taxonomy.all_labels()
-    # The taxonomy's "heart" is the whole heart minus its chamber cavities --
-    # the muscle the shape model represents -- so the report names it that way.
-    heart_names = {
-        label: "heart muscle" if all_labels[label] == "heart" else all_labels[label]
-        for label in HEART_LABEL_IDS
-    }
+    # Step 1: the cohort assembles what this case is scored against -- every
+    # gated frame's labelmap, the reference frame among them, and Tutorial 8's
+    # per-frame fits, which are the only geometry that shares the fitted
+    # reference mesh's point ordering.
+    cohort = EvaluateMovementDukeHeart(log_level=log_level)
+    ground_truth = cohort.assemble_ground_truth(
+        case_id=case_id,
+        frame_directory=labelmap_dir,
+        fit_directory=case_dir,
+    )
 
     infer_workflow = WorkflowInferPhysicsNeMo(
         model_directory=model_dir, epoch=epoch, log_level=log_level
     )
     evaluate_workflow = WorkflowEvaluateMovement(
         movement_workflow=WorkflowInferMovement(infer_workflow, log_level=log_level),
-        label_names=heart_names,
+        cohort=cohort,
         log_level=log_level,
     )
     result = evaluate_workflow.process(
         case_id=case_id,
         shape_parameters=pca_file,
-        reference_mesh=reference_mesh_file,
-        reference_labelmap=itk.imread(str(reference_files[0])),
-        ground_truth_labelmaps=ground_truth_labelmaps,
+        fitted_reference_mesh=fitted_reference_mesh_file,
+        ground_truth=ground_truth,
         output_directory=output_dir,
         smoothing_sigma_mm=smoothing_sigma_mm,
         evaluation_spacing_mm=evaluation_spacing_mm,
+        report_displacement_data=report_displacement_data,
+        include_predicted_displacements=include_predicted_displacements,
+        include_true_displacements=include_true_displacements,
+        include_displacement_error=include_displacement_error,
     )
 
     # Step 3: the report and the CSV are written by the workflow.
     logger.info("Report: %s", result["report_file"])
     logger.info("Metrics: %s", result["csv_file"])
+    if result["displacement_data_file"] is not None:
+        logger.info("Displacements: %s", result["displacement_data_file"])
+    logger.info(
+        "Displacement error: rms=%.3f mm  95th=%.3f mm  max=%.3f mm",
+        result["displacement_rms_mm"],
+        result["displacement_95th_mm"],
+        result["displacement_max_mm"],
+    )
 
     tutorial_results: dict[str, Any] = dict(result)
 

--- a/tutorials/tutorial_11_lung_evaluate_physicsnemo.py
+++ b/tutorials/tutorial_11_lung_evaluate_physicsnemo.py
@@ -55,7 +55,6 @@ Outputs (under ``output/tutorial_11_lung/<case>/``)
     worst case, with the per-point displacement error per phase
   * ``evaluation_metrics.csv``  - one row per stage and lobe, each carrying
     that lobe's displacement error (RMS, 95th percentile, maximum)
-  * ``statistics_per_stage.csv`` - displacement error statistics per phase
   * ``volume_vs_stage.png``     - each lobe's volume across the stages
   * ``ground_truth/<case>_T{PP}_labelmap.nii.gz`` - cached per-phase segmentation
   * ``<case>_ssm_pca_coefficients_s{TTT}_pred.vtp`` - predicted surface per stage,

--- a/tutorials/tutorial_11_lung_evaluate_physicsnemo.py
+++ b/tutorials/tutorial_11_lung_evaluate_physicsnemo.py
@@ -20,13 +20,22 @@ Tutorial 9 training, so this scores generalization rather than recall.
    fraction stays above 0.96 however well or badly the motion is predicted, and
    describes the lobe rather than the motion.
 
-3. Write ``evaluation_report.md`` and ``evaluation_metrics.csv``, both carrying
+3. Score the motion point by point: with Tutorial 8's per-phase SSM surfaces as
+   the ground truth, the report also carries the distance between where the
+   network puts each mesh point and where the shape model fitted it --- RMS,
+   95th percentile and maximum, per lobe and per phase.  The lung shape model
+   tags every triangle with its lobe, so a mesh point is scored under the lobe
+   the model itself says it belongs to.  A lobe whose predicted motion is right on average can
+   still be wrong everywhere, and only this measure says so.
+
+4. Write ``evaluation_report.md`` and ``evaluation_metrics.csv``, both carrying
    the hold-out case name, the case's shape parameters, and the network weights
-   path with its dates.
+   path with its dates.  Each metric is reported both averaged over the phases
+   and at the phase it is worst at.
 
 Step 1 costs one segmentation pass per phase on first run and is cached
-afterwards; Step 2 is the workflow, so this script only chooses the case, the
-lobes and the ground truth.
+afterwards; Steps 2 to 4 are the workflow, so this script only chooses the case,
+the lobes and the ground truth.
 
 Extra Install Required
 ----------------------
@@ -42,11 +51,17 @@ Data Required
 
 Outputs (under ``output/tutorial_11_lung/<case>/``)
 ---------------------------------------------------
-  * ``evaluation_report.md``    - per-lobe accuracy of the prediction
-  * ``evaluation_metrics.csv``  - one row per stage and lobe
+  * ``evaluation_report.md``    - per-lobe accuracy of the prediction, mean and
+    worst case, with the per-point displacement error per phase
+  * ``evaluation_metrics.csv``  - one row per stage and lobe, each carrying
+    that lobe's displacement error (RMS, 95th percentile, maximum)
+  * ``statistics_per_stage.csv`` - displacement error statistics per phase
   * ``volume_vs_stage.png``     - each lobe's volume across the stages
   * ``ground_truth/<case>_T{PP}_labelmap.nii.gz`` - cached per-phase segmentation
-  * ``<case>_ssm_pca_coefficients_s{TTT}_pred.vtp`` - predicted surface per stage
+  * ``<case>_ssm_pca_coefficients_s{TTT}_pred.vtp`` - predicted surface per stage,
+    carrying the displacement point-data arrays the ``include_*`` switches ask for
+  * ``displacement_per_point.csv`` - every mesh point's predicted and true
+    displacement at every phase; written only when ``report_displacement_data``
 """
 
 # Imports
@@ -61,24 +76,12 @@ import pyvista as pv
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from physiotwin4d import (
-    SegmentNVSegmentCTMRI,
+    EvaluateMovementLung,
     TestTools,
     WorkflowEvaluateMovement,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
 )
-
-# The five lobes of ``SegmentNVSegmentCTMRI``.  Its "lung" group also carries
-# whole-lung, tumor and airway labels, which are not lobes.
-LOBE_LABEL_IDS = [28, 29, 30, 31, 32]
-
-
-def _respiratory_stage_from_filename(image_file: Path) -> float:
-    """Extract the normalized respiratory stage [0, 1] from a ``T{PP}`` filename stem."""
-    for part in image_file.stem.split("_"):
-        if part.startswith("T") and part[1:].isdigit():
-            return int(part[1:]) / 100.0
-    raise ValueError(f"Cannot parse respiratory phase from filename: {image_file}")
 
 
 # Only run if this script is not imported as a module
@@ -115,6 +118,18 @@ if __name__ == "__main__":
     # that a lobe boundary is not quantized away.
     evaluation_spacing_mm = 2.0
 
+    # Per-point displacement reporting, all off by default.  The first writes
+    # one CSV row per mesh point per phase; the rest carry the same quantities
+    # as point data on each phase's predicted surface.  Every one of them except
+    # the predicted displacement is measured against Tutorial 8's per-phase SSM
+    # surfaces, the only geometry that shares this mesh's point ordering.
+    report_displacement_data = False
+    include_predicted_displacements = False
+    include_true_displacements = False
+    # On: the point-by-point error is the one measure a displacement predicted
+    # in the wrong direction cannot hide in, and it costs one mesh read a phase.
+    include_displacement_error = True
+
     output_dir = tutorials_dir / "output" / "tutorial_11_lung" / case_id
     ground_truth_dir = output_dir / "ground_truth"
     log_level = logging.INFO
@@ -129,79 +144,64 @@ if __name__ == "__main__":
 
     ground_truth_dir.mkdir(parents=True, exist_ok=True)
 
-    reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
+    fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
     pca_file = case_dir / f"{case_id}_ssm_pca_coefficients.json"
-    for required_file in (reference_mesh_file, pca_file):
+    for required_file in (fitted_reference_mesh_file, pca_file):
         if not required_file.exists():
             raise FileNotFoundError(
                 f"Tutorial 8 output not found: {required_file}\n"
                 "Run tutorials/tutorial_08_lung_fit_model_to_4d_patients.py first."
             )
 
-    frame_files = sorted(data_dir.glob(f"{case_id}_T??.mha"))
-    if not frame_files:
-        raise FileNotFoundError(
-            f"No {case_id}_T??.mha frames found under {data_dir}.\n"
-            "See data/DirLab-4DCT/README.md for download instructions."
-        )
-
-    # Step 1: ground truth.  Every gated frame is segmented on its own, so the
-    # lobes each phase is scored against came from that phase's image rather
-    # than from a registration or a shape-model fit.  Segmentation dominates the
-    # runtime, so each labelmap is cached and reused on a re-run.
-    segmenter = SegmentNVSegmentCTMRI(log_level=log_level)
-    ground_truth_labelmaps: dict[float, itk.Image] = {}
-    for frame_file in frame_files:
-        labelmap_file = ground_truth_dir / f"{frame_file.stem}_labelmap.nii.gz"
-        if not labelmap_file.exists():
-            logger.info("Segmenting ground-truth frame %s", frame_file.name)
-            segmentation_result = segmenter.segment(itk.imread(str(frame_file)))
-            itk.imwrite(
-                segmentation_result["labelmap"], str(labelmap_file), compression=True
-            )
-        ground_truth_labelmaps[_respiratory_stage_from_filename(frame_file)] = (
-            itk.imread(str(labelmap_file))
-        )
-
-    reference_labelmap_file = (
-        ground_truth_dir / f"{case_id}_{reference_phase}_labelmap.nii.gz"
+    # Step 1: the cohort assembles what this case is scored against.  Every
+    # gated frame is segmented on its own, so the lobes each phase is scored
+    # against came from that phase's image rather than from a registration or a
+    # shape-model fit; segmentation dominates the runtime, so each labelmap is
+    # cached in ``ground_truth_dir`` and reused on a re-run.  Tutorial 8's
+    # per-phase fits come along too: they are the only geometry that shares the
+    # fitted reference mesh's point ordering, so they are what the
+    # point-by-point error is measured against.
+    cohort = EvaluateMovementLung(reference_phase=reference_phase, log_level=log_level)
+    ground_truth = cohort.assemble_ground_truth(
+        case_id=case_id,
+        frame_directory=data_dir,
+        fit_directory=case_dir,
+        cache_directory=ground_truth_dir,
     )
-    if not reference_labelmap_file.exists():
-        raise FileNotFoundError(
-            f"Reference phase {reference_phase} is not among {data_dir}'s frames, "
-            f"so {reference_labelmap_file} was never segmented."
-        )
-
-    # Step 2: score every phase, per lobe, against its own segmentation.
-    all_labels = segmenter.taxonomy.all_labels()
-    lobe_names = {label: all_labels[label] for label in LOBE_LABEL_IDS}
 
     infer_workflow = WorkflowInferPhysicsNeMo(
         model_directory=model_dir, epoch=epoch, log_level=log_level
     )
     evaluate_workflow = WorkflowEvaluateMovement(
         movement_workflow=WorkflowInferMovement(infer_workflow, log_level=log_level),
-        label_names=lobe_names,
+        cohort=cohort,
         log_level=log_level,
     )
     result = evaluate_workflow.process(
         case_id=case_id,
         shape_parameters=pca_file,
-        reference_mesh=reference_mesh_file,
-        reference_labelmap=itk.imread(str(reference_labelmap_file)),
-        ground_truth_labelmaps=ground_truth_labelmaps,
+        fitted_reference_mesh=fitted_reference_mesh_file,
+        ground_truth=ground_truth,
         output_directory=output_dir,
         smoothing_sigma_mm=smoothing_sigma_mm,
         evaluation_spacing_mm=evaluation_spacing_mm,
-        # A lobe barely changes shape over a breath compared to how big it is,
-        # so Dice says more about the lobe than about the motion. Volume
-        # difference and surface RMSE are what resolve it here.
-        include_dice=False,
+        report_displacement_data=report_displacement_data,
+        include_predicted_displacements=include_predicted_displacements,
+        include_true_displacements=include_true_displacements,
+        include_displacement_error=include_displacement_error,
     )
 
     # Step 3: the report and the CSV are written by the workflow.
     logger.info("Report: %s", result["report_file"])
     logger.info("Metrics: %s", result["csv_file"])
+    if result["displacement_data_file"] is not None:
+        logger.info("Displacements: %s", result["displacement_data_file"])
+    logger.info(
+        "Displacement error: rms=%.3f mm  95th=%.3f mm  max=%.3f mm",
+        result["displacement_rms_mm"],
+        result["displacement_95th_mm"],
+        result["displacement_max_mm"],
+    )
 
     tutorial_results: dict[str, Any] = dict(result)
     tutorial_results["ground_truth_labelmap_dir"] = ground_truth_dir

--- a/tutorials/tutorial_12_duke_heart_end_to_end_inference.py
+++ b/tutorials/tutorial_12_duke_heart_end_to_end_inference.py
@@ -259,6 +259,7 @@ if __name__ == "__main__":
         number_of_pca_components=number_of_pca_components,
         use_surface=False,
     )
+    fit_workflow.set_icp_transform_type(DUKE_HEART.icp_transform_type)
     fit_workflow.set_mask_dilation_mm(DUKE_HEART.mask_dilation_mm)
     fit_workflow.set_distancemap_squared_max(DUKE_HEART.distancemap_squared_max)
     if use_finetuned_weights:
@@ -273,8 +274,8 @@ if __name__ == "__main__":
 
     # The heart PCA model from Tutorial 6 (Duke Heart) is built from surfaces
     # only, so the model *is* a surface here: only the .vtp is written.
-    reference_mesh_file = output_dir / f"{case_id}_ssm_surface.vtp"
-    fit_result["registered_template_model_surface"].save(str(reference_mesh_file))
+    fitted_reference_mesh_file = output_dir / f"{case_id}_ssm_surface.vtp"
+    fit_result["fitted_reference_mesh"].save(str(fitted_reference_mesh_file))
     logger.info("Fitted the heart model to %s", reference_file.name)
     step_start = _record_step(step_times_s, "fit_shape_model", step_start)
 
@@ -293,7 +294,7 @@ if __name__ == "__main__":
         shape_parameters=pca_coefficients_file,
         stages=stages,
         output_directory=output_dir,
-        reference_mesh=reference_mesh_file,
+        fitted_reference_mesh=fitted_reference_mesh_file,
         reference_image=reference_labelmap,
         warp_interpolation="nearest",
         warp_background_value=0.0,
@@ -307,7 +308,7 @@ if __name__ == "__main__":
 
     tutorial_results: dict[str, Any] = dict(infer_result)
     tutorial_results["pca_coefficients_file"] = pca_coefficients_file
-    tutorial_results["reference_mesh_file"] = reference_mesh_file
+    tutorial_results["fitted_reference_mesh_file"] = fitted_reference_mesh_file
 
     # Testing: the fitted reference surface beside the first predicted stage.
     tt = TestTools(
@@ -318,7 +319,7 @@ if __name__ == "__main__":
     )
     tutorial_results["screenshots"] = [
         tt.save_screenshot_mesh(
-            cast(pv.DataSet, pv.read(str(reference_mesh_file))),
+            cast(pv.DataSet, pv.read(str(fitted_reference_mesh_file))),
             "fitted_reference_surface.png",
             camera_position="iso",
             color="steelblue",

--- a/tutorials/tutorial_12_lung_end_to_end_inference.py
+++ b/tutorials/tutorial_12_lung_end_to_end_inference.py
@@ -256,6 +256,7 @@ if __name__ == "__main__":
         number_of_pca_components=number_of_pca_components,
         use_surface=False,
     )
+    fit_workflow.set_icp_transform_type(LUNG_CT_DIRLAB.icp_transform_type)
     fit_workflow.set_mask_dilation_mm(LUNG_CT_DIRLAB.mask_dilation_mm)
     fit_workflow.set_distancemap_squared_max(LUNG_CT_DIRLAB.distancemap_squared_max)
     if use_finetuned_distancemap_weights:
@@ -272,8 +273,8 @@ if __name__ == "__main__":
 
     # The lung PCA model from Tutorial 6 is built from surfaces only, so the
     # model *is* a surface here: only the .vtp is written.
-    reference_mesh_file = output_dir / f"{case_id}_ssm_surface.vtp"
-    fit_result["registered_template_model_surface"].save(str(reference_mesh_file))
+    fitted_reference_mesh_file = output_dir / f"{case_id}_ssm_surface.vtp"
+    fit_result["fitted_reference_mesh"].save(str(fitted_reference_mesh_file))
     logger.info("Fitted the lung model to %s", reference_file.name)
     step_start = _record_step(step_times_s, "fit_shape_model", step_start)
 
@@ -290,7 +291,7 @@ if __name__ == "__main__":
         shape_parameters=pca_coefficients_file,
         stages=stages,
         output_directory=output_dir,
-        reference_mesh=reference_mesh_file,
+        fitted_reference_mesh=fitted_reference_mesh_file,
         reference_image=reference_image,
         warp_interpolation="linear",
         warp_background_value=-1000.0,
@@ -304,7 +305,7 @@ if __name__ == "__main__":
 
     tutorial_results: dict[str, Any] = dict(infer_result)
     tutorial_results["pca_coefficients_file"] = pca_coefficients_file
-    tutorial_results["reference_mesh_file"] = reference_mesh_file
+    tutorial_results["fitted_reference_mesh_file"] = fitted_reference_mesh_file
 
     # Testing: the fitted reference surface beside the first predicted stage.
     tt = TestTools(
@@ -315,7 +316,7 @@ if __name__ == "__main__":
     )
     tutorial_results["screenshots"] = [
         tt.save_screenshot_mesh(
-            cast(pv.DataSet, pv.read(str(reference_mesh_file))),
+            cast(pv.DataSet, pv.read(str(fitted_reference_mesh_file))),
             "fitted_reference_surface.png",
             camera_position="iso",
             color="steelblue",

--- a/tutorials/tutorial_13_heart_and_lung_motion.py
+++ b/tutorials/tutorial_13_heart_and_lung_motion.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
     lung_coefficients_file = (
         tutorial_07_lung_dir / "tutorial_07_lung_registered_coefficients.json"
     )
-    lung_reference_mesh_file = (
+    lung_fitted_reference_mesh_file = (
         tutorial_07_lung_dir / "tutorial_07_lung_template_surface_registered.vtp"
     )
 
@@ -274,7 +274,7 @@ if __name__ == "__main__":
             "tutorial_07_lung_fit_statistical_model_to_patient.py",
         ),
         (
-            lung_reference_mesh_file,
+            lung_fitted_reference_mesh_file,
             "tutorial_07_lung_fit_statistical_model_to_patient.py",
         ),
         (heart_pca_json, "tutorial_06_duke_heart_create_statistical_model.py"),
@@ -400,8 +400,12 @@ if __name__ == "__main__":
     # already did the equivalent for the lungs.
     heart_fit_dir = output_dir / "heart_fit"
     heart_coefficients_file = heart_fit_dir / "heart_registered_coefficients.json"
-    heart_reference_mesh_file = heart_fit_dir / "heart_template_surface_registered.vtp"
-    if not (heart_coefficients_file.exists() and heart_reference_mesh_file.exists()):
+    heart_fitted_reference_mesh_file = (
+        heart_fit_dir / "heart_template_surface_registered.vtp"
+    )
+    if not (
+        heart_coefficients_file.exists() and heart_fitted_reference_mesh_file.exists()
+    ):
         heart_fit_dir.mkdir(parents=True, exist_ok=True)
 
         # The whole heart minus its chamber cavities and the vessels whose
@@ -436,6 +440,7 @@ if __name__ == "__main__":
             labelmap_interior_object_ids=DUKE_HEART.interior_object_ids,
             log_level=log_level,
         )
+        heart_fit_workflow.set_icp_transform_type(DUKE_HEART.icp_transform_type)
         heart_fit_workflow.set_mask_dilation_mm(DUKE_HEART.mask_dilation_mm)
         heart_fit_workflow.set_distancemap_squared_max(
             DUKE_HEART.distancemap_squared_max
@@ -467,8 +472,8 @@ if __name__ == "__main__":
         )
         with heart_coefficients_file.open(mode="w", encoding="utf-8") as f:
             json.dump(heart_coefficients.tolist(), f)
-        heart_fit_result["registered_template_model_surface"].save(
-            str(heart_reference_mesh_file)
+        heart_fit_result["fitted_reference_mesh"].save(
+            str(heart_fitted_reference_mesh_file)
         )
         logger.info("Fitted the Duke heart model to %s", patient_image_file.name)
 
@@ -545,7 +550,7 @@ if __name__ == "__main__":
     def stage_transforms(
         model_directory: Path,
         coefficients_file: Path,
-        reference_mesh_file: Path,
+        fitted_reference_mesh_file: Path,
         stages: list[float],
         sigma_mm: float,
         tag: str,
@@ -578,7 +583,7 @@ if __name__ == "__main__":
             log_level=log_level,
         )
         reference_points = np.asarray(
-            pv.read(str(reference_mesh_file)).points, dtype=np.float64
+            pv.read(str(fitted_reference_mesh_file)).points, dtype=np.float64
         )
         forward_transforms: list[itk.Transform] = []
         inverse_transforms: list[itk.Transform] = []
@@ -590,7 +595,7 @@ if __name__ == "__main__":
                     shape_parameters=coefficients_file,
                     stage=float(stage),
                     reference_image=deformation_grid,
-                    reference_mesh=reference_mesh_file,
+                    fitted_reference_mesh=fitted_reference_mesh_file,
                     direction=direction,
                 )
                 for direction in directions
@@ -667,7 +672,7 @@ if __name__ == "__main__":
     respiratory_forward, respiratory_inverse, lung_surfaces = stage_transforms(
         lung_model_dir,
         lung_coefficients_file,
-        lung_reference_mesh_file,
+        lung_fitted_reference_mesh_file,
         respiratory_stages,
         respiratory_sigma_mm,
         "respiratory",
@@ -676,7 +681,7 @@ if __name__ == "__main__":
     cardiac_forward, cardiac_inverse, heart_surfaces = stage_transforms(
         heart_model_dir,
         heart_coefficients_file,
-        heart_reference_mesh_file,
+        heart_fitted_reference_mesh_file,
         cardiac_stages,
         cardiac_sigma_mm,
         "cardiac",

--- a/tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
+++ b/tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
@@ -47,8 +47,9 @@ the grid.
    over frames and structures).
 
 Every combination also carries ``displacement_rms_mm``,
-``displacement_95th_mm`` and ``displacement_max_mm``, the point-by-point distance between where the network
-puts each mesh point and where Tutorial 8 fitted it in that frame.  That is the
+``displacement_95th_mm`` and ``displacement_max_mm``, the point-by-point
+distance between where the network puts each mesh point and where Tutorial 8
+fitted it in that frame.  That is the
 column to read the sweep by: a perturbed coefficient can leave a chamber the
 same size in the same place and still move every point of it wrong, which the
 labelmap metrics cannot see and this one cannot miss.  Those three are

--- a/tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
+++ b/tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
@@ -1,0 +1,401 @@
+"""
+Tutorial 14 (Duke Heart, MGN): How Much Do the Shape Parameters Move the Motion?
+
+Purpose
+-------
+Tutorial 11 scores the inferred motion of the hold-out case at the shape
+parameters its statistical-model fit happened to land on --- one point in shape
+space.  This tutorial sweeps that point.  It perturbs the first few PCA
+coefficients over a grid, re-infers the whole cardiac cycle at every
+combination, and scores each one the way Tutorial 11 scores its single fit, so
+the CSV says how far Dice, volume and surface RMSE move when the shape
+parameters move.
+
+The case is ``ParametersDukeHeartLabelmaps.hold_out_case``, held out of every
+fit in this chain, so this measures the sensitivity of a generalizing prediction
+rather than of a recalled one.
+
+**Only the coefficients handed to the network change.**  The reference anatomy
+stays the Tutorial 8 fitted surface at every point of the grid; what the
+perturbed coefficients change is the displacement field the MeshGraphNet infers,
+and those displacements are applied to that one unmodified surface.  So the
+sweep isolates the network's sensitivity to its shape conditioning, with no
+shape difference of the patient's own anatomy mixed in.
+
+Because the reference surface, the reference labelmap and the acquired frames
+are the same for every combination, every combination is scored on the same
+evaluation grid, and the Dice and volume figures are directly comparable across
+the grid.
+
+1. Read the Tutorial 8 fit: the fitted SSM surface, held fixed for the whole
+   sweep, and the case's PCA coefficient vector, which is the center of the
+   grid.
+
+2. Build the grid: every combination of ``number_of_modes_to_vary`` offsets,
+   each running from ``-perturbation_range`` to ``+perturbation_range`` in steps
+   of ``perturbation_step``, in units of standard deviations.  The all-zero
+   combination is in the grid, so the unperturbed score comes out of the same
+   code path as every perturbed one.
+
+3. Score every combination with :class:`physiotwin4d.WorkflowEvaluateMovement`,
+   which carries the reference frame's labelmap into every other frame with that
+   combination's inferred deformation and compares the result, per chamber, to
+   the frame that was acquired.
+
+4. Write ``shape_sweep_metrics.csv`` (one row per combination, gated frame and
+   structure) and ``shape_sweep_summary.csv`` (one row per combination, averaged
+   over frames and structures).
+
+Every combination also carries ``displacement_rms_mm``,
+``displacement_95th_mm`` and ``displacement_max_mm``, the point-by-point distance between where the network
+puts each mesh point and where Tutorial 8 fitted it in that frame.  That is the
+column to read the sweep by: a perturbed coefficient can leave a chamber the
+same size in the same place and still move every point of it wrong, which the
+labelmap metrics cannot see and this one cannot miss.  Those three are
+pooled over the whole model; ``mean_displacement_rms_mm`` and
+``mean_displacement_95th_mm`` are the same error averaged over the
+chambers, each scored on the mesh points nearest to it.
+
+Cost
+----
+Every combination is a full time-series inference, deformation-field
+rasterization, warp, contour and metric pass, and the per-combination
+directories hold the warped labelmaps of every frame.  The default grid is
+``5 ** 2 = 25`` combinations, each costing one Tutorial 11 run: tens of
+minutes to hours in total, depending on the case, and a few gigabytes on disk.
+``number_of_modes_to_vary``, ``perturbation_step`` and ``evaluation_spacing_mm``
+are the knobs.  The acquired labelmaps are resampled and contoured once per
+combination even though they never change; that is the price of calling the
+scoring workflow unchanged.
+
+Extra Install Required
+----------------------
+PhysicsNeMo and PyTorch Geometric must be installed::
+
+    pip install "physiotwin4d[physicsnemo]"
+
+Data Required
+-------------
+  * ``data/Duke-Heart-4DLabelmaps/<case>/*_labelmap.nii.gz`` - gated frames
+  * ``output/tutorial_08_duke_heart/<case>/`` - Tutorial 8 SSM surface + coefficients
+  * ``network_weights/physicsnemo_mgn_duke_heart_motion/`` - Tutorial 9 checkpoint
+
+Outputs (under ``output/tutorial_14_duke_heart/<case>/``)
+---------------------------------------------------------
+  * ``shape_sweep_metrics.csv`` - one row per combination, frame and structure
+  * ``shape_sweep_summary.csv`` - one row per combination, with that
+    combination's pooled displacement error
+  * ``combo_{NNN}/shape_parameters.json`` - that combination's coefficients
+  * ``combo_{NNN}/evaluation_report.md``, ``evaluation_metrics.csv``,
+    ``volume_vs_stage.png`` - that combination's own Tutorial 11 style report
+  * ``combo_{NNN}/shape_parameters_s{TTT}_pred.vtp`` - predicted surface per frame
+  * ``combo_{NNN}/shape_parameters_s{TTT}_warped.mha`` - reference labelmap
+    carried to that frame
+"""
+
+# Imports
+from __future__ import annotations
+
+import csv
+import itertools
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Any, Optional, cast
+
+import numpy as np
+import pyvista as pv
+from parameters_duke_heart_labelmaps import DUKE_HEART
+
+from physiotwin4d import (
+    EvaluateMovementDukeHeart,
+    TestTools,
+    WorkflowEvaluateMovement,
+    WorkflowInferMovement,
+    WorkflowInferPhysicsNeMo,
+)
+
+
+def _offset_grid(
+    number_of_modes: int, perturbation_range: float, perturbation_step: float
+) -> list[tuple[float, ...]]:
+    """Every combination of per-mode offsets, in standard deviations.
+
+    Half a step is added to the stop so that ``+perturbation_range`` itself is on
+    the grid rather than falling off its floating-point edge.
+    """
+    offsets = np.arange(
+        -perturbation_range,
+        perturbation_range + perturbation_step / 2.0,
+        perturbation_step,
+    )
+    return [
+        tuple(float(offset) for offset in combination)
+        for combination in itertools.product(offsets, repeat=number_of_modes)
+    ]
+
+
+def _mean_of_measured(values: list[float]) -> float:
+    """Mean of the values that could be measured; ``nan`` when none could."""
+    measured = [value for value in values if not math.isnan(value)]
+    return float(np.mean(measured)) if measured else float("nan")
+
+
+# Only run if this script is not imported as a module
+
+# PhysicsNeMo and torch spawn worker processes. On Windows the spawn start
+# method re-imports this script in each child; without the
+# __name__ == "__main__" guard around top-level work, that re-import would
+# restart the whole sweep in every worker.
+if __name__ == "__main__":
+    # Data directory specification
+    repo_root = Path(__file__).resolve().parent.parent
+    tutorials_dir = Path(__file__).resolve().parent
+
+    class_name = "tutorial_14_duke_heart_shape_parameter_sweep"
+
+    # Case to sweep: the case held out of every fit in this chain.
+    case_id = DUKE_HEART.hold_out_case
+
+    # Fitted SSM surface and PCA coefficients written by Tutorial 8 (Duke Heart).
+    case_dir = tutorials_dir / "output" / "tutorial_08_duke_heart" / case_id
+    # Weights Tutorial 9 trained, and the checkpoint epoch to infer with; None
+    # uses the final weights.
+    model_dir = DUKE_HEART.mgn_weights_dir
+    epoch: Optional[int] = None
+
+    # Gaussian sigma, in mm, that spreads the predicted surface displacements
+    # into the continuous field the labelmap is resampled through.
+    smoothing_sigma_mm = 10.0
+    # Isotropic pitch every metric is measured on.  Coarser than these
+    # labelmaps, whose in-plane pitch is finer than the accuracy being reported,
+    # and still below the thinnest wall of the heart.
+    evaluation_spacing_mm = 1.0
+
+    output_dir = tutorials_dir / "output" / "tutorial_14_duke_heart" / case_id
+    log_level = logging.INFO
+
+    logging.basicConfig(level=log_level)
+    logger = logging.getLogger(class_name)
+
+    test_mode = TestTools.running_as_test()
+    labelmap_dir = DUKE_HEART.hold_out_directory(test_mode) / case_id
+
+    # The sweep itself.  The first modes carry the most variance, so varying
+    # them is what a shape-parameter study is about; the offsets are in standard
+    # deviations, the units the coefficients themselves are in.  The grid is
+    # every combination of them, so its size is
+    # (2 * range / step + 1) ** number_of_modes_to_vary and its cost grows the
+    # same way.
+    number_of_modes_to_vary = 2
+    perturbation_range = 2.0
+    perturbation_step = 1.0
+    if test_mode:
+        # Three combinations rather than twenty-five: the test asserts the sweep
+        # runs and reports, not that the grid is finely sampled.
+        number_of_modes_to_vary = 1
+        perturbation_range = 1.0
+
+    # Directory setup and data reading
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
+    pca_file = case_dir / f"{case_id}_ssm_pca_coefficients.json"
+    for required_file in (fitted_reference_mesh_file, pca_file):
+        if not required_file.exists():
+            raise FileNotFoundError(
+                f"Tutorial 8 output not found: {required_file}\n"
+                "Run tutorials/tutorial_08_duke_heart_fit_model_to_4d_patients.py "
+                "first."
+            )
+
+    # The cohort assembles what every combination is scored against: every gated
+    # frame's labelmap, the reference frame among them, and Tutorial 8's
+    # per-frame fits.  None of it depends on the perturbation, so it is read
+    # once for the whole sweep.
+    cohort = EvaluateMovementDukeHeart(log_level=log_level)
+    ground_truth = cohort.assemble_ground_truth(
+        case_id=case_id,
+        frame_directory=labelmap_dir,
+        fit_directory=case_dir,
+    )
+
+    # Step 1: the fit this sweep is centered on.  The surface is held fixed for
+    # every combination; only the coefficients below are perturbed.
+    baseline_coefficients = np.asarray(
+        json.loads(pca_file.read_text(encoding="utf-8")), dtype=np.float32
+    )
+    if number_of_modes_to_vary > len(baseline_coefficients):
+        raise ValueError(
+            f"Asked to vary {number_of_modes_to_vary} modes, but the fit has only "
+            f"{len(baseline_coefficients)} coefficients."
+        )
+
+    # Step 2: the grid of coefficient offsets.
+    combinations = _offset_grid(
+        number_of_modes_to_vary, perturbation_range, perturbation_step
+    )
+    logger.info(
+        "Sweeping the first %d mode(s) from %+.2f to %+.2f in steps of %.2f "
+        "standard deviations: %d combinations",
+        number_of_modes_to_vary,
+        -perturbation_range,
+        perturbation_range,
+        perturbation_step,
+        len(combinations),
+    )
+
+    # Step 3: score every combination.  The network is loaded once and reused,
+    # so the per-combination cost is inference and scoring alone.
+    infer_workflow = WorkflowInferPhysicsNeMo(
+        model_directory=model_dir, epoch=epoch, log_level=log_level
+    )
+    evaluate_workflow = WorkflowEvaluateMovement(
+        movement_workflow=WorkflowInferMovement(infer_workflow, log_level=log_level),
+        cohort=cohort,
+        log_level=log_level,
+    )
+
+    metric_rows: list[dict[str, Any]] = []
+    summary_rows: list[dict[str, Any]] = []
+    combination_dirs: list[Path] = []
+    first_surfaces: list[Path] = []
+
+    for index, offsets in enumerate(combinations):
+        combination_dir = output_dir / f"combo_{index:03d}"
+        combination_dir.mkdir(parents=True, exist_ok=True)
+        combination_dirs.append(combination_dir)
+
+        coefficients = baseline_coefficients.copy()
+        coefficients[:number_of_modes_to_vary] += np.asarray(offsets, dtype=np.float32)
+        coefficients_file = combination_dir / "shape_parameters.json"
+        with coefficients_file.open(mode="w", encoding="utf-8") as f:
+            json.dump(coefficients.tolist(), f)
+
+        result = evaluate_workflow.process(
+            case_id=case_id,
+            shape_parameters=coefficients_file,
+            fitted_reference_mesh=fitted_reference_mesh_file,
+            ground_truth=ground_truth,
+            output_directory=combination_dir,
+            smoothing_sigma_mm=smoothing_sigma_mm,
+            evaluation_spacing_mm=evaluation_spacing_mm,
+            # The one metric measured point by point, and the most responsive of
+            # them to a perturbed coefficient: the labelmap metrics see a chamber
+            # that stayed the same size, this sees every point that moved wrong.
+            include_displacement_error=True,
+        )
+        first_surfaces.append(Path(result["predicted_surfaces"][0]))
+
+        # The offsets say where in the grid the row is; the coefficients the
+        # workflow already stamped on it as pca_c01.. say what was actually fed
+        # to the network.
+        grid_position = {
+            f"mode_{mode:02d}_offset": offset for mode, offset in enumerate(offsets)
+        }
+        rows = [
+            {"combination": index, **grid_position, **row} for row in result["rows"]
+        ]
+        metric_rows.extend(rows)
+
+        summary: dict[str, Any] = {
+            "combination": index,
+            **grid_position,
+            **{
+                f"mode_{mode:02d}_coefficient": float(coefficients[mode])
+                for mode in range(number_of_modes_to_vary)
+            },
+            "mean_dice": _mean_of_measured([float(row["dice"]) for row in rows]),
+            "mean_volume_difference_percent": _mean_of_measured(
+                [float(row["volume_difference_percent"]) for row in rows]
+            ),
+            "mean_abs_volume_difference_percent": _mean_of_measured(
+                [abs(float(row["volume_difference_percent"])) for row in rows]
+            ),
+            "mean_surface_rmse_mm": _mean_of_measured(
+                [float(row["surface_rmse_mm"]) for row in rows]
+            ),
+            # Averaged over the structures, beside the same error pooled over
+            # every point of the whole model: a mean of structures and a pooled
+            # figure answer different questions, so both are kept.
+            "mean_displacement_rms_mm": _mean_of_measured(
+                [float(row["displacement_rms_mm"]) for row in rows]
+            ),
+            "mean_displacement_95th_mm": _mean_of_measured(
+                [float(row["displacement_95th_mm"]) for row in rows]
+            ),
+            "displacement_rms_mm": result["displacement_rms_mm"],
+            "displacement_95th_mm": result["displacement_95th_mm"],
+            "displacement_max_mm": result["displacement_max_mm"],
+            "n_rows": len(rows),
+        }
+        summary_rows.append(summary)
+
+        logger.info(
+            "combination %d/%d  offsets %s  dice=%.4f  dV=%+.2f%%  rmse=%.3f mm  "
+            "displacement rms=%.3f mm  95th=%.3f mm  max=%.3f mm  "
+            "(per structure: 95th=%.3f mm)",
+            index + 1,
+            len(combinations),
+            ", ".join(f"{offset:+.2f}" for offset in offsets),
+            summary["mean_dice"],
+            summary["mean_volume_difference_percent"],
+            summary["mean_surface_rmse_mm"],
+            summary["displacement_rms_mm"],
+            summary["displacement_95th_mm"],
+            summary["displacement_max_mm"],
+            summary["mean_displacement_95th_mm"],
+        )
+
+    # Step 4: the whole grid as two CSVs.
+    metrics_csv_file = output_dir / "shape_sweep_metrics.csv"
+    with metrics_csv_file.open(mode="w", newline="", encoding="utf-8") as f:
+        metrics_writer = csv.DictWriter(f, fieldnames=list(metric_rows[0].keys()))
+        metrics_writer.writeheader()
+        metrics_writer.writerows(metric_rows)
+
+    summary_csv_file = output_dir / "shape_sweep_summary.csv"
+    with summary_csv_file.open(mode="w", newline="", encoding="utf-8") as f:
+        summary_writer = csv.DictWriter(f, fieldnames=list(summary_rows[0].keys()))
+        summary_writer.writeheader()
+        summary_writer.writerows(summary_rows)
+
+    logger.info("Metrics: %s", metrics_csv_file)
+    logger.info("Summary: %s", summary_csv_file)
+
+    tutorial_results: dict[str, Any] = {
+        "rows": metric_rows,
+        "summary_rows": summary_rows,
+        "metrics_csv_file": metrics_csv_file,
+        "summary_csv_file": summary_csv_file,
+        "combination_directories": combination_dirs,
+    }
+
+    # Testing: the unperturbed prediction beside the most perturbed one, which
+    # is the difference the sweep is measuring.
+    grid_distances = [float(np.abs(offsets).sum()) for offsets in combinations]
+    baseline_index = int(np.argmin(grid_distances))
+    extreme_index = int(np.argmax(grid_distances))
+
+    tt = TestTools(
+        class_name=class_name,
+        results_dir=output_dir,
+        baselines_dir=repo_root / "tests" / "baselines" / class_name,
+        log_level=log_level,
+    )
+    tutorial_results["screenshots"] = [
+        tt.save_screenshot_mesh(
+            cast(pv.DataSet, pv.read(str(first_surfaces[baseline_index]))),
+            "unperturbed_surface.png",
+            camera_position="iso",
+            color="limegreen",
+        ),
+        tt.save_screenshot_mesh(
+            cast(pv.DataSet, pv.read(str(first_surfaces[extreme_index]))),
+            "perturbed_surface.png",
+            camera_position="iso",
+            color="orange",
+        ),
+    ]

--- a/tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
+++ b/tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
@@ -189,9 +189,9 @@ if __name__ == "__main__":
     # every combination of them, so its size is
     # (2 * range / step + 1) ** number_of_modes_to_vary and its cost grows the
     # same way.
-    number_of_modes_to_vary = 2
-    perturbation_range = 2.0
-    perturbation_step = 1.0
+    number_of_modes_to_vary = 1
+    perturbation_range = 4.0
+    perturbation_step = 2.0
     if test_mode:
         # Three combinations rather than twenty-five: the test asserts the sweep
         # runs and reports, not that the grid is finely sampled.

--- a/tutorials/tutorial_14_lung_shape_parameter_sweep.py
+++ b/tutorials/tutorial_14_lung_shape_parameter_sweep.py
@@ -54,8 +54,9 @@ Dice column to move far less across the grid than the volume and surface RMSE
 columns do.
 
 Every combination also carries ``displacement_rms_mm``,
-``displacement_95th_mm`` and ``displacement_max_mm``, the point-by-point distance between where the network
-puts each mesh point and where Tutorial 8 fitted it in that phase.  That is the
+``displacement_95th_mm`` and ``displacement_max_mm``, the point-by-point
+distance between where the network puts each mesh point and where Tutorial 8
+fitted it in that phase.  That is the
 column to read the sweep by: a perturbed coefficient can leave a lobe the same
 size in the same place and still move every point of it wrong, which the
 labelmap metrics cannot see and this one cannot miss.  Those three are

--- a/tutorials/tutorial_14_lung_shape_parameter_sweep.py
+++ b/tutorials/tutorial_14_lung_shape_parameter_sweep.py
@@ -1,0 +1,414 @@
+"""
+Tutorial 14 (Lung, MGN): How Much Do the Shape Parameters Move the Motion?
+
+Purpose
+-------
+Tutorial 11 scores the inferred motion of the hold-out case at the shape
+parameters its statistical-model fit happened to land on --- one point in shape
+space.  This tutorial sweeps that point.  It perturbs the first few PCA
+coefficients over a grid, re-infers the whole respiratory cycle at every
+combination, and scores each one the way Tutorial 11 scores its single fit, so
+the CSV says how far Dice, volume and surface RMSE move when the shape
+parameters move.
+
+The case is ``ParametersLungCTDirLab.mgn_hold_out_case``, held out of the
+Tutorial 9 training, so this measures the sensitivity of a generalizing
+prediction rather than of a recalled one.
+
+**Only the coefficients handed to the network change.**  The reference anatomy
+stays the Tutorial 8 fitted surface at every point of the grid; what the
+perturbed coefficients change is the displacement field the MeshGraphNet infers,
+and those displacements are applied to that one unmodified surface.  So the
+sweep isolates the network's sensitivity to its shape conditioning, with no
+shape difference of the patient's own anatomy mixed in.
+
+Because the reference surface, the reference labelmap and the acquired frames
+are the same for every combination, every combination is scored on the same
+evaluation grid, and the Dice and volume figures are directly comparable across
+the grid.
+
+1. Build the ground truth: segment every gated CT frame of the case
+   independently, giving one labelmap per respiratory phase whose lobes were
+   never seen by the shape model or by the network.  It does not depend on the
+   perturbation, so it is built once and cached for the whole sweep.
+
+2. Read the Tutorial 8 fit: the fitted SSM surface, held fixed for the whole
+   sweep, and the case's PCA coefficient vector, which is the center of the
+   grid.
+
+3. Build the grid: every combination of ``number_of_modes_to_vary`` offsets,
+   each running from ``-perturbation_range`` to ``+perturbation_range`` in steps
+   of ``perturbation_step``, in units of standard deviations.  The all-zero
+   combination is in the grid, so the unperturbed score comes out of the same
+   code path as every perturbed one.
+
+4. Score every combination with :class:`physiotwin4d.WorkflowEvaluateMovement`
+   and write ``shape_sweep_metrics.csv`` (one row per combination, phase and
+   lobe) and ``shape_sweep_summary.csv`` (one row per combination, averaged over
+   phases and lobes).
+
+Unlike Tutorial 11, Dice is reported here.  The caveat it states still holds ---
+a lobe barely changes shape over a breath compared to how big it is, so the
+overlap fraction stays above 0.96 whatever the prediction does --- so expect the
+Dice column to move far less across the grid than the volume and surface RMSE
+columns do.
+
+Every combination also carries ``displacement_rms_mm``,
+``displacement_95th_mm`` and ``displacement_max_mm``, the point-by-point distance between where the network
+puts each mesh point and where Tutorial 8 fitted it in that phase.  That is the
+column to read the sweep by: a perturbed coefficient can leave a lobe the same
+size in the same place and still move every point of it wrong, which the
+labelmap metrics cannot see and this one cannot miss.  Those three are
+pooled over the whole model; ``mean_displacement_rms_mm`` and
+``mean_displacement_95th_mm`` are the same error averaged over the
+lobes, each scored on the mesh points nearest to it.
+
+Cost
+----
+Every combination is a full time-series inference, deformation-field
+rasterization, warp, contour and metric pass, and the per-combination
+directories hold the warped labelmaps of every phase.  The default grid is
+``5 ** 2 = 25`` combinations, each costing one Tutorial 11 run: tens of
+minutes to hours in total, depending on the case, and a few gigabytes on disk.
+``number_of_modes_to_vary``, ``perturbation_step`` and ``evaluation_spacing_mm``
+are the knobs.  The acquired labelmaps are resampled and contoured once per
+combination even though they never change; that is the price of calling the
+scoring workflow unchanged.
+
+Extra Install Required
+----------------------
+PhysicsNeMo and PyTorch Geometric must be installed::
+
+    pip install "physiotwin4d[physicsnemo]"
+
+Data Required
+-------------
+  * ``data/DirLab-4DCT/<case>_T??.mha``  - the gated CT sequence
+  * ``output/tutorial_08_lung/<case>/``  - Tutorial 8 SSM surface + coefficients
+  * ``network_weights/physicsnemo_mgn_lung_motion/`` - Tutorial 9 checkpoint
+
+Outputs (under ``output/tutorial_14_lung/<case>/``)
+---------------------------------------------------
+  * ``shape_sweep_metrics.csv`` - one row per combination, phase and lobe
+  * ``shape_sweep_summary.csv`` - one row per combination, with that
+    combination's pooled displacement error
+  * ``ground_truth/<case>_T{PP}_labelmap.nii.gz`` - cached per-phase segmentation
+  * ``combo_{NNN}/shape_parameters.json`` - that combination's coefficients
+  * ``combo_{NNN}/evaluation_report.md``, ``evaluation_metrics.csv``,
+    ``volume_vs_stage.png`` - that combination's own Tutorial 11 style report
+  * ``combo_{NNN}/shape_parameters_s{TTT}_pred.vtp`` - predicted surface per phase
+  * ``combo_{NNN}/shape_parameters_s{TTT}_warped.mha`` - reference labelmap
+    carried to that phase
+"""
+
+# Imports
+from __future__ import annotations
+
+import csv
+import itertools
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Any, Optional, cast
+
+import numpy as np
+import pyvista as pv
+from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
+
+from physiotwin4d import (
+    EvaluateMovementLung,
+    TestTools,
+    WorkflowEvaluateMovement,
+    WorkflowInferMovement,
+    WorkflowInferPhysicsNeMo,
+)
+
+
+def _offset_grid(
+    number_of_modes: int, perturbation_range: float, perturbation_step: float
+) -> list[tuple[float, ...]]:
+    """Every combination of per-mode offsets, in standard deviations.
+
+    Half a step is added to the stop so that ``+perturbation_range`` itself is on
+    the grid rather than falling off its floating-point edge.
+    """
+    offsets = np.arange(
+        -perturbation_range,
+        perturbation_range + perturbation_step / 2.0,
+        perturbation_step,
+    )
+    return [
+        tuple(float(offset) for offset in combination)
+        for combination in itertools.product(offsets, repeat=number_of_modes)
+    ]
+
+
+def _mean_of_measured(values: list[float]) -> float:
+    """Mean of the values that could be measured; ``nan`` when none could."""
+    measured = [value for value in values if not math.isnan(value)]
+    return float(np.mean(measured)) if measured else float("nan")
+
+
+# Only run if this script is not imported as a module
+
+# nnUNetv2 and torch spawn worker processes. On Windows the spawn start method
+# re-imports this script in each child; without the __name__ == "__main__" guard
+# around top-level work, that re-import would restart the whole sweep in every
+# worker.
+if __name__ == "__main__":
+    # Data directory specification
+    repo_root = Path(__file__).resolve().parent.parent
+    tutorials_dir = Path(__file__).resolve().parent
+
+    class_name = "tutorial_14_lung_shape_parameter_sweep"
+
+    # Case to sweep: the case Tutorial 9 held out of training.
+    case_id = LUNG_CT_DIRLAB.mgn_hold_out_case
+    # Phase Tutorial 8 fitted the SSM to, and therefore the phase whose anatomy
+    # the predicted deformations carry into every other phase.
+    reference_phase = "T70"
+
+    # Fitted SSM surface and PCA coefficients written by Tutorial 8 (lung).
+    case_dir = tutorials_dir / "output" / "tutorial_08_lung" / case_id
+    # Weights Tutorial 9 trained, and the checkpoint epoch to infer with; None
+    # uses the final weights.
+    model_dir = LUNG_CT_DIRLAB.mgn_weights_dir
+    epoch: Optional[int] = None
+
+    # Gaussian sigma, in mm, that spreads the predicted surface displacements
+    # into the continuous field the labelmap is resampled through.
+    smoothing_sigma_mm = 10.0
+    # Isotropic pitch every metric is measured on.  Coarser than the CT, whose
+    # in-plane pitch is finer than the accuracy being reported, and fine enough
+    # that a lobe boundary is not quantized away.
+    evaluation_spacing_mm = 2.0
+
+    output_dir = tutorials_dir / "output" / "tutorial_14_lung" / case_id
+    ground_truth_dir = output_dir / "ground_truth"
+    log_level = logging.INFO
+
+    logging.basicConfig(level=log_level)
+    logger = logging.getLogger(class_name)
+
+    test_mode = TestTools.running_as_test()
+    data_dir = LUNG_CT_DIRLAB.input_directory(test_mode)
+
+    # The sweep itself.  The first modes carry the most variance, so varying
+    # them is what a shape-parameter study is about; the offsets are in standard
+    # deviations, the units the coefficients themselves are in.  The grid is
+    # every combination of them, so its size is
+    # (2 * range / step + 1) ** number_of_modes_to_vary and its cost grows the
+    # same way.
+    number_of_modes_to_vary = 2
+    perturbation_range = 2.0
+    perturbation_step = 1.0
+    if test_mode:
+        # Three combinations rather than twenty-five: the test asserts the sweep
+        # runs and reports, not that the grid is finely sampled.
+        number_of_modes_to_vary = 1
+        perturbation_range = 1.0
+
+    # Directory setup and data reading
+
+    ground_truth_dir.mkdir(parents=True, exist_ok=True)
+
+    fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
+    pca_file = case_dir / f"{case_id}_ssm_pca_coefficients.json"
+    for required_file in (fitted_reference_mesh_file, pca_file):
+        if not required_file.exists():
+            raise FileNotFoundError(
+                f"Tutorial 8 output not found: {required_file}\n"
+                "Run tutorials/tutorial_08_lung_fit_model_to_4d_patients.py first."
+            )
+
+    # The cohort assembles what every combination is scored against.  It does
+    # not depend on the perturbation, so it is read once for the whole sweep.
+    cohort = EvaluateMovementLung(reference_phase=reference_phase, log_level=log_level)
+    ground_truth = cohort.assemble_ground_truth(
+        case_id=case_id,
+        frame_directory=data_dir,
+        fit_directory=case_dir,
+        cache_directory=ground_truth_dir,
+    )
+
+    baseline_coefficients = np.asarray(
+        json.loads(pca_file.read_text(encoding="utf-8")), dtype=np.float32
+    )
+    if number_of_modes_to_vary > len(baseline_coefficients):
+        raise ValueError(
+            f"Asked to vary {number_of_modes_to_vary} modes, but the fit has only "
+            f"{len(baseline_coefficients)} coefficients."
+        )
+
+    # Step 3: the grid of coefficient offsets.
+    combinations = _offset_grid(
+        number_of_modes_to_vary, perturbation_range, perturbation_step
+    )
+    logger.info(
+        "Sweeping the first %d mode(s) from %+.2f to %+.2f in steps of %.2f "
+        "standard deviations: %d combinations",
+        number_of_modes_to_vary,
+        -perturbation_range,
+        perturbation_range,
+        perturbation_step,
+        len(combinations),
+    )
+
+    # Step 4: score every combination.  The network is loaded once and reused,
+    # so the per-combination cost is inference and scoring alone.
+    infer_workflow = WorkflowInferPhysicsNeMo(
+        model_directory=model_dir, epoch=epoch, log_level=log_level
+    )
+    evaluate_workflow = WorkflowEvaluateMovement(
+        movement_workflow=WorkflowInferMovement(infer_workflow, log_level=log_level),
+        cohort=cohort,
+        log_level=log_level,
+    )
+
+    metric_rows: list[dict[str, Any]] = []
+    summary_rows: list[dict[str, Any]] = []
+    combination_dirs: list[Path] = []
+    first_surfaces: list[Path] = []
+
+    for index, offsets in enumerate(combinations):
+        combination_dir = output_dir / f"combo_{index:03d}"
+        combination_dir.mkdir(parents=True, exist_ok=True)
+        combination_dirs.append(combination_dir)
+
+        coefficients = baseline_coefficients.copy()
+        coefficients[:number_of_modes_to_vary] += np.asarray(offsets, dtype=np.float32)
+        coefficients_file = combination_dir / "shape_parameters.json"
+        with coefficients_file.open(mode="w", encoding="utf-8") as f:
+            json.dump(coefficients.tolist(), f)
+
+        result = evaluate_workflow.process(
+            case_id=case_id,
+            shape_parameters=coefficients_file,
+            fitted_reference_mesh=fitted_reference_mesh_file,
+            ground_truth=ground_truth,
+            output_directory=combination_dir,
+            smoothing_sigma_mm=smoothing_sigma_mm,
+            evaluation_spacing_mm=evaluation_spacing_mm,
+            # Kept on, unlike Tutorial 11: a sweep over the shape parameters is
+            # asked to report Dice, so it does. It is the least responsive of
+            # the three columns for the reason Tutorial 11 leaves it out.
+            report_dice=True,
+            # The one metric measured point by point, and the most responsive of
+            # them to a perturbed coefficient: the labelmap metrics see a lobe
+            # that stayed the same size, this sees every point that moved wrong.
+            include_displacement_error=True,
+        )
+        first_surfaces.append(Path(result["predicted_surfaces"][0]))
+
+        # The offsets say where in the grid the row is; the coefficients the
+        # workflow already stamped on it as pca_c01.. say what was actually fed
+        # to the network.
+        grid_position = {
+            f"mode_{mode:02d}_offset": offset for mode, offset in enumerate(offsets)
+        }
+        rows = [
+            {"combination": index, **grid_position, **row} for row in result["rows"]
+        ]
+        metric_rows.extend(rows)
+
+        summary: dict[str, Any] = {
+            "combination": index,
+            **grid_position,
+            **{
+                f"mode_{mode:02d}_coefficient": float(coefficients[mode])
+                for mode in range(number_of_modes_to_vary)
+            },
+            "mean_dice": _mean_of_measured([float(row["dice"]) for row in rows]),
+            "mean_volume_difference_percent": _mean_of_measured(
+                [float(row["volume_difference_percent"]) for row in rows]
+            ),
+            "mean_abs_volume_difference_percent": _mean_of_measured(
+                [abs(float(row["volume_difference_percent"])) for row in rows]
+            ),
+            "mean_surface_rmse_mm": _mean_of_measured(
+                [float(row["surface_rmse_mm"]) for row in rows]
+            ),
+            # Averaged over the structures, beside the same error pooled over
+            # every point of the whole model: a mean of structures and a pooled
+            # figure answer different questions, so both are kept.
+            "mean_displacement_rms_mm": _mean_of_measured(
+                [float(row["displacement_rms_mm"]) for row in rows]
+            ),
+            "mean_displacement_95th_mm": _mean_of_measured(
+                [float(row["displacement_95th_mm"]) for row in rows]
+            ),
+            "displacement_rms_mm": result["displacement_rms_mm"],
+            "displacement_95th_mm": result["displacement_95th_mm"],
+            "displacement_max_mm": result["displacement_max_mm"],
+            "n_rows": len(rows),
+        }
+        summary_rows.append(summary)
+
+        logger.info(
+            "combination %d/%d  offsets %s  dice=%.4f  dV=%+.2f%%  rmse=%.3f mm  "
+            "displacement rms=%.3f mm  95th=%.3f mm  max=%.3f mm  "
+            "(per structure: 95th=%.3f mm)",
+            index + 1,
+            len(combinations),
+            ", ".join(f"{offset:+.2f}" for offset in offsets),
+            summary["mean_dice"],
+            summary["mean_volume_difference_percent"],
+            summary["mean_surface_rmse_mm"],
+            summary["displacement_rms_mm"],
+            summary["displacement_95th_mm"],
+            summary["displacement_max_mm"],
+            summary["mean_displacement_95th_mm"],
+        )
+
+    # Step 5: the whole grid as two CSVs.
+    metrics_csv_file = output_dir / "shape_sweep_metrics.csv"
+    with metrics_csv_file.open(mode="w", newline="", encoding="utf-8") as f:
+        metrics_writer = csv.DictWriter(f, fieldnames=list(metric_rows[0].keys()))
+        metrics_writer.writeheader()
+        metrics_writer.writerows(metric_rows)
+
+    summary_csv_file = output_dir / "shape_sweep_summary.csv"
+    with summary_csv_file.open(mode="w", newline="", encoding="utf-8") as f:
+        summary_writer = csv.DictWriter(f, fieldnames=list(summary_rows[0].keys()))
+        summary_writer.writeheader()
+        summary_writer.writerows(summary_rows)
+
+    logger.info("Metrics: %s", metrics_csv_file)
+    logger.info("Summary: %s", summary_csv_file)
+
+    tutorial_results: dict[str, Any] = {
+        "rows": metric_rows,
+        "summary_rows": summary_rows,
+        "metrics_csv_file": metrics_csv_file,
+        "summary_csv_file": summary_csv_file,
+        "combination_directories": combination_dirs,
+        "ground_truth_labelmap_dir": ground_truth_dir,
+    }
+
+    # Testing: the unperturbed prediction beside the most perturbed one, which
+    # is the difference the sweep is measuring.
+    grid_distances = [float(np.abs(offsets).sum()) for offsets in combinations]
+    baseline_index = int(np.argmin(grid_distances))
+    extreme_index = int(np.argmax(grid_distances))
+
+    tt = TestTools(
+        class_name=class_name,
+        results_dir=output_dir,
+        baselines_dir=repo_root / "tests" / "baselines" / class_name,
+        log_level=log_level,
+    )
+    tutorial_results["screenshots"] = [
+        tt.save_screenshot_mesh(
+            cast(pv.DataSet, pv.read(str(first_surfaces[baseline_index]))),
+            "unperturbed_surface.png",
+            camera_position="iso",
+            color="limegreen",
+        ),
+        tt.save_screenshot_mesh(
+            cast(pv.DataSet, pv.read(str(first_surfaces[extreme_index]))),
+            "perturbed_surface.png",
+            camera_position="iso",
+            color="orange",
+        ),
+    ]

--- a/tutorials/tutorial_15_duke_heart_leave_one_out.py
+++ b/tutorials/tutorial_15_duke_heart_leave_one_out.py
@@ -1,0 +1,907 @@
+"""
+Tutorial 15 (Duke Heart, MGN): Leave-One-Out Cross-Validation of the Whole Chain
+
+Purpose
+-------
+Duke counterpart of ``tutorial_15_lung_leave_one_out.py``.  Tutorials 6 -> 8 ->
+9 -> 11 report accuracy for one fixed held-out case; this runs the same chain
+once per fold, holding out a different patient each time, and reports the mean
+and spread of the metrics across folds.
+
+Each fold is a full re-run, not a re-score of a shared model:
+
+1. Build a PCA statistical shape model from the population *without* the
+   held-out case (``WorkflowCreateMeanSurface`` then
+   ``WorkflowCreateStatisticalModel``).  Rebuilding is the whole point --- a
+   model built once from everyone has already seen every case, so scoring
+   against it measures recall rather than generalization.
+
+2. Fit that fold's model to every case, held-out one included, and propagate
+   each fit through the gated cardiac frames.  This cohort ships labelmaps
+   rather than CT, so there is no intensity image to register: each frame's
+   heart surface is contoured and the fitted SSM surface is registered to it
+   with ``RegisterModelsDistanceMaps``, which warps the SSM while keeping its
+   topology.
+
+3. Train a MeshGraphNet on the other cases' frames
+   (``WorkflowTrainPhysicsNeMo`` driving ``TrainPhysicsNeMoMGN``).
+
+4. Infer the held-out case at every gated frame and score it against that
+   frame's acquired labelmap --- Dice, volume difference and surface RMSE per
+   chamber (``WorkflowEvaluateMovement``), plus, also per chamber, the
+   distance between where the network puts each mesh point and where this
+   fold's own fit put it.
+
+Then every fold's rows are pooled into ``loo_metrics.csv`` and summarized per
+chamber in ``loo_report.md``, which also carries each fold's displacement error, its
+RMS, 95th percentile and maximum.
+That last measure is the point-by-point one: a fold can keep every chamber the
+right size and still put all of them in the wrong place, and only it says so.
+
+The shape model this network moves is one structure, the whole heart minus its
+chamber cavities, so the chambers exist only in the acquired labelmaps.  Going
+through the labelmaps rather than through the model's surface is what makes
+per-chamber scores possible at all.
+
+What is *not* recomputed per fold
+---------------------------------
+The per-frame heart contours and the remeshed model-population surfaces do not
+depend on which case is held out, so they are contoured once into ``shared/``
+and reused by every fold.  Tutorial 4's surfaces are read in place of the cache
+when they exist.
+
+Unlike the lung variant, the *phase propagation* here cannot be hoisted: it
+registers the fold's own fitted SSM surface to each frame, and that surface
+changes with the fold.  This is why a Duke fold costs materially more than a
+lung fold.
+
+Multi-GPU
+---------
+Launch under ``torchrun`` and every rank runs this script:
+
+    torchrun --standalone --nproc_per_node=8 \\
+        tutorials/tutorial_15_duke_heart_leave_one_out.py
+
+Training is then data-parallel across the ranks (``DistributedDataParallel``
+inside ``WorkflowTrainPhysicsNeMo``), and the per-case contouring, fitting and
+frame-registration loops are split across the ranks a case at a time.  Run
+without a launcher and the same script runs as a single process.
+
+Extra Install Required
+----------------------
+PhysicsNeMo and PyTorch Geometric must be installed::
+
+    pip install "physiotwin4d[physicsnemo]"
+
+Data Required
+-------------
+  * ``data/Duke-Heart-4DLabelmaps/pm????/*_labelmap.nii.gz`` - the whole cohort,
+    one directory per case with exactly one ``*_ref_labelmap.nii.gz`` frame
+  * Nothing from Tutorials 4, 6, 8 or 9.  Their outputs are reused as a cache
+    when present, but this tutorial contours everything it needs.
+
+Outputs (under ``tutorials/output/tutorial_15_duke_heart/``)
+------------------------------------------------------------
+  * ``loo_metrics.csv``           - every metric row of every fold
+  * ``loo_report.md``             - per-chamber mean +/- std across folds,
+    displacement 95th percentile included, plus each fold's whole-model error
+  * ``loo_metrics_by_label.png``  - the same, as a per-chamber box plot
+  * ``fold_<case>/``              - that fold's shape model, fits and weights
+  * ``shared/``                   - the fold-independent contours
+
+Runtime
+-------
+The long pole is the per-fold frame registration: roughly one distance-map ICON
+registration per case per gated frame, across the whole cohort, repeated for
+every fold.  Splitting the cases across ranks divides that by the rank count.
+Training adds one MeshGraphNet run per fold on top.  Expect five folds to run
+overnight even on eight GPUs.
+"""
+
+# Imports
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Any, cast
+
+import itk
+import numpy as np
+import pyvista as pv
+from parameters_duke_heart_labelmaps import DUKE_HEART
+
+from physiotwin4d import (
+    ContourTools,
+    DistributedContext,
+    RegisterModelsDistanceMaps,
+    EvaluateMovementDukeHeart,
+    TestTools,
+    TrainPhysicsNeMoMGN,
+    WorkflowCreateMeanSurface,
+    WorkflowCreateStatisticalModel,
+    WorkflowEvaluateMovement,
+    WorkflowFitStatisticalModelToPatient,
+    WorkflowInferMovement,
+    WorkflowInferPhysicsNeMo,
+    WorkflowTrainPhysicsNeMo,
+    distributed_context,
+)
+
+# Structure name Tutorial 4 (Duke Heart) writes its whole-heart surfaces under.
+WHOLE_HEART_NAME = "heart_minus_interior_chambers"
+LABELMAP_SUFFIX = "_labelmap.nii.gz"
+
+# The four chambers, plus the myocardium and the whole heart for context: 5 and
+# 6 are what the shape model itself represents, 1-4 are the cavities it does
+# not.  The great vessels and coronaries (7-10) are left out; they come and go
+# between frames and are not part of the model.
+HEART_LABEL_IDS = [1, 2, 3, 4, 5, 6]
+
+# Point-data array the tutorial writes its targets into and the manifests name.
+TARGET_ARRAY = "displacement"
+
+# Gated frames carry a ``g{PPP}`` tag naming their percentage of the R-R
+# interval; this is what a per-frame SSM surface is matched and staged by.
+PHASE_SURFACE_PATTERN = "*_g[0-9][0-9][0-9]_*_ssm_surface.vtp"
+
+
+def _cardiac_stage_from_filename(frame_file: Path) -> float:
+    """Extract the normalized cardiac stage [0, 1] from a ``g{PPP}`` filename stem."""
+    for part in frame_file.name.split("_"):
+        if part.startswith("g") and part[1:].isdigit():
+            return int(part[1:]) / 100.0
+    raise ValueError(f"Cannot parse cardiac gate from filename: {frame_file}")
+
+
+def _rank_share(items: list[Any], context: DistributedContext) -> list[Any]:
+    """Return the slice of ``items`` this rank is responsible for.
+
+    Every rank writes to its own cases' directories and the caller waits on a
+    barrier afterwards, so the ranks never contend for a file.
+    """
+    return items[context.rank :: context.world_size]
+
+
+def _write_target_mesh(
+    phase_file: Path, ref_points: np.ndarray, targets_dir: Path
+) -> Path:
+    """Write one frame's training target and return the mesh path.
+
+    The target is the per-vertex displacement from the case's reference surface,
+    stored as the ``TARGET_ARRAY`` point-data array on a copy of the frame
+    surface.  The training workflow reads whatever array the manifest names and
+    never derives one.
+    """
+    phase_mesh = pv.read(str(phase_file))
+    phase_points = np.asarray(phase_mesh.points, dtype=np.float32)
+    phase_mesh.point_data[TARGET_ARRAY] = phase_points - ref_points
+    target_path = targets_dir / f"{phase_file.stem}_target.vtp"
+    phase_mesh.save(str(target_path))
+    return target_path
+
+
+def _write_case_manifest(case_dir: Path, manifests_dir: Path) -> Path:
+    """Write one case's training manifest and return its path."""
+    case_id = case_dir.name
+    fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
+    phase_files = sorted(case_dir.glob(PHASE_SURFACE_PATTERN))
+    manifests_dir.mkdir(parents=True, exist_ok=True)
+    ref_points = np.asarray(
+        pv.read(str(fitted_reference_mesh_file)).points, dtype=np.float32
+    )
+    manifest = {
+        "subject_id": case_id,
+        "fitted_reference_mesh": str(fitted_reference_mesh_file),
+        "pca_coefficients": str(case_dir / f"{case_id}_ssm_pca_coefficients.json"),
+        "target_array": TARGET_ARRAY,
+        "phases": [
+            {
+                "mesh": str(_write_target_mesh(phase_file, ref_points, manifests_dir)),
+                "stage": _cardiac_stage_from_filename(phase_file),
+            }
+            for phase_file in phase_files
+        ],
+    }
+    manifest_path = manifests_dir / f"{case_id}_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest_path
+
+
+def _summarize(values: list[float]) -> tuple[float, float, int]:
+    """Return ``(mean, sample standard deviation, count)`` ignoring NaNs.
+
+    One fold cannot have a spread, so its standard deviation is reported as 0.0
+    rather than left undefined.
+    """
+    finite = [value for value in values if np.isfinite(value)]
+    if not finite:
+        return float("nan"), float("nan"), 0
+    mean = float(np.mean(finite))
+    std = float(np.std(finite, ddof=1)) if len(finite) > 1 else 0.0
+    return mean, std, len(finite)
+
+
+def _write_loo_report(
+    rows: list[dict[str, Any]],
+    held_out_cases: list[str],
+    label_names: dict[int, str],
+    report_file: Path,
+) -> None:
+    """Write the per-chamber cross-fold summary.
+
+    Each fold contributes one number per structure --- the mean over that fold's
+    frames --- and the reported spread is across those per-fold numbers.
+    Pooling every frame of every fold instead would let a case with more gated
+    frames weigh more heavily than the others.
+    """
+    metrics = [
+        ("dice", "Dice", "{:.4f}"),
+        ("volume_difference_percent", "|volume difference| (%)", "{:.2f}"),
+        ("surface_rmse_mm", "surface RMSE (mm)", "{:.3f}"),
+        ("displacement_95th_mm", "displacement 95th percentile (mm)", "{:.3f}"),
+    ]
+    lines = [
+        "# Leave-One-Out Cross-Validation: Duke Heart Motion",
+        "",
+        f"Folds: {len(held_out_cases)}",
+        f"Held-out cases: {', '.join(held_out_cases)}",
+        "",
+        "Each fold rebuilt the shape model without its held-out case, refitted "
+        "the cohort, retrained the MeshGraphNet and scored that case against "
+        "its own acquired labelmaps. Every cell is the mean over folds of the "
+        "fold's own mean over frames, plus or minus the standard deviation "
+        "across folds.",
+        "",
+        "| Structure | " + " | ".join(title for _, title, _ in metrics) + " |",
+        "|---|" + "---|" * len(metrics),
+    ]
+    for label in sorted(label_names):
+        cells = []
+        for key, _, fmt in metrics:
+            per_fold = []
+            for case_id in held_out_cases:
+                fold_values = [
+                    abs(float(row[key]))
+                    for row in rows
+                    if row["held_out_case"] == case_id
+                    and int(row["label_id"]) == label
+                    and np.isfinite(float(row[key]))
+                ]
+                if fold_values:
+                    per_fold.append(float(np.mean(fold_values)))
+            mean, std, count = _summarize(per_fold)
+            cells.append(
+                "n/a" if count == 0 else f"{fmt.format(mean)} +/- {fmt.format(std)}"
+            )
+        lines.append(f"| {label_names[label]} | " + " | ".join(cells) + " |")
+
+    lines.extend(["", "## Pooled over all structures", ""])
+    for key, title, fmt in metrics:
+        values = [abs(float(row[key])) for row in rows if np.isfinite(float(row[key]))]
+        mean, std, count = _summarize(values)
+        lines.append(
+            f"- {title}: "
+            + ("n/a" if count == 0 else f"{fmt.format(mean)} +/- {fmt.format(std)}")
+            + f"  (n={count} rows)"
+        )
+
+    lines.extend(_displacement_error_lines(rows, held_out_cases))
+    report_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _displacement_error_lines(
+    rows: list[dict[str, Any]], held_out_cases: list[str]
+) -> list[str]:
+    """Per-fold displacement error, one number per fold rather than per structure.
+
+    The error is measured on the whole shape model at once, so every row of a
+    fold carries the same ``fold_displacement_*`` figures; the fold is the unit
+    here, while each row's own ``displacement_*`` columns are its stage's.
+    """
+    per_fold: list[tuple[str, float, float, float]] = []
+    for case_id in held_out_cases:
+        fold_rows = [row for row in rows if row["held_out_case"] == case_id]
+        if fold_rows and np.isfinite(float(fold_rows[0]["fold_displacement_rms_mm"])):
+            per_fold.append(
+                (
+                    case_id,
+                    float(fold_rows[0]["fold_displacement_rms_mm"]),
+                    float(fold_rows[0]["fold_displacement_95th_mm"]),
+                    float(fold_rows[0]["fold_displacement_max_mm"]),
+                )
+            )
+    if not per_fold:
+        return []
+
+    mean, std, _ = _summarize([rms for _, rms, _, _ in per_fold])
+    p95_mean, p95_std, _ = _summarize([p95 for _, _, p95, _ in per_fold])
+    lines = [
+        "",
+        "## Displacement error, per fold",
+        "",
+        "Distance between where the network puts each mesh point of the held-out "
+        "case and where that fold's own fit put it, pooled over every point and "
+        "frame. Measured point by point, so a chamber predicted the right size "
+        "in the wrong place is scored here and nowhere above.",
+        "",
+        f"- RMS across folds: {mean:.3f} +/- {std:.3f} mm",
+        f"- 95th percentile across folds: {p95_mean:.3f} +/- {p95_std:.3f} mm",
+        f"- Worst fold: {max(maximum for _, _, _, maximum in per_fold):.3f} mm",
+        "",
+        "| Held-out case | RMS (mm) | 95th percentile (mm) | Max (mm) |",
+        "|---|---:|---:|---:|",
+    ]
+    lines += [
+        f"| {case_id} | {rms:.3f} | {p95:.3f} | {maximum:.3f} |"
+        for case_id, rms, p95, maximum in per_fold
+    ]
+    return lines
+
+
+def _plot_metrics_by_label(
+    rows: list[dict[str, Any]], label_names: dict[int, str], plot_file: Path
+) -> Path:
+    """Box-plot each metric per structure, one box over every scored frame."""
+    import matplotlib.pyplot as plt
+
+    metrics = [
+        ("dice", "Dice"),
+        ("volume_difference_percent", "|volume difference| (%)"),
+        ("surface_rmse_mm", "surface RMSE (mm)"),
+        ("displacement_95th_mm", "displacement 95th percentile (mm)"),
+    ]
+    labels = sorted(label_names)
+    fig, axes = plt.subplots(1, len(metrics), figsize=(17.0, 4.5))
+    try:
+        for ax, (key, title) in zip(axes, metrics):
+            data = [
+                [
+                    abs(float(row[key]))
+                    for row in rows
+                    if int(row["label_id"]) == label and np.isfinite(float(row[key]))
+                ]
+                for label in labels
+            ]
+            # A structure absent from every acquired frame has no box to draw;
+            # give it an empty slot so the tick labels stay aligned.
+            ax.boxplot([values or [np.nan] for values in data], showmeans=True)
+            ax.set_xticklabels(
+                [label_names[label] for label in labels], rotation=30, ha="right"
+            )
+            ax.set_title(title)
+            ax.grid(axis="y", alpha=0.3)
+        fig.tight_layout()
+        fig.savefig(str(plot_file), dpi=110)
+    finally:
+        plt.close(fig)
+    return plot_file
+
+
+# Only run if this script is not imported as a module
+
+# The registration backends and torch spawn worker processes. On Windows the
+# spawn start method re-imports this script in each child; without the
+# __name__ == "__main__" guard around top-level work, that re-import would
+# restart the whole study in every worker.
+if __name__ == "__main__":
+    # Data directory specification
+    repo_root = Path(__file__).resolve().parent.parent
+    tutorials_dir = Path(__file__).resolve().parent
+
+    class_name = "tutorial_15_duke_heart_leave_one_out"
+
+    # Number of folds. Each holds out one patient and re-runs the entire chain
+    # without them, so the runtime is linear in this.
+    number_of_leave_one_out_runs = 5
+
+    # Atlas iterations used to build each fold's reference surface; 1 is a
+    # single template-biased pass.
+    mean_surface_iterations = 3
+
+    # Training hyperparameters, matching Tutorial 9 (duke heart) so a fold's
+    # network is comparable to the one that tutorial trains.
+    epochs = 1500
+    batch_size = 8  # mini-batch measured in (case, frame) graphs
+    learning_rate = 1.0e-3
+    processor_size = 3  # message-passing hops
+    hidden_dim = 128
+    num_layers = 2  # MLP layers inside each encoder / processor / decoder block
+
+    # Pitch of the grid the frame distance maps are rasterized on. Coarser than
+    # the contouring pitch: it carries a distance field, not a boundary.
+    registration_spacing_mm = 1.0
+
+    # Gaussian sigma, in mm, that spreads the predicted surface displacements
+    # into the continuous field the labelmap is resampled through.
+    smoothing_sigma_mm = 10.0
+    # Isotropic pitch every metric is measured on. Coarser than these
+    # labelmaps, whose in-plane pitch is finer than the accuracy being
+    # reported, and still below the thinnest wall of the heart.
+    evaluation_spacing_mm = 1.0
+
+    output_dir = tutorials_dir / "output" / "tutorial_15_duke_heart"
+    shared_dir = output_dir / "shared"
+    log_level = logging.INFO
+
+    logging.basicConfig(level=log_level)
+    logger = logging.getLogger(class_name)
+
+    # Under torchrun / SLURM / mpirun this is one rank of many; started plainly
+    # it reports a world of one and every branch below collapses to a single
+    # process.
+    context = distributed_context()
+
+    test_mode = TestTools.running_as_test()
+    data_dir = DUKE_HEART.hold_out_directory(test_mode)
+    tutorial_04_dir = DUKE_HEART.input_directory(test_mode)
+    number_of_pca_components = DUKE_HEART.pca_components(test_mode)
+
+    # Labels left out of the whole-heart structure, the same ones Tutorials 4,
+    # 6 and 8 drop, so the frames and the model describe the same structure.
+    interior_object_ids = DUKE_HEART.interior_object_ids
+
+    # In test mode, run the smallest study that is still a cross-validation and
+    # train for a couple of epochs, to keep the run inside the pytest timeout.
+    if test_mode:
+        number_of_leave_one_out_runs = 2
+        mean_surface_iterations = 1
+        epochs = 2
+
+    # Distance-map weights finetuned by
+    # tutorial_02_duke_heart_distancemap_finetune_icon.py, used both by the
+    # labelmap-to-labelmap stage of the SSM fit and by the frame registrations.
+    icon_weights_path = (
+        tutorials_dir
+        / "network_weights"
+        / "icon_duke_heart_distancemap"
+        / "icon_duke_heart_distancemap_model"
+        / "checkpoints"
+        / "network_weights_final.trch"
+    )
+
+    # Directory setup and data reading
+
+    contour_dir = shared_dir / "contours"
+    samples_dir = shared_dir / "model_samples"
+    if context.is_main:
+        for directory in (contour_dir, samples_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+    context.barrier()
+
+    case_dirs = sorted(
+        path for path in data_dir.glob("pm[0-9][0-9][0-9][0-9]") if path.is_dir()
+    )
+    if not case_dirs:
+        raise FileNotFoundError(
+            f"No pm???? case directories found under {data_dir}.\n"
+            "See data/Duke-Heart-4DLabelmaps/README.md."
+        )
+
+    def reference_frame_file(case_dir: Path) -> Path:
+        """Return the case's reference frame, the one every fit starts from."""
+        matches = sorted(case_dir.glob(f"*_ref{LABELMAP_SUFFIX}"))
+        if not matches:
+            raise FileNotFoundError(
+                f"No *_ref{LABELMAP_SUFFIX} frame in {case_dir}; the SSM is "
+                "fitted to that frame, so it is the one every deformation "
+                "starts from."
+            )
+        return matches[0]
+
+    case_dirs = [
+        path for path in case_dirs if sorted(path.glob(f"*_ref{LABELMAP_SUFFIX}"))
+    ]
+    case_ids = [path.name for path in case_dirs]
+    case_dir_by_id = dict(zip(case_ids, case_dirs))
+    if len(case_ids) < 3:
+        raise RuntimeError(
+            f"Found only {len(case_ids)} case(s) with a reference frame under "
+            f"{data_dir}; a fold needs one case to hold out and at least two to "
+            "build a shape model from."
+        )
+    if number_of_leave_one_out_runs > len(case_ids):
+        raise ValueError(
+            f"number_of_leave_one_out_runs is {number_of_leave_one_out_runs} but "
+            f"only {len(case_ids)} cases are available under {data_dir}."
+        )
+    held_out_cases = case_ids[:number_of_leave_one_out_runs]
+    logger.info(
+        "%d cases, %d folds; holding out %s",
+        len(case_ids),
+        len(held_out_cases),
+        ", ".join(held_out_cases),
+    )
+
+    use_finetuned_weights = icon_weights_path.exists()
+    if not use_finetuned_weights:
+        logger.warning(
+            "Finetuned distance-map ICON weights not found at %s; registering "
+            "with the stock uniGradICON weights. Run "
+            "tutorials/tutorial_02_duke_heart_distancemap_finetune_icon.py to "
+            "create them.",
+            icon_weights_path,
+        )
+
+    contour_tools = ContourTools(log_level=log_level)
+
+    # The cohort names the structures every fold reports and, in Step 5, reads
+    # each fold's ground truth: the acquired labelmaps and this fold's own fits.
+    cohort = EvaluateMovementDukeHeart(log_level=log_level)
+    heart_names = cohort.label_names()
+
+    def heart_surface_for(labelmap_file: Path) -> Path:
+        """Return the path to one frame's whole heart, minus its chamber cavities.
+
+        Tutorial 4's ``"full"`` pass contours this surface for every gated
+        frame, so its output is used when present.  Otherwise the surface is
+        contoured into the shared cache, which no fold recomputes: the contour
+        of an acquired frame does not depend on which case was held out.
+        """
+        stem = labelmap_file.name[: -len(LABELMAP_SUFFIX)]
+        tutorial_04_file = tutorial_04_dir / f"{stem}_{WHOLE_HEART_NAME}.vtp"
+        if tutorial_04_file.exists():
+            return tutorial_04_file
+
+        surface_file = contour_dir / f"{stem}_heart_surface.vtp"
+        if not surface_file.exists():
+            labelmap = itk.imread(str(labelmap_file))
+            labels = itk.GetArrayViewFromImage(labelmap)
+            heart_ids = [
+                int(value)
+                for value in np.unique(labels)
+                if value != 0 and int(value) not in interior_object_ids
+            ]
+            heart_mask = itk.GetImageFromArray(
+                np.isin(labels, heart_ids).astype(np.uint8)
+            )
+            heart_mask.CopyInformation(labelmap)
+            contour_tools.extract_label_surfaces(
+                heart_mask,
+                isotropic_spacing_mm=DUKE_HEART.surface_spacing_mm,
+                smoothing_iterations=DUKE_HEART.surface_smoothing_iterations,
+            )[1].save(str(surface_file))
+        return surface_file
+
+    # Step 1: the shared cache. Contouring a frame and remeshing a case's
+    # reference surface to the model's point budget are both independent of
+    # which case is held out, so they happen once. Cases are split across the
+    # ranks; the barrier below is what lets every rank read every case's files.
+    for case_id in _rank_share(case_ids, context):
+        case_dir = case_dir_by_id[case_id]
+        for frame_file in sorted(case_dir.glob(f"*{LABELMAP_SUFFIX}")):
+            heart_surface_for(frame_file)
+
+        # The population surface: the model's fixed point budget, which the
+        # contours carry thirty times over. See the parameters module.
+        sample_file = samples_dir / f"{case_id}_ref_model_surface.vtp"
+        if not sample_file.exists():
+            surface = cast(
+                pv.PolyData,
+                pv.read(str(heart_surface_for(reference_frame_file(case_dir)))),
+            )
+            contour_tools.remesh_and_smooth_surface(
+                surface, 1.0 - DUKE_HEART.model_points / surface.n_points, 0
+            ).save(str(sample_file))
+    context.barrier()
+
+    # Steps 2-5: one fold per held-out case.
+    all_rows: list[dict[str, Any]] = []
+    fold_results: dict[str, Any] = {}
+
+    for fold_index, held_out_case in enumerate(held_out_cases):
+        logger.info("%s", "=" * 48)
+        logger.info(
+            "Fold %d/%d: holding out %s",
+            fold_index + 1,
+            len(held_out_cases),
+            held_out_case,
+        )
+        logger.info("%s", "=" * 48)
+
+        fold_dir = output_dir / f"fold_{held_out_case}"
+        fits_dir = fold_dir / "fits"
+        weights_dir = fold_dir / "weights"
+        pca_model_file = fold_dir / "pca_model.json"
+        pca_mean_file = fold_dir / "pca_mean_surface.vtp"
+        if context.is_main:
+            fits_dir.mkdir(parents=True, exist_ok=True)
+
+        # Step 2: the fold's shape model, built without the held-out case.
+        # Groupwise and not parallel over cases, so rank 0 builds it and the
+        # others pick it up off disk after the barrier.
+        if context.is_main and not (pca_model_file.exists() and pca_mean_file.exists()):
+            sample_surfaces = [
+                pv.read(str(samples_dir / f"{case_id}_ref_model_surface.vtp"))
+                for case_id in case_ids
+                if case_id != held_out_case
+            ]
+            reference_surface_file = fold_dir / "reference_mean_surface.vtp"
+            if not reference_surface_file.exists():
+                # The reference surface defines the topology every PCA input is
+                # expressed in, so picking one case would make the model inherit
+                # that case's shape. Use the unbiased mean of the fold's own
+                # population instead.
+                mean_workflow = WorkflowCreateMeanSurface(
+                    surfaces=sample_surfaces,
+                    template_surface=sample_surfaces[len(sample_surfaces) // 2],
+                    log_level=log_level,
+                )
+                mean_workflow.set_number_of_iterations(mean_surface_iterations)
+                mean_workflow.set_mask_dilation_mm(DUKE_HEART.mask_dilation_mm)
+                mean_workflow.set_distance_squared_max(
+                    DUKE_HEART.distancemap_squared_max
+                )
+                if use_finetuned_weights:
+                    mean_workflow.set_icon_weights_path(str(icon_weights_path))
+                mean_workflow.process()["mean_surface"].save(
+                    str(reference_surface_file)
+                )
+            model_workflow = WorkflowCreateStatisticalModel(
+                sample_meshes=sample_surfaces,
+                reference_mesh=pv.read(str(reference_surface_file)),
+                number_of_pca_components=number_of_pca_components,
+                icp_transform_type=DUKE_HEART.icp_transform_type,
+                mask_dilation_mm=DUKE_HEART.mask_dilation_mm,
+                distance_squared_max=DUKE_HEART.distancemap_squared_max,
+                log_level=log_level,
+            )
+            if use_finetuned_weights:
+                model_workflow.set_icon_weights_path(str(icon_weights_path))
+            model_result = model_workflow.process()
+            pca_model_file.write_text(
+                json.dumps(model_result["pca_model"], indent=2), encoding="utf-8"
+            )
+            model_result["pca_mean_surface"].save(str(pca_mean_file))
+        context.barrier()
+
+        pca_mean_surface = cast(pv.DataSet, pv.read(str(pca_mean_file)))
+        with pca_model_file.open(encoding="utf-8") as f:
+            pca_model = json.load(f)
+
+        # Step 3: fit the fold's model to every case, held-out one included, and
+        # carry each fit onto every gated frame.
+        for case_id in _rank_share(case_ids, context):
+            case_dir = case_dir_by_id[case_id]
+            case_fit_dir = fits_dir / case_id
+            case_fit_dir.mkdir(parents=True, exist_ok=True)
+            fitted_reference_mesh_file = case_fit_dir / f"{case_id}_ssm_surface.vtp"
+            pca_coefficients_file = (
+                case_fit_dir / f"{case_id}_ssm_pca_coefficients.json"
+            )
+
+            reference_file = reference_frame_file(case_dir)
+            reference_surface = cast(
+                pv.PolyData, pv.read(str(heart_surface_for(reference_file)))
+            )
+            if not (
+                fitted_reference_mesh_file.exists() and pca_coefficients_file.exists()
+            ):
+                logger.info("Fold %s: fitting %s", held_out_case, case_id)
+                # This data carries no intensity image, so the workflow
+                # rasterizes its own reference grid from the patient surface.
+                fit_workflow = WorkflowFitStatisticalModelToPatient(
+                    template_model=pca_mean_surface,
+                    patient_models=[reference_surface],
+                    patient_image=None,
+                    patient_labelmap=itk.imread(str(reference_file)),
+                    labelmap_interior_object_ids=interior_object_ids,
+                    log_level=log_level,
+                )
+                fit_workflow.set_use_pca_registration(
+                    use_pca_registration=True,
+                    pca_model=pca_model,
+                    number_of_pca_components=number_of_pca_components,
+                    use_surface=False,
+                )
+                fit_workflow.set_icp_transform_type(DUKE_HEART.icp_transform_type)
+                fit_workflow.set_mask_dilation_mm(DUKE_HEART.mask_dilation_mm)
+                fit_workflow.set_distancemap_squared_max(
+                    DUKE_HEART.distancemap_squared_max
+                )
+                if use_finetuned_weights:
+                    fit_workflow.set_labelmap_to_labelmap_icon_weights_path(
+                        str(icon_weights_path)
+                    )
+                fit_result = fit_workflow.process()
+
+                coefficients = fit_workflow.pca_coefficients
+                assert coefficients is not None
+                pca_coefficients_file.write_text(
+                    json.dumps(coefficients.tolist()), encoding="utf-8"
+                )
+                # The heart PCA model is built from surfaces only, so the fitted
+                # model is itself a surface and only the .vtp is written.
+                fit_result["fitted_reference_mesh"].save(
+                    str(fitted_reference_mesh_file)
+                )
+            fitted_reference_mesh = cast(
+                pv.PolyData, pv.read(str(fitted_reference_mesh_file))
+            )
+
+            # One grid built around the reference frame's heart and reused by
+            # every frame, so the whole case is registered in a common space;
+            # its buffer holds the frames the heart moves into.
+            registration_grid = contour_tools.create_reference_image(
+                mesh=reference_surface,
+                spatial_resolution=registration_spacing_mm,
+                buffer_factor=0.25,
+                ptype=itk.F,
+            )
+            for frame_file in sorted(case_dir.glob(f"*{LABELMAP_SUFFIX}")):
+                stem = frame_file.name[: -len(LABELMAP_SUFFIX)]
+                frame_surface_file = case_fit_dir / f"{stem}_ssm_surface.vtp"
+                if frame_surface_file.exists():
+                    continue
+                if frame_file == reference_file:
+                    # The fit already placed the SSM on this frame.
+                    fitted_reference_mesh.save(str(frame_surface_file))
+                    continue
+                logger.info("Fold %s: %s warping to %s", held_out_case, case_id, stem)
+                registrar = RegisterModelsDistanceMaps(
+                    moving_model=fitted_reference_mesh,
+                    fixed_model=cast(
+                        pv.PolyData, pv.read(str(heart_surface_for(frame_file)))
+                    ),
+                    reference_image=registration_grid,
+                    distance_squared_max=DUKE_HEART.distancemap_squared_max,
+                    mask_dilation_mm=DUKE_HEART.mask_dilation_mm,
+                    log_level=log_level,
+                )
+                if use_finetuned_weights:
+                    registrar.set_icon_weights_path(str(icon_weights_path))
+                registrar.register(transform_type="Deformable")[
+                    "registered_model"
+                ].save(str(frame_surface_file))
+
+        context.barrier()
+
+        # Step 4: train on every case but the held-out one. Manifest paths are
+        # derived from the case ids, so every rank names the same files without
+        # having to be told which ones the others wrote.
+        manifests_dir = fold_dir / "manifests_mgn"
+        for case_id in _rank_share(case_ids, context):
+            _write_case_manifest(fits_dir / case_id, manifests_dir)
+        context.barrier()
+
+        manifests = {
+            case_id: manifests_dir / f"{case_id}_manifest.json" for case_id in case_ids
+        }
+        training_method = TrainPhysicsNeMoMGN(log_level=log_level)
+        training_method.set_epochs(epochs)
+        training_method.set_batch_size(batch_size)
+        training_method.set_learning_rate(learning_rate)
+        training_method.set_processor_size(processor_size)
+        training_method.set_hidden_dim(hidden_dim)
+        training_method.set_num_layers(num_layers)
+
+        train_result = WorkflowTrainPhysicsNeMo(
+            train_manifests=[
+                path for case_id, path in manifests.items() if case_id != held_out_case
+            ],
+            # Spending a case on validation would take it out of a training set
+            # that is already one case short, so the intermittent validation
+            # RMSE reads "n/a" here as it does in Tutorial 9.
+            val_manifests=[],
+            pca_mean_mesh=pca_mean_file,
+            output_directory=weights_dir,
+            training_method=training_method,
+            log_level=log_level,
+        ).process()
+
+        # Step 5: score the held-out case against its acquired labelmaps. No
+        # segmentation is needed: this cohort ships one labelmap per gated
+        # frame, each already carrying the four chambers, the myocardium and
+        # the whole heart.
+        if context.is_main:
+            held_out_dir = case_dir_by_id[held_out_case]
+            case_fit_dir = fits_dir / held_out_case
+            # The fits scored against are this fold's own, not Tutorial 8's,
+            # which is what makes the fold's number honest.
+            fold_ground_truth = cohort.assemble_ground_truth(
+                case_id=held_out_case,
+                frame_directory=held_out_dir,
+                fit_directory=case_fit_dir,
+            )
+            evaluate_workflow = WorkflowEvaluateMovement(
+                movement_workflow=WorkflowInferMovement(
+                    WorkflowInferPhysicsNeMo(
+                        model_directory=train_result["output_directory"],
+                        log_level=log_level,
+                    ),
+                    log_level=log_level,
+                ),
+                cohort=cohort,
+                log_level=log_level,
+            )
+            fold_result = evaluate_workflow.process(
+                case_id=held_out_case,
+                shape_parameters=case_fit_dir
+                / f"{held_out_case}_ssm_pca_coefficients.json",
+                fitted_reference_mesh=case_fit_dir / f"{held_out_case}_ssm_surface.vtp",
+                ground_truth=fold_ground_truth,
+                output_directory=fold_dir / "evaluation",
+                smoothing_sigma_mm=smoothing_sigma_mm,
+                evaluation_spacing_mm=evaluation_spacing_mm,
+                # The point-by-point error, which is what separates a fold that
+                # placed the chambers right from one that merely kept their size.
+                include_displacement_error=True,
+            )
+            for row in fold_result["rows"]:
+                all_rows.append(
+                    {
+                        "fold_index": fold_index,
+                        "held_out_case": held_out_case,
+                        **row,
+                        "fold_displacement_rms_mm": fold_result["displacement_rms_mm"],
+                        "fold_displacement_95th_mm": fold_result[
+                            "displacement_95th_mm"
+                        ],
+                        "fold_displacement_max_mm": fold_result["displacement_max_mm"],
+                    }
+                )
+            fold_results[held_out_case] = {
+                "model_directory": train_result["output_directory"],
+                "report_file": fold_result["report_file"],
+                "csv_file": fold_result["csv_file"],
+                "displacement_rms_mm": fold_result["displacement_rms_mm"],
+                "displacement_95th_mm": fold_result["displacement_95th_mm"],
+                "displacement_max_mm": fold_result["displacement_max_mm"],
+            }
+        context.barrier()
+
+    # Step 6: pool the folds. Only rank 0 has the rows.
+    tutorial_results: dict[str, Any] = {
+        "held_out_cases": held_out_cases,
+        "folds": fold_results,
+        "screenshots": [],
+    }
+    if context.is_main:
+        metrics_file = output_dir / "loo_metrics.csv"
+        with metrics_file.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(all_rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(all_rows)
+
+        report_file = output_dir / "loo_report.md"
+        _write_loo_report(all_rows, held_out_cases, heart_names, report_file)
+        plot_file = _plot_metrics_by_label(
+            all_rows, heart_names, output_dir / "loo_metrics_by_label.png"
+        )
+        logger.info("Metrics: %s", metrics_file)
+        logger.info("Report: %s", report_file)
+
+        tutorial_results["metrics_file"] = metrics_file
+        tutorial_results["report_file"] = report_file
+        tutorial_results["rows"] = all_rows
+
+        # Testing
+        tt = TestTools(
+            class_name=class_name,
+            results_dir=output_dir,
+            baselines_dir=repo_root / "tests" / "baselines" / class_name,
+            log_level=log_level,
+        )
+        last_case = held_out_cases[-1]
+        tutorial_results["screenshots"] = [
+            plot_file,
+            tt.save_screenshot_mesh(
+                cast(
+                    pv.DataSet,
+                    pv.read(
+                        str(
+                            output_dir
+                            / f"fold_{last_case}"
+                            / "fits"
+                            / last_case
+                            / f"{last_case}_ssm_surface.vtp"
+                        )
+                    ),
+                ),
+                "held_out_fitted_surface.png",
+                camera_position="iso",
+                color="steelblue",
+            ),
+        ]
+        logger.info("Last fold report: %s", fold_results[last_case]["report_file"])

--- a/tutorials/tutorial_15_lung_leave_one_out.py
+++ b/tutorials/tutorial_15_lung_leave_one_out.py
@@ -1,0 +1,927 @@
+"""
+Tutorial 15 (Lung, MGN): Leave-One-Out Cross-Validation of the Whole Chain
+
+Purpose
+-------
+Tutorials 6 -> 8 -> 9 -> 11 report accuracy for one fixed held-out case. That
+is a single observation: it says nothing about how much the number would move
+had a different patient been held out. This tutorial runs the same chain once
+per fold, holding out a different DIR-Lab case each time, and reports the mean
+and spread of the metrics across folds.
+
+Each fold is a full re-run, not a re-score of a shared model:
+
+1. Build a PCA statistical shape model from the population *without* the
+   held-out case (``WorkflowCreateMeanSurface`` then
+   ``WorkflowCreateStatisticalModel``). Rebuilding is the whole point --- a
+   model built once from everyone has already seen every case, so scoring
+   against it measures recall rather than generalization.
+
+2. Fit that fold's model to every case, held-out one included, and propagate
+   each fit through the respiratory phases
+   (``WorkflowFitStatisticalModelToPatient``, then the cached phase transforms).
+   The held-out case is fitted by a model that never saw it, which is what makes
+   its shape parameters an honest input to inference.
+
+3. Train a MeshGraphNet on the other cases' phases
+   (``WorkflowTrainPhysicsNeMo`` driving ``TrainPhysicsNeMoMGN``).
+
+4. Infer the held-out case at every acquired phase and score it against that
+   phase's own segmentation --- Dice, volume difference and surface RMSE per
+   lobe (``WorkflowEvaluateMovement``), plus, also per lobe, the distance
+   between where the network puts each mesh point and where this fold's own
+   fit put it.
+
+Then every fold's rows are pooled into ``loo_metrics.csv`` and summarized per
+lobe in ``loo_report.md``, which also carries each fold's displacement error, its
+RMS, 95th percentile and maximum.
+That last measure is the point-by-point one: a fold can keep every lobe the
+right size and still put all of them in the wrong place, and only it says so.
+
+On Dice for lobes: ``tutorial_11_lung_evaluate_physicsnemo.py`` deliberately
+leaves it out, because a lobe barely deforms over a breath compared to how big
+it is, so the overlap fraction mostly describes the lobe. It is reported here
+because a leave-one-out study is about comparing folds, and a metric that is
+insensitive in absolute terms can still separate a fold that went wrong. Read it
+alongside surface RMSE, which is what resolves the motion.
+
+What is *not* recomputed per fold
+---------------------------------
+Two things do not depend on which case is held out, so they are computed once
+into ``shared/`` and reused by every fold:
+
+  * the T70 lung segmentations, and
+  * the phase-to-reference-phase image registrations.
+
+The registrations are image-to-image and never touch the shape model, so one
+set is correct for every fold. Hoisting them is what makes this tutorial
+tractable; they otherwise dominate its runtime. Tutorial 6 and Tutorial 8
+outputs are read in place of the cache when they exist.
+
+Multi-GPU
+---------
+Launch under ``torchrun`` and every rank runs this script:
+
+    torchrun --standalone --nproc_per_node=8 \\
+        tutorials/tutorial_15_lung_leave_one_out.py
+
+Training is then data-parallel across the ranks (``DistributedDataParallel``
+inside ``WorkflowTrainPhysicsNeMo``), and the per-case segmentation, fitting and
+registration loops are split across the ranks a case at a time. Run without a
+launcher and the same script runs as a single process.
+
+Extra Install Required
+----------------------
+PhysicsNeMo and PyTorch Geometric must be installed::
+
+    pip install "physiotwin4d[physicsnemo]"
+
+Data Required
+-------------
+  * ``data/DirLab-4DCT/Case*_T??.mha`` - the whole cohort; see
+    ``data/DirLab-4DCT/README.md``
+  * Nothing from Tutorials 6, 8 or 9. Their outputs are reused as a cache when
+    present, but this tutorial builds everything it needs.
+
+Outputs (under ``tutorials/output/tutorial_15_lung/``)
+------------------------------------------------------
+  * ``loo_metrics.csv``           - every metric row of every fold
+  * ``loo_report.md``             - per-lobe mean +/- std across folds,
+    displacement 95th percentile included, plus each fold's whole-model error
+  * ``loo_metrics_by_label.png``  - the same, as a per-lobe box plot
+  * ``fold_<case>/``              - that fold's shape model, fits and weights
+  * ``shared/``                   - the fold-independent segmentations and
+    transforms
+
+Runtime
+-------
+Dominated by training: Tutorial 9 measures the full lung template (179k points,
+1.07M mesh-graph edges) at roughly four hours for 1500 epochs on one GPU, and
+that is paid once per fold. Eight ranks bring a fold's training well under an
+hour, so five folds is an afternoon rather than a week. The shared cache is
+built once and costs one segmentation and one phase registration per case.
+"""
+
+# Imports
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Any, cast
+
+import itk
+import numpy as np
+import pyvista as pv
+from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
+
+from physiotwin4d import (
+    ContourTools,
+    DistributedContext,
+    RegisterImagesGreedy,
+    EvaluateMovementLung,
+    SegmentNVSegmentCTMRI,
+    TestTools,
+    TrainPhysicsNeMoMGN,
+    TransformTools,
+    WorkflowConvertImageToVTK,
+    WorkflowCreateMeanSurface,
+    WorkflowCreateStatisticalModel,
+    WorkflowEvaluateMovement,
+    WorkflowFitStatisticalModelToPatient,
+    WorkflowInferMovement,
+    WorkflowInferPhysicsNeMo,
+    WorkflowReconstructHighres4DCT,
+    WorkflowTrainPhysicsNeMo,
+    distributed_context,
+)
+
+# The five lobes of ``SegmentNVSegmentCTMRI``.  Its "lung" group also carries
+# whole-lung, tumor and airway labels, which are not lobes.
+LOBE_LABEL_IDS = [28, 29, 30, 31, 32]
+
+# Point-data array the tutorial writes its targets into and the manifests name.
+TARGET_ARRAY = "displacement"
+
+
+def _respiratory_stage_from_filename(surface_file: Path) -> float:
+    """Extract the normalized respiratory stage [0, 1] from a ``T{PP}`` filename stem."""
+    for part in surface_file.stem.split("_"):
+        if part.startswith("T") and part[1:].isdigit():
+            return int(part[1:]) / 100.0
+    raise ValueError(f"Cannot parse respiratory phase from filename: {surface_file}")
+
+
+def _rank_share(items: list[Any], context: DistributedContext) -> list[Any]:
+    """Return the slice of ``items`` this rank is responsible for.
+
+    Every rank writes to its own cases' directories and the caller waits on a
+    barrier afterwards, so the ranks never contend for a file.
+    """
+    return items[context.rank :: context.world_size]
+
+
+def _write_target_mesh(
+    phase_file: Path, ref_points: np.ndarray, targets_dir: Path
+) -> Path:
+    """Write one phase's training target and return the mesh path.
+
+    The target is the per-vertex displacement from the case's reference surface,
+    stored as the ``TARGET_ARRAY`` point-data array on a copy of the phase
+    surface.  The training workflow reads whatever array the manifest names and
+    never derives one.
+    """
+    phase_mesh = pv.read(str(phase_file))
+    phase_points = np.asarray(phase_mesh.points, dtype=np.float32)
+    phase_mesh.point_data[TARGET_ARRAY] = phase_points - ref_points
+    target_path = targets_dir / f"{phase_file.stem}_target.vtp"
+    phase_mesh.save(str(target_path))
+    return target_path
+
+
+def _write_case_manifest(case_dir: Path, manifests_dir: Path) -> Path:
+    """Write one case's training manifest and return its path."""
+    case_id = case_dir.name
+    fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
+    phase_files = sorted(case_dir.glob(f"{case_id}_T??_ssm_surface.vtp"))
+    manifests_dir.mkdir(parents=True, exist_ok=True)
+    ref_points = np.asarray(
+        pv.read(str(fitted_reference_mesh_file)).points, dtype=np.float32
+    )
+    manifest = {
+        "subject_id": case_id,
+        "fitted_reference_mesh": str(fitted_reference_mesh_file),
+        "pca_coefficients": str(case_dir / f"{case_id}_ssm_pca_coefficients.json"),
+        "target_array": TARGET_ARRAY,
+        "phases": [
+            {
+                "mesh": str(_write_target_mesh(phase_file, ref_points, manifests_dir)),
+                "stage": _respiratory_stage_from_filename(phase_file),
+            }
+            for phase_file in phase_files
+        ],
+    }
+    manifest_path = manifests_dir / f"{case_id}_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest_path
+
+
+def _summarize(values: list[float]) -> tuple[float, float, int]:
+    """Return ``(mean, sample standard deviation, count)`` ignoring NaNs.
+
+    One fold cannot have a spread, so its standard deviation is reported as 0.0
+    rather than left undefined.
+    """
+    finite = [value for value in values if np.isfinite(value)]
+    if not finite:
+        return float("nan"), float("nan"), 0
+    mean = float(np.mean(finite))
+    std = float(np.std(finite, ddof=1)) if len(finite) > 1 else 0.0
+    return mean, std, len(finite)
+
+
+def _write_loo_report(
+    rows: list[dict[str, Any]],
+    held_out_cases: list[str],
+    label_names: dict[int, str],
+    report_file: Path,
+) -> None:
+    """Write the per-lobe cross-fold summary.
+
+    Each fold contributes one number per lobe --- the mean over that fold's
+    phases --- and the reported spread is across those per-fold numbers.
+    Pooling every phase of every fold instead would let a case with more
+    acquired phases weigh more heavily than the others.
+    """
+    metrics = [
+        ("dice", "Dice", "{:.4f}"),
+        ("volume_difference_percent", "|volume difference| (%)", "{:.2f}"),
+        ("surface_rmse_mm", "surface RMSE (mm)", "{:.3f}"),
+        ("displacement_95th_mm", "displacement 95th percentile (mm)", "{:.3f}"),
+    ]
+    lines = [
+        "# Leave-One-Out Cross-Validation: Lung Motion",
+        "",
+        f"Folds: {len(held_out_cases)}",
+        f"Held-out cases: {', '.join(held_out_cases)}",
+        "",
+        "Each fold rebuilt the shape model without its held-out case, refitted "
+        "the cohort, retrained the MeshGraphNet and scored that case against "
+        "its own per-phase segmentations. Every cell is the mean over folds of "
+        "the fold's own mean over phases, plus or minus the standard deviation "
+        "across folds.",
+        "",
+        "Dice on a lobe is dominated by the size of the lobe rather than by how "
+        "far it moved; surface RMSE is what resolves the motion here.",
+        "",
+        "| Structure | " + " | ".join(title for _, title, _ in metrics) + " |",
+        "|---|" + "---|" * len(metrics),
+    ]
+    for label in sorted(label_names):
+        cells = []
+        for key, _, fmt in metrics:
+            per_fold = []
+            for case_id in held_out_cases:
+                fold_values = [
+                    abs(float(row[key]))
+                    for row in rows
+                    if row["held_out_case"] == case_id
+                    and int(row["label_id"]) == label
+                    and np.isfinite(float(row[key]))
+                ]
+                if fold_values:
+                    per_fold.append(float(np.mean(fold_values)))
+            mean, std, count = _summarize(per_fold)
+            cells.append(
+                "n/a" if count == 0 else f"{fmt.format(mean)} +/- {fmt.format(std)}"
+            )
+        lines.append(f"| {label_names[label]} | " + " | ".join(cells) + " |")
+
+    lines.extend(["", "## Pooled over all lobes", ""])
+    for key, title, fmt in metrics:
+        values = [abs(float(row[key])) for row in rows if np.isfinite(float(row[key]))]
+        mean, std, count = _summarize(values)
+        lines.append(
+            f"- {title}: "
+            + ("n/a" if count == 0 else f"{fmt.format(mean)} +/- {fmt.format(std)}")
+            + f"  (n={count} rows)"
+        )
+
+    lines.extend(_displacement_error_lines(rows, held_out_cases))
+    report_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _displacement_error_lines(
+    rows: list[dict[str, Any]], held_out_cases: list[str]
+) -> list[str]:
+    """Per-fold displacement error, one number per fold rather than per lobe.
+
+    The error is measured on the whole shape model at once, so every row of a
+    fold carries the same ``fold_displacement_*`` figures; the fold is the unit
+    here, while each row's own ``displacement_*`` columns are its stage's.
+    """
+    per_fold: list[tuple[str, float, float, float]] = []
+    for case_id in held_out_cases:
+        fold_rows = [row for row in rows if row["held_out_case"] == case_id]
+        if fold_rows and np.isfinite(float(fold_rows[0]["fold_displacement_rms_mm"])):
+            per_fold.append(
+                (
+                    case_id,
+                    float(fold_rows[0]["fold_displacement_rms_mm"]),
+                    float(fold_rows[0]["fold_displacement_95th_mm"]),
+                    float(fold_rows[0]["fold_displacement_max_mm"]),
+                )
+            )
+    if not per_fold:
+        return []
+
+    mean, std, _ = _summarize([rms for _, rms, _, _ in per_fold])
+    p95_mean, p95_std, _ = _summarize([p95 for _, _, p95, _ in per_fold])
+    lines = [
+        "",
+        "## Displacement error, per fold",
+        "",
+        "Distance between where the network puts each mesh point of the held-out "
+        "case and where that fold's own fit put it, pooled over every point and "
+        "phase. Measured point by point, so a lobe predicted the right size in "
+        "the wrong place is scored here and nowhere above.",
+        "",
+        f"- RMS across folds: {mean:.3f} +/- {std:.3f} mm",
+        f"- 95th percentile across folds: {p95_mean:.3f} +/- {p95_std:.3f} mm",
+        f"- Worst fold: {max(maximum for _, _, _, maximum in per_fold):.3f} mm",
+        "",
+        "| Held-out case | RMS (mm) | 95th percentile (mm) | Max (mm) |",
+        "|---|---:|---:|---:|",
+    ]
+    lines += [
+        f"| {case_id} | {rms:.3f} | {p95:.3f} | {maximum:.3f} |"
+        for case_id, rms, p95, maximum in per_fold
+    ]
+    return lines
+
+
+def _plot_metrics_by_label(
+    rows: list[dict[str, Any]], label_names: dict[int, str], plot_file: Path
+) -> Path:
+    """Box-plot each metric per lobe, one box per lobe over every scored phase."""
+    import matplotlib.pyplot as plt
+
+    metrics = [
+        ("dice", "Dice"),
+        ("volume_difference_percent", "|volume difference| (%)"),
+        ("surface_rmse_mm", "surface RMSE (mm)"),
+        ("displacement_95th_mm", "displacement 95th percentile (mm)"),
+    ]
+    labels = sorted(label_names)
+    fig, axes = plt.subplots(1, len(metrics), figsize=(17.0, 4.5))
+    try:
+        for ax, (key, title) in zip(axes, metrics):
+            data = [
+                [
+                    abs(float(row[key]))
+                    for row in rows
+                    if int(row["label_id"]) == label and np.isfinite(float(row[key]))
+                ]
+                for label in labels
+            ]
+            # A lobe absent from every acquired frame has no box to draw; give
+            # it an empty slot so the tick labels stay aligned with the lobes.
+            ax.boxplot([values or [np.nan] for values in data], showmeans=True)
+            ax.set_xticklabels(
+                [label_names[label] for label in labels], rotation=30, ha="right"
+            )
+            ax.set_title(title)
+            ax.grid(axis="y", alpha=0.3)
+        fig.tight_layout()
+        fig.savefig(str(plot_file), dpi=110)
+    finally:
+        plt.close(fig)
+    return plot_file
+
+
+# Only run if this script is not imported as a module
+
+# nnUNetv2 (inside SegmentNVSegmentCTMRI), the registration backends and torch
+# all spawn worker processes. On Windows the spawn start method re-imports this
+# script in each child; without the __name__ == "__main__" guard around
+# top-level work, that re-import would restart the whole study in every worker.
+if __name__ == "__main__":
+    # Data directory specification
+    repo_root = Path(__file__).resolve().parent.parent
+    tutorials_dir = Path(__file__).resolve().parent
+
+    class_name = "tutorial_15_lung_leave_one_out"
+
+    # Number of folds. Each holds out one DIR-Lab case and re-runs the entire
+    # chain without it, so the runtime is linear in this.
+    number_of_leave_one_out_runs = 5
+
+    # Atlas iterations used to build each fold's reference surface; 1 is a
+    # single template-biased pass.
+    mean_surface_iterations = 3
+
+    # Training hyperparameters, matching Tutorial 9 (lung) so a fold's network
+    # is comparable to the one that tutorial trains.
+    epochs = 1500
+    batch_size = 4
+    learning_rate = 1.0e-3
+    processor_size = 3  # message-passing hops
+    hidden_dim = 128
+    num_layers = 2  # MLP layers inside each encoder / processor / decoder block
+
+    # Phase the SSM is fitted to, and therefore the phase whose anatomy the
+    # predicted deformations carry into every other phase.
+    reference_phase = "T70"
+
+    # Gaussian sigma, in mm, that spreads the predicted surface displacements
+    # into the continuous field the labelmap is resampled through.
+    smoothing_sigma_mm = 10.0
+    # Isotropic pitch every metric is measured on. Coarser than the CT, whose
+    # in-plane pitch is finer than the accuracy being reported, and fine enough
+    # that a lobe boundary is not quantized away.
+    evaluation_spacing_mm = 2.0
+
+    output_dir = tutorials_dir / "output" / "tutorial_15_lung"
+    shared_dir = output_dir / "shared"
+    log_level = logging.INFO
+
+    logging.basicConfig(level=log_level)
+    logger = logging.getLogger(class_name)
+
+    # Under torchrun / SLURM / mpirun this is one rank of many; started plainly
+    # it reports a world of one and every branch below collapses to a single
+    # process.
+    context = distributed_context()
+
+    test_mode = TestTools.running_as_test()
+    data_dir = LUNG_CT_DIRLAB.input_directory(test_mode)
+    number_of_pca_components = LUNG_CT_DIRLAB.pca_components(test_mode)
+
+    # In test mode, run the smallest study that is still a cross-validation and
+    # train for a couple of epochs, to keep the run inside the pytest timeout.
+    if test_mode:
+        number_of_leave_one_out_runs = 2
+        mean_surface_iterations = 1
+        epochs = 2
+
+    # Tutorial 6 caches one segmentation per case beside its model, and
+    # Tutorial 8 one set of phase transforms per case; both are reused when
+    # present because neither depends on which case is held out.
+    tutorial_06_dir = LUNG_CT_DIRLAB.pca_json_file.parent
+    tutorial_08_dir = tutorials_dir / "output" / "tutorial_08_lung"
+
+    # Distance-map weights finetuned on DIR-Lab by
+    # tutorial_02_lung_distancemap_finetune_icon.py, used by the
+    # labelmap-to-labelmap stage of the SSM fit.
+    icon_distancemap_weights_path = (
+        tutorials_dir
+        / "network_weights"
+        / "icon_dirlab_4dct_distancemap"
+        / "icon_dirlab_4dct_distancemap_model"
+        / "checkpoints"
+        / "network_weights_final.trch"
+    )
+
+    # Directory setup and data reading
+
+    if context.is_main:
+        shared_dir.mkdir(parents=True, exist_ok=True)
+    context.barrier()
+
+    # DIR-Lab names case 8 "Case8Deploy" while every other case is "Case*Pack",
+    # so match on "Case*" to avoid silently dropping it.
+    reference_files = sorted(data_dir.glob(f"Case*_{reference_phase}.mha"))
+    if not reference_files:
+        raise FileNotFoundError(
+            f"No DirLab {reference_phase} images found under {data_dir}.\n"
+            "See data/DirLab-4DCT/README.md for download instructions."
+        )
+    case_ids = [path.name.split("_")[0] for path in reference_files]
+    if len(case_ids) < 3:
+        raise RuntimeError(
+            f"Found only {len(case_ids)} case(s) under {data_dir}; a fold needs "
+            "one case to hold out and at least two to build a shape model from."
+        )
+    if number_of_leave_one_out_runs > len(case_ids):
+        raise ValueError(
+            f"number_of_leave_one_out_runs is {number_of_leave_one_out_runs} but "
+            f"only {len(case_ids)} cases are available under {data_dir}."
+        )
+    held_out_cases = case_ids[:number_of_leave_one_out_runs]
+    logger.info(
+        "%d cases, %d folds; holding out %s",
+        len(case_ids),
+        len(held_out_cases),
+        ", ".join(held_out_cases),
+    )
+
+    use_finetuned_distancemap_weights = icon_distancemap_weights_path.exists()
+    if not use_finetuned_distancemap_weights:
+        logger.warning(
+            "Finetuned distance-map ICON weights not found at %s; fitting the "
+            "SSM with the stock uniGradICON weights. Run "
+            "tutorials/tutorial_02_lung_distancemap_finetune_icon.py to create "
+            "them.",
+            icon_distancemap_weights_path,
+        )
+
+    segmentation_method = SegmentNVSegmentCTMRI(log_level=log_level)
+    segmentation_workflow = WorkflowConvertImageToVTK(
+        segmentation_method=segmentation_method, log_level=log_level
+    )
+    contour_tools = ContourTools(log_level=log_level)
+    transform_tools = TransformTools(log_level=log_level)
+
+    # The cohort names the structures every fold reports and, in Step 5, reads
+    # each fold's ground truth back out of the shared cache below.
+    cohort = EvaluateMovementLung(reference_phase=reference_phase, log_level=log_level)
+    lobe_names = cohort.label_names()
+
+    # Step 1: the shared cache. Neither the reference-phase segmentations nor
+    # the phase registrations depend on which case is held out, so they are
+    # built once here and every fold reads them. Cases are split across the
+    # ranks; the barrier below is what lets every rank read every case's files.
+    segmentation_dir = shared_dir / "segmentations"
+    transform_dir = shared_dir / "transforms"
+    ground_truth_dir = shared_dir / "ground_truth"
+    if context.is_main:
+        for directory in (segmentation_dir, transform_dir, ground_truth_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+    context.barrier()
+
+    def shared_segmentation_files(case_id: str) -> tuple[Path, Path]:
+        """Return this case's cached reference-phase surface and labelmap paths.
+
+        Tutorial 6 wrote the same two files for its own population, so they are
+        read from there when they exist rather than segmented again.
+        """
+        stem = f"{case_id}_{reference_phase}"
+        tutorial_06_surface = tutorial_06_dir / f"{stem}.vtp"
+        tutorial_06_labelmap = tutorial_06_dir / f"{stem}_labelmap.nii.gz"
+        if tutorial_06_surface.exists() and tutorial_06_labelmap.exists():
+            return tutorial_06_surface, tutorial_06_labelmap
+        return (
+            segmentation_dir / f"{stem}.vtp",
+            segmentation_dir / f"{stem}_labelmap.nii.gz",
+        )
+
+    for case_id in _rank_share(case_ids, context):
+        surface_file, labelmap_file = shared_segmentation_files(case_id)
+        if not (surface_file.exists() and labelmap_file.exists()):
+            logger.info("Segmenting %s %s", case_id, reference_phase)
+            segmentation_result = segmentation_workflow.process(
+                input_image=itk.imread(
+                    str(data_dir / f"{case_id}_{reference_phase}.mha")
+                ),
+                anatomy_groups=["lung"],
+                surface_reduction_rate=LUNG_CT_DIRLAB.surface_reduction_rate,
+                extract_label_surfaces=True,
+            )
+            contour_tools.save_combined_surfaces(
+                segmentation_result["label_surfaces"], str(surface_file)
+            )
+            itk.imwrite(
+                segmentation_result["labelmap"], str(labelmap_file), compression=True
+            )
+
+        # Every phase registered to the reference phase. This is image-to-image
+        # and never sees the shape model, so one set of transforms serves every
+        # fold. Tutorial 8 wrote the same transforms; reuse them when present.
+        case_transform_dir = transform_dir / case_id
+        case_transform_dir.mkdir(parents=True, exist_ok=True)
+        phase_files = sorted(data_dir.glob(f"{case_id}_T??.mha"))
+        phase_ids = [path.stem.split("_")[1] for path in phase_files]
+        wanted = [
+            case_transform_dir / f"{case_id}_{p}_forward_tfm.hdf" for p in phase_ids
+        ]
+        if not all(path.exists() for path in wanted):
+            tutorial_08_case_dir = tutorial_08_dir / case_id
+            existing = [
+                tutorial_08_case_dir / f"{case_id}_{p}_forward_tfm.hdf"
+                for p in phase_ids
+            ]
+            if all(path.exists() for path in existing):
+                logger.info("Reusing Tutorial 8 phase transforms for %s", case_id)
+                for source, destination in zip(existing, wanted):
+                    destination.write_bytes(source.read_bytes())
+            else:
+                logger.info("Registering %d phases of %s", len(phase_files), case_id)
+                reg_workflow = WorkflowReconstructHighres4DCT(
+                    time_series_images=[itk.imread(str(path)) for path in phase_files],
+                    reference_image=itk.imread(
+                        str(data_dir / f"{case_id}_{reference_phase}.mha")
+                    ),
+                    reference_time_frame=phase_ids.index(reference_phase),
+                    register_reference_time_frame_to_reference_image=False,
+                    registration_method=RegisterImagesGreedy(log_level=log_level),
+                    log_level=log_level,
+                )
+                reg_workflow.set_modality("ct")
+                reg_result = reg_workflow.process()
+                for phase_index, destination in enumerate(wanted):
+                    itk.transformwrite(
+                        reg_result["forward_transforms"][phase_index], str(destination)
+                    )
+
+    # Ground truth for the folds' held-out cases: every gated frame segmented on
+    # its own, so the lobes a phase is scored against came from that phase's
+    # image rather than from a registration or a shape-model fit.
+    for case_id in _rank_share(held_out_cases, context):
+        case_ground_truth_dir = ground_truth_dir / case_id
+        case_ground_truth_dir.mkdir(parents=True, exist_ok=True)
+        for frame_file in sorted(data_dir.glob(f"{case_id}_T??.mha")):
+            labelmap_file = case_ground_truth_dir / f"{frame_file.stem}_labelmap.nii.gz"
+            if labelmap_file.exists():
+                continue
+            logger.info("Segmenting ground-truth frame %s", frame_file.name)
+            itk.imwrite(
+                segmentation_method.segment(itk.imread(str(frame_file)))["labelmap"],
+                str(labelmap_file),
+                compression=True,
+            )
+    context.barrier()
+
+    # Steps 2-5: one fold per held-out case.
+    all_rows: list[dict[str, Any]] = []
+    fold_results: dict[str, Any] = {}
+
+    for fold_index, held_out_case in enumerate(held_out_cases):
+        logger.info("%s", "=" * 48)
+        logger.info(
+            "Fold %d/%d: holding out %s",
+            fold_index + 1,
+            len(held_out_cases),
+            held_out_case,
+        )
+        logger.info("%s", "=" * 48)
+
+        fold_dir = output_dir / f"fold_{held_out_case}"
+        fits_dir = fold_dir / "fits"
+        weights_dir = fold_dir / "weights"
+        pca_model_file = fold_dir / "pca_model.json"
+        pca_mean_file = fold_dir / "pca_mean_surface.vtp"
+        if context.is_main:
+            fits_dir.mkdir(parents=True, exist_ok=True)
+
+        # Step 2: the fold's shape model, built without the held-out case.
+        # Groupwise and not parallel over cases, so rank 0 builds it and the
+        # others pick it up off disk after the barrier.
+        if context.is_main and not (pca_model_file.exists() and pca_mean_file.exists()):
+            training_case_ids = [c for c in case_ids if c != held_out_case]
+            sample_surfaces = [
+                pv.read(str(shared_segmentation_files(c)[0])) for c in training_case_ids
+            ]
+            reference_surface_file = fold_dir / "reference_mean_surface.vtp"
+            if not reference_surface_file.exists():
+                # The reference surface defines the topology every PCA input is
+                # expressed in, so picking one case would make the model inherit
+                # that case's shape. Use the unbiased mean of the fold's own
+                # population instead.
+                mean_workflow = WorkflowCreateMeanSurface(
+                    surfaces=sample_surfaces, log_level=log_level
+                )
+                mean_workflow.set_number_of_iterations(mean_surface_iterations)
+                mean_workflow.set_mask_dilation_mm(LUNG_CT_DIRLAB.mask_dilation_mm)
+                mean_workflow.set_distance_squared_max(
+                    LUNG_CT_DIRLAB.distancemap_squared_max
+                )
+                if use_finetuned_distancemap_weights:
+                    mean_workflow.set_icon_weights_path(
+                        str(icon_distancemap_weights_path)
+                    )
+                mean_workflow.process()["mean_surface"].save(
+                    str(reference_surface_file)
+                )
+            model_workflow = WorkflowCreateStatisticalModel(
+                sample_meshes=sample_surfaces,
+                reference_mesh=pv.read(str(reference_surface_file)),
+                number_of_pca_components=number_of_pca_components,
+                icp_transform_type=LUNG_CT_DIRLAB.icp_transform_type,
+                mask_dilation_mm=LUNG_CT_DIRLAB.mask_dilation_mm,
+                distance_squared_max=LUNG_CT_DIRLAB.distancemap_squared_max,
+                log_level=log_level,
+            )
+            if use_finetuned_distancemap_weights:
+                model_workflow.set_icon_weights_path(str(icon_distancemap_weights_path))
+            model_result = model_workflow.process()
+            pca_model_file.write_text(
+                json.dumps(model_result["pca_model"], indent=2), encoding="utf-8"
+            )
+            model_result["pca_mean_surface"].save(str(pca_mean_file))
+        context.barrier()
+
+        pca_mean_surface = cast(pv.DataSet, pv.read(str(pca_mean_file)))
+        with pca_model_file.open(encoding="utf-8") as f:
+            pca_model = json.load(f)
+
+        # Step 3: fit the fold's model to every case, held-out one included, and
+        # carry each fit through the phases with the cached transforms.
+        for case_id in _rank_share(case_ids, context):
+            case_fit_dir = fits_dir / case_id
+            case_fit_dir.mkdir(parents=True, exist_ok=True)
+            fitted_reference_mesh_file = case_fit_dir / f"{case_id}_ssm_surface.vtp"
+            pca_coefficients_file = (
+                case_fit_dir / f"{case_id}_ssm_pca_coefficients.json"
+            )
+            if not (
+                fitted_reference_mesh_file.exists() and pca_coefficients_file.exists()
+            ):
+                logger.info("Fold %s: fitting %s", held_out_case, case_id)
+                surface_file, labelmap_file = shared_segmentation_files(case_id)
+                fit_workflow = WorkflowFitStatisticalModelToPatient(
+                    template_model=pca_mean_surface,
+                    patient_models=[cast(pv.PolyData, pv.read(str(surface_file)))],
+                    patient_image=itk.imread(
+                        str(data_dir / f"{case_id}_{reference_phase}.mha")
+                    ),
+                    patient_labelmap=itk.imread(str(labelmap_file)),
+                    log_level=log_level,
+                )
+                fit_workflow.set_use_pca_registration(
+                    use_pca_registration=True,
+                    pca_model=pca_model,
+                    number_of_pca_components=number_of_pca_components,
+                    use_surface=False,
+                )
+                fit_workflow.set_icp_transform_type(LUNG_CT_DIRLAB.icp_transform_type)
+                fit_workflow.set_mask_dilation_mm(LUNG_CT_DIRLAB.mask_dilation_mm)
+                fit_workflow.set_distancemap_squared_max(
+                    LUNG_CT_DIRLAB.distancemap_squared_max
+                )
+                if use_finetuned_distancemap_weights:
+                    fit_workflow.set_labelmap_to_labelmap_icon_weights_path(
+                        str(icon_distancemap_weights_path)
+                    )
+                fit_result = fit_workflow.process()
+
+                coefficients = fit_workflow.pca_coefficients
+                assert coefficients is not None
+                pca_coefficients_file.write_text(
+                    json.dumps(coefficients.tolist()), encoding="utf-8"
+                )
+                fit_result["fitted_reference_mesh"].save(
+                    str(fitted_reference_mesh_file)
+                )
+
+            # The lung PCA model is built from surfaces only, so the fitted
+            # model is itself a surface and only the .vtp is written.
+            fitted_reference_mesh = cast(
+                pv.PolyData, pv.read(str(fitted_reference_mesh_file))
+            )
+            for phase_file in sorted(data_dir.glob(f"{case_id}_T??.mha")):
+                phase_id = phase_file.stem.split("_")[1]
+                phase_surface_file = (
+                    case_fit_dir / f"{case_id}_{phase_id}_ssm_surface.vtp"
+                )
+                if phase_surface_file.exists():
+                    continue
+                # itk.transformread returns a list; a composite is written with
+                # its sub-transforms behind it, so the first entry is the whole
+                # transform either way.
+                forward_transform = itk.transformread(
+                    str(
+                        transform_dir
+                        / case_id
+                        / f"{case_id}_{phase_id}_forward_tfm.hdf"
+                    )
+                )[0]
+                transform_tools.transform_pvcontour(
+                    fitted_reference_mesh,
+                    forward_transform,
+                    with_deformation_magnitude=True,
+                ).save(str(phase_surface_file))
+
+        context.barrier()
+
+        # Step 4: train on every case but the held-out one. Manifest paths are
+        # derived from the case ids, so every rank names the same files without
+        # having to be told which ones the others wrote.
+        manifests_dir = fold_dir / "manifests_mgn"
+        for case_id in _rank_share(case_ids, context):
+            _write_case_manifest(fits_dir / case_id, manifests_dir)
+        context.barrier()
+
+        manifests = {
+            case_id: manifests_dir / f"{case_id}_manifest.json" for case_id in case_ids
+        }
+        training_method = TrainPhysicsNeMoMGN(log_level=log_level)
+        training_method.set_epochs(epochs)
+        training_method.set_batch_size(batch_size)
+        training_method.set_learning_rate(learning_rate)
+        training_method.set_processor_size(processor_size)
+        training_method.set_hidden_dim(hidden_dim)
+        training_method.set_num_layers(num_layers)
+
+        train_result = WorkflowTrainPhysicsNeMo(
+            train_manifests=[
+                path for case_id, path in manifests.items() if case_id != held_out_case
+            ],
+            # Spending a case on validation would take it out of a training set
+            # that is already one case short, so the intermittent validation
+            # RMSE reads "n/a" here as it does in Tutorial 9.
+            val_manifests=[],
+            pca_mean_mesh=pca_mean_file,
+            output_directory=weights_dir,
+            training_method=training_method,
+            log_level=log_level,
+        ).process()
+
+        # Step 5: score the held-out case against its own segmentations. The
+        # metrics are read off one process; the other ranks wait at the barrier.
+        if context.is_main:
+            case_fit_dir = fits_dir / held_out_case
+            # Every labelmap this needs was segmented into the shared cache
+            # above, so the cohort reads them straight back; the fits it scores
+            # against are this fold's own, which is what makes the fold honest.
+            fold_ground_truth = cohort.assemble_ground_truth(
+                case_id=held_out_case,
+                frame_directory=data_dir,
+                fit_directory=case_fit_dir,
+                cache_directory=ground_truth_dir / held_out_case,
+            )
+            evaluate_workflow = WorkflowEvaluateMovement(
+                movement_workflow=WorkflowInferMovement(
+                    WorkflowInferPhysicsNeMo(
+                        model_directory=train_result["output_directory"],
+                        log_level=log_level,
+                    ),
+                    log_level=log_level,
+                ),
+                cohort=cohort,
+                log_level=log_level,
+            )
+            fold_result = evaluate_workflow.process(
+                case_id=held_out_case,
+                shape_parameters=case_fit_dir
+                / f"{held_out_case}_ssm_pca_coefficients.json",
+                fitted_reference_mesh=case_fit_dir / f"{held_out_case}_ssm_surface.vtp",
+                ground_truth=fold_ground_truth,
+                output_directory=fold_dir / "evaluation",
+                smoothing_sigma_mm=smoothing_sigma_mm,
+                evaluation_spacing_mm=evaluation_spacing_mm,
+                # Reported for both anatomies here, unlike Tutorial 11 (lung):
+                # a study that compares folds can use a metric that is
+                # insensitive in absolute terms.
+                report_dice=True,
+                # The point-by-point error, which is what separates a fold that
+                # placed the lobes right from one that merely kept their size.
+                include_displacement_error=True,
+            )
+            for row in fold_result["rows"]:
+                all_rows.append(
+                    {
+                        "fold_index": fold_index,
+                        "held_out_case": held_out_case,
+                        **row,
+                        "fold_displacement_rms_mm": fold_result["displacement_rms_mm"],
+                        "fold_displacement_95th_mm": fold_result[
+                            "displacement_95th_mm"
+                        ],
+                        "fold_displacement_max_mm": fold_result["displacement_max_mm"],
+                    }
+                )
+            fold_results[held_out_case] = {
+                "model_directory": train_result["output_directory"],
+                "report_file": fold_result["report_file"],
+                "csv_file": fold_result["csv_file"],
+                "displacement_rms_mm": fold_result["displacement_rms_mm"],
+                "displacement_95th_mm": fold_result["displacement_95th_mm"],
+                "displacement_max_mm": fold_result["displacement_max_mm"],
+            }
+        context.barrier()
+
+    # Step 6: pool the folds. Only rank 0 has the rows.
+    tutorial_results: dict[str, Any] = {
+        "held_out_cases": held_out_cases,
+        "folds": fold_results,
+        "screenshots": [],
+    }
+    if context.is_main:
+        metrics_file = output_dir / "loo_metrics.csv"
+        with metrics_file.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(all_rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(all_rows)
+
+        report_file = output_dir / "loo_report.md"
+        _write_loo_report(all_rows, held_out_cases, lobe_names, report_file)
+        plot_file = _plot_metrics_by_label(
+            all_rows, lobe_names, output_dir / "loo_metrics_by_label.png"
+        )
+        logger.info("Metrics: %s", metrics_file)
+        logger.info("Report: %s", report_file)
+
+        tutorial_results["metrics_file"] = metrics_file
+        tutorial_results["report_file"] = report_file
+        tutorial_results["rows"] = all_rows
+
+        # Testing
+        tt = TestTools(
+            class_name=class_name,
+            results_dir=output_dir,
+            baselines_dir=repo_root / "tests" / "baselines" / class_name,
+            log_level=log_level,
+        )
+        last_fold = fold_results[held_out_cases[-1]]
+        tutorial_results["screenshots"] = [
+            plot_file,
+            tt.save_screenshot_mesh(
+                cast(
+                    pv.DataSet,
+                    pv.read(
+                        str(
+                            output_dir
+                            / f"fold_{held_out_cases[-1]}"
+                            / "fits"
+                            / held_out_cases[-1]
+                            / f"{held_out_cases[-1]}_ssm_surface.vtp"
+                        )
+                    ),
+                ),
+                "held_out_fitted_surface.png",
+                camera_position="iso",
+                color="steelblue",
+            ),
+        ]
+        logger.info("Last fold report: %s", last_fold["report_file"])


### PR DESCRIPTION
Split movement evaluation into cohort + reporting collaborators so WorkflowEvaluateMovement stops growing anatomy branches:

- EvaluateMovementBase / EvaluateMovementLung / EvaluateMovementDukeHeart own the structures to report, stage-from-filename parsing, and ground truth assembly (MovementGroundTruth).
- ReportEvaluateMovement owns CSVs, volume plot and markdown report; it computes nothing, so presentation changes never touch measurement.

Add multi-GPU training. physicsnemo_tools gains DistributedContext / distributed_context over PhysicsNeMo's DistributedManager; a run without a launcher gets world size 1, so single-process callers need no branch. TrainPhysicsNeMoBase wraps in DistributedDataParallel before compiling, shards a shared permutation across ranks, and writes only from rank 0.

Require an explicit fitted reference mesh for inference. SubjectManifest's reference_mesh becomes fitted_reference_mesh, and reconstruct_reference_points is removed: displacements are defined relative to the patient's fit, and a surface reconstructed from shape parameters alone is not one. The CLI now errors instead of silently displacing a PCA reconstruction.

Add tutorials 14 (shape-parameter sweep) and 15 (leave-one-out cross-validation) for both lung and Duke heart cohorts, plus registration knobs they need (mask dilation, distance-squared max, ICP transform type, ICON weights path).

Add docs/cookbook: train and infer on your own data, add a segmentation method, add a registration method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added heart and lung movement evaluation with displacement metrics, CSV outputs, plots, and Markdown reports.
  * Added shape-parameter sweeps, leave-one-out validation tutorials, and a Cookbook.
  * Added distributed multi-GPU training support.

* **Updates**
  * Inference now requires `--fitted-reference-mesh`; PCA-only fallback and inference-time scoring were removed.
  * Added configurable ICP transforms and registration correspondence settings.
  * Expanded tutorials with visual comparisons and evaluation workflows.

* **Bug Fixes**
  * Preserved segmentation labels during surface remeshing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->