### PR TITLE
ENH: Allow data and output directories of tutorials to be specified

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.mha filter=lfs diff=lfs merge=lfs -text
 docs/assets/*.gif filter=lfs diff=lfs merge=lfs -text
 docs/assets/*.png filter=lfs diff=lfs merge=lfs -text
+tests/baselines/**/*.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -163,7 +163,7 @@ GPU tests require self-hosted runners with:
 **Option 3: Run Locally**
 ```bash
 # Install with CUDA + PhysicsNeMo (matches the self-hosted GPU runner).
-# Requires Python >= 3.11 (nvidia-physicsnemo does not support 3.10).
+# Requires Python 3.11-3.13 (the range nvidia-physicsnemo supports).
 uv pip install -e ".[test,cuda13,physicsnemo]"
 
 # Run GPU tests
@@ -237,7 +237,7 @@ pytest tests/ -m "unit and not requires_gpu" --cov=physiotwin4d
 ### GPU Tests
 ```bash
 # Install with CUDA + PhysicsNeMo (matches the self-hosted GPU runner).
-# Requires Python >= 3.11 (nvidia-physicsnemo does not support 3.10).
+# Requires Python 3.11-3.13 (the range nvidia-physicsnemo supports).
 uv pip install -e ".[test,cuda13,physicsnemo]"
 
 # Run GPU tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - name: Checkout code
@@ -272,7 +272,6 @@ jobs:
     timeout-minutes: 30
     # Only run GPU tests on manual trigger or if 'run-gpu-tests' label is present
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-gpu-tests')
-    continue-on-error: true
 
     steps:
     - name: Checkout code
@@ -281,14 +280,30 @@ jobs:
         lfs: true
 
     - name: Create venv in RUNNER_TEMP
-      # Python 3.11 is required because the [physicsnemo] extra pulls in
-      # nvidia-physicsnemo, which requires Python >= 3.11.
+      # The oldest interpreter the project supports, so this job is the one
+      # that catches a regression at the floor. nightly-health.yml runs the
+      # newest (3.13) for the opposite reason. Both are on the runner.
       run: |
         & "C:\Program Files\Python311\python.exe" -m venv "$env:RUNNER_TEMP\physiotwin4d-venv"
         echo "$env:RUNNER_TEMP\physiotwin4d-venv\Scripts" >> $env:GITHUB_PATH
 
     - name: Check GPU availability
       run: nvidia-smi
+
+    - name: Check nvcc availability
+      # torch-scatter compiles CUDA kernels from source when no matching
+      # pre-built wheel exists. Without nvcc on PATH the build silently falls
+      # back to a CPU-only extension that only fails later, at test time, with
+      # an opaque scatter error. Fail here instead.
+      run: |
+        $nvcc = Get-Command nvcc -ErrorAction SilentlyContinue
+        if (-not $nvcc) {
+            Write-Error "nvcc not found on PATH; torch-scatter would build CPU-only"
+            exit 1
+        }
+        Write-Output "nvcc found at $($nvcc.Source)"
+        nvcc --version
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Cache uv packages
       uses: actions/cache@v4
@@ -308,7 +323,9 @@ jobs:
       # requires_physicsnemo-marked tests can run on this GPU runner.
       # Invoke via python -m uv so uv targets the active venv interpreter.
       run: |
-        python -m uv pip install -e ".[test,cuda13,physicsnemo]"
+        python -m uv pip install -e ".[cuda13]"
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        python -m uv pip install -e ".[test,cuda13,physicsnemo]" --no-build-isolation-package torch-scatter
 
     - name: Assert CUDA is accessible
       run: |
@@ -334,14 +351,26 @@ jobs:
         pip list
 
     - name: Run GPU tests
-      # External self-hosted GPU runner: enable every opt-in bucket via --run-all.
-      # Tests whose host requirements (e.g. a licensed Simpleware install)
-      # aren't met on the runner will runtime-skip cleanly via their
-      # internal availability guards.
+      # A pre-merge gate, so it runs the GPU buckets only and finishes inside
+      # timeout-minutes. The exhaustive --run-all sweep, tutorials included,
+      # belongs to nightly-health.yml: running it here too would duplicate six
+      # hours of work on this same runner and could never fit the timeout.
+      #
+      # --require-tutorial-data turns missing data into a failure rather than a
+      # skip, so this job cannot report green having run nothing.
       run: |
-        pytest tests/ -v --run-all --cov=physiotwin4d --cov-report=xml --cov-report=term --cov-report=html
+        pytest tests/ -v --run-gpu --run-physicsnemo --require-tutorial-data --max-test-seconds=600 --timeout=1800 --cov=physiotwin4d --cov-report=xml --cov-report=term --cov-report=html
       env:
         CUDA_VISIBLE_DEVICES: 0
+        # The datasets, the results and the trained networks live outside the
+        # checkout, which actions/checkout wipes on every run. Each root has a
+        # "test" subtree that this suite reads and writes, so a CI run never
+        # touches a full run's files. Unset, each falls back to its in-repo
+        # default; see data/README.md. These are the same paths
+        # nightly-health.yml uses, because both jobs run on this same runner.
+        PHYSIOTWIN_INPUT_DATA_DIR: D:\PhysioTwin4D\nightly-runner\data
+        PHYSIOTWIN_OUTPUT_DATA_DIR: D:\PhysioTwin4D\nightly-runner\output
+        PHYSIOTWIN_WEIGHTS_DIR: D:\PhysioTwin4D\nightly-runner\network_weights
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -42,7 +42,8 @@ jobs:
 
     outputs:
       # Captures the pytest step's actual outcome (success / failure / skipped)
-      # even though the job itself is not failed by a test failure.
+      # for the dashboard. The job itself is failed by the gate step at the end,
+      # after the artifacts have been uploaded.
       test-outcome: ${{ steps.run-tests.outcome }}
 
     steps:
@@ -70,8 +71,9 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Create venv in RUNNER_TEMP
-        # Python 3.13 is required because the [physicsnemo] extra pulls in
-        # nvidia-physicsnemo, which requires Python >= 3.11.
+        # The newest interpreter the project supports, so this job is the one
+        # that catches a dependency shipping no wheel for it. ci.yml runs the
+        # floor (3.11) for the opposite reason. Both are on the runner.
         run: |
           & "C:\actions-runner\python\WPy64-3.13.12.0\python\python.exe" -m venv "$env:RUNNER_TEMP\physiotwin4d-venv"
           echo "$env:RUNNER_TEMP\physiotwin4d-venv\Scripts" >> $env:GITHUB_PATH
@@ -157,14 +159,33 @@ jobs:
         # continue-on-error keeps the job running so artifacts are always uploaded.
         # The step outcome (success/failure) is still captured and passed downstream.
         continue-on-error: true
+        # --max-test-seconds fails a test that finishes but took too long, so the
+        # overrun is reported with its duration and the rest of the suite still
+        # runs. --timeout raises the pytest-timeout backstop above it: on
+        # Windows that backstop can only kill the whole process, which would
+        # take the JUnit XML and every other result with it, so it is left to
+        # catch a genuine hang and nothing else. Both numbers are provisional
+        # until the per-tutorial timings are measured.
         run: |
-          pytest tests/ -v --run-all `
+          pytest tests/ -v --run-all --require-tutorial-data `
+            --max-test-seconds=900 `
+            --timeout=3600 `
             --cov=physiotwin4d `
             --cov-report=xml `
             --cov-report=json `
             --junitxml=test-results.xml
         env:
           CUDA_VISIBLE_DEVICES: 0
+          # The datasets, the results and the trained networks live on the
+          # runner's own disk rather than in the checkout, which
+          # actions/checkout wipes every run. Each root has a "test" subtree
+          # that this suite reads and writes, so a nightly run never touches a
+          # full run's files, and the downsampled subsets the fixtures build
+          # under <input>/test survive between runs instead of being rebuilt.
+          # Unset, each falls back to its in-repo default; see data/README.md.
+          PHYSIOTWIN_INPUT_DATA_DIR: D:\PhysioTwin4D\nightly-runner\data
+          PHYSIOTWIN_OUTPUT_DATA_DIR: D:\PhysioTwin4D\nightly-runner\output
+          PHYSIOTWIN_WEIGHTS_DIR: D:\PhysioTwin4D\nightly-runner\network_weights
 
       - name: Upload test results
         uses: actions/upload-artifact@v6
@@ -176,6 +197,18 @@ jobs:
             coverage.xml
             coverage.json
           retention-days: 90
+
+      - name: Fail the job if the test suite did not pass
+        # The pytest step is continue-on-error so that the artifacts and the
+        # dashboard are produced whatever happened. Without this gate the job
+        # would report success even when tests failed or the step timed out,
+        # and the workflow status badge would say green while nothing passed.
+        # build-dashboard runs on if: always(), so it still gets its inputs.
+        if: steps.run-tests.outcome != 'success'
+        run: |
+          Write-Output "Health test suite outcome: ${{ steps.run-tests.outcome }}"
+          Write-Output "See the health-test-results artifact for the JUnit XML."
+          exit 1
 
   # ──────────────────────────────────────────────────────────────────────────
   # 2. Build the HTML dashboard from test results (runs even if tests failed)

--- a/data/README.md
+++ b/data/README.md
@@ -49,7 +49,7 @@ survive a checkout and are built once rather than every run.
 
 The layout under an overridden input root is the same as here:
 
-```
+```text
 <PHYSIOTWIN_INPUT_DATA_DIR>/
   DirLab-4DCT/             Case1Pack_T00.mha, ...
   Duke-Heart-4DLabelmaps/  pm0027/*_labelmap.nii.gz, *_landmark.mrk.json

--- a/data/README.md
+++ b/data/README.md
@@ -26,6 +26,39 @@ downloader — DIR-Lab distributes each case individually and may require
 registration, so it must be obtained manually; see
 [DirLab-4DCT/README.md](DirLab-4DCT/README.md).
 
+## Keeping the Data Outside the Clone
+
+The tutorials resolve three roots through `ParametersBase` in
+[`tutorials/parameters_base.py`](../tutorials/parameters_base.py), each
+defaulting to its location in the clone and each overridable by environment
+variable. Point them elsewhere when the data should outlive the checkout — on a
+CI runner, for instance, where every run starts from a fresh working tree:
+
+| Variable | Default | Holds |
+| --- | --- | --- |
+| `PHYSIOTWIN_INPUT_DATA_DIR` | `<repo>/data` | The datasets in this directory |
+| `PHYSIOTWIN_OUTPUT_DATA_DIR` | `<repo>/tutorials/output` | What the tutorials write |
+| `PHYSIOTWIN_WEIGHTS_DIR` | `<repo>/tutorials/network_weights` | Networks the tutorials train |
+
+Each root has a `test` subdirectory used when a tutorial runs under
+`PHYSIOTWIN_RUNNING_AS_TEST`, so a test run reads the small downsampled subsets
+and writes beside them rather than touching a full run's datasets, results, or
+checkpoints. The subsets under `<input root>/test` are built on demand by the
+fixtures in `tests/conftest.py`; putting that root outside the clone means they
+survive a checkout and are built once rather than every run.
+
+The layout under an overridden input root is the same as here:
+
+```
+<PHYSIOTWIN_INPUT_DATA_DIR>/
+  DirLab-4DCT/             Case1Pack_T00.mha, ...
+  Duke-Heart-4DLabelmaps/  pm0027/*_labelmap.nii.gz, *_landmark.mrk.json
+  Chest-CT/                Chest-CT.mha
+  KCL-Heart-Model/         average_mesh.vtk, input_meshes/
+  Slicer-Heart-CT/         slice_000.mha, ...
+  test/                    built by the pytest fixtures
+```
+
 ## Notes
 
 - Always cite the original data source in publications — see each dataset's

--- a/data/test/.gitignore
+++ b/data/test/.gitignore
@@ -1,2 +1,5 @@
-slicer_heart
-slicer_heart_small
+# Everything here is a pytest-built cache; only this file and the README are
+# tracked. See README.md for which fixture builds which directory.
+*
+!.gitignore
+!README.md

--- a/data/test/README.md
+++ b/data/test/README.md
@@ -22,19 +22,23 @@ subsets here only when run as tests, under `PHYSIOTWIN_RUNNING_AS_TEST`.
   used by tests that need a smaller/faster image (labelmaps and
   transforms computed from this data are cached here too).
 - `KCL-Heart-Model/` — downloaded by the `download_kcl_heart_model` fixture.
-- `DirLab-4DCT/` — a few cases from `data/DirLab-4DCT`, downsampled to 3 mm
-  by the `dirlab_test_data` fixture.
-- `Duke-Heart-4DLabelmaps/` — a few cases from `data/Duke-Heart-4DLabelmaps`,
-  their labelmaps downsampled to 2 mm nearest-neighbour by the
-  `duke_heart_test_data` fixture.
-- `Chest-CT/` — `data/Chest-CT` downsampled to 3 mm by the `chest_ct_test_data`
-  fixture.
+- `DirLab-4DCT/` — a few cases from `<input root>/DirLab-4DCT`, downsampled to
+  3 mm by the `dirlab_test_data` fixture.
+- `Duke-Heart-4DLabelmaps/` — a few cases from
+  `<input root>/Duke-Heart-4DLabelmaps`, their labelmaps downsampled to 2 mm
+  nearest-neighbour by the `duke_heart_test_data` fixture.
+- `Chest-CT/` — `<input root>/Chest-CT` downsampled to 3 mm by the
+  `chest_ct_test_data` fixture.
+
+Here `<input root>` is whatever `PHYSIOTWIN_INPUT_DATA_DIR` names, defaulting to
+the `data/` directory of the clone — so each subset is built from the full
+dataset alongside it, wherever that root has been pointed.
 
 Every subdirectory is created on demand by `tests/conftest.py` fixtures
 the first time a test needs them, and is `.gitignore`d — do not commit
 their contents. The subsets derived from another dataset are only built
-when that source dataset is present under `data/`; otherwise the tests that
-need them skip, or fail if `--require-tutorial-data` was passed.
+when that source dataset is present under the input root; otherwise the tests
+that need them skip, or fail if `--require-tutorial-data` was passed.
 
 The tutorials read these directories rather than the full datasets whenever
 `PHYSIOTWIN_RUNNING_AS_TEST` is set, and write to the matching `test` subtree of

--- a/data/test/README.md
+++ b/data/test/README.md
@@ -4,9 +4,14 @@ This directory is **automatically managed by the pytest infrastructure**
 (`tests/conftest.py`) — it is a cache, not a dataset you download or
 maintain by hand. It holds data used to run the unit test suite.
 
-This data is **not** used by the workflows, tutorials, or CLIs of the
-PhysioTwin4D library; those consume the datasets documented in
-[`data/README.md`](../README.md) instead.
+It is the `test` subdirectory of the input data root, so setting
+`PHYSIOTWIN_INPUT_DATA_DIR` moves it too; see
+[`data/README.md`](../README.md#keeping-the-data-outside-the-clone). The paths
+below are written relative to that root, which defaults to `data/`.
+
+The workflows, tutorials, and CLIs of the PhysioTwin4D library consume the
+full datasets documented in [`data/README.md`](../README.md). They read the
+subsets here only when run as tests, under `PHYSIOTWIN_RUNNING_AS_TEST`.
 
 ## What Lives Here
 
@@ -16,10 +21,26 @@ PhysioTwin4D library; those consume the datasets documented in
 - `slicer_heart_small/` — the same phases downsampled to 1.5x1.5x1.5 mm,
   used by tests that need a smaller/faster image (labelmaps and
   transforms computed from this data are cached here too).
+- `KCL-Heart-Model/` — downloaded by the `download_kcl_heart_model` fixture.
+- `DirLab-4DCT/` — a few cases from `data/DirLab-4DCT`, downsampled to 3 mm
+  by the `dirlab_test_data` fixture.
+- `Duke-Heart-4DLabelmaps/` — a few cases from `data/Duke-Heart-4DLabelmaps`,
+  their labelmaps downsampled to 2 mm nearest-neighbour by the
+  `duke_heart_test_data` fixture.
+- `Chest-CT/` — `data/Chest-CT` downsampled to 3 mm by the `chest_ct_test_data`
+  fixture.
 
-Both subdirectories are created on demand by `tests/conftest.py` fixtures
-the first time a test needs them, and are `.gitignore`d — do not commit
-their contents.
+Every subdirectory is created on demand by `tests/conftest.py` fixtures
+the first time a test needs them, and is `.gitignore`d — do not commit
+their contents. The subsets derived from another dataset are only built
+when that source dataset is present under `data/`; otherwise the tests that
+need them skip, or fail if `--require-tutorial-data` was passed.
+
+The tutorials read these directories rather than the full datasets whenever
+`PHYSIOTWIN_RUNNING_AS_TEST` is set, and write to the matching `test` subtree of
+the output and weights roots — `tutorials/output/test/` and
+`tutorials/network_weights/test/` by default. A test run therefore never reads
+or overwrites the datasets, results, or trained checkpoints of a full run.
 
 ## Regenerating
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -68,10 +68,12 @@ torchvision, and torchaudio are sourced from
 What Python version is required?
 ---------------------------------
 
-Python 3.10, 3.11 and 3.12 are supported.
+Python 3.11, 3.12 and 3.13 are supported.
 
-The one exception is the optional ``[physicsnemo]`` extra: ``nvidia-physicsnemo``
-requires Python >= 3.11, so the AI-surrogate tutorials need 3.11 or 3.12.
+The floor is set by the optional ``[physicsnemo]`` extra: ``nvidia-physicsnemo``
+supports >= 3.11, < 3.14, and the AI-surrogate tutorials need it. The rest of
+the library would run on 3.10, but declaring 3.10 would promise an install
+that cannot resolve that extra.
 
 Usage Questions
 ===============

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ Prerequisites
 System Requirements
 -------------------
 
-* **Python**: 3.10, 3.11, or 3.12
+* **Python**: 3.11, 3.12, or 3.13
 * **GPU**: NVIDIA GPU with CUDA 13 — required for full capability and best performance; a CPU-only PyPI installation is a supported fallback, but it is slow, emits a runtime warning, and cannot run the AI-surrogate workflows
 * **RAM**: 16GB minimum (32GB+ recommended for large datasets)
 * **Storage**: 10GB+ for package and model weights

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ maintainers = [
 ]
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache-2.0"}
-requires-python = ">=3.10"
+# 3.11 is the floor because the [physicsnemo] extra needs nvidia-physicsnemo,
+# which supports >=3.11,<3.14. Declaring 3.10 made that extra unresolvable
+# there while claiming otherwise.
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Healthcare Industry",
@@ -22,9 +25,9 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Scientific/Engineering :: Image Processing",
     "Topic :: Scientific/Engineering :: Visualization",
@@ -76,7 +79,10 @@ dependencies = [
     "einops>=0.6.1",
 
     # Registration
-    "antspyx>=0.4.0",
+    # 0.6.1 is the first release with a CPython 3.13 Windows wheel. Below it the
+    # solver is free to pick 0.5.3, whose newest Windows wheel is 3.12, and on
+    # 3.13 that means building ANTs and ITK from source -- which fails.
+    "antspyx>=0.6.1",
     "icon-registration>=1.0.0",
     "picsl-greedy>=0.0.12",
     "scipy>=1.10.0",
@@ -105,6 +111,11 @@ link-mode = "copy"
 # so torch (and setuptools) must already be installed before installing the
 # physicsnemo extra.
 no-build-isolation-package = ["torch-scatter"]
+# antspyx builds ANTs and ITK from source, which takes a long time and needs a
+# toolchain the runners do not all have. Refusing the sdist turns a silent
+# fallback to a doomed source build into an immediate resolution error naming
+# the interpreter that has no wheel.
+no-build-package = ["antspyx"]
 
 # PyTorch packages default to the CUDA 13.0 wheel index for uv-managed
 # environments. This avoids ambiguous resolution across multiple PyTorch CUDA
@@ -249,7 +260,11 @@ push = false
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
+# The tutorials' parameter modules are plain sibling modules rather than a
+# package, so tests that import them need this on the search path, the same
+# way pythonpath does it for pytest.
+mypy_path = "tutorials"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -333,6 +348,7 @@ module = [
     # pre-commit mypy environment and ships no py.typed marker when installed.
     # mypy per-module patterns match whole components only, so each tutorial is
     # listed by name; add a line here when adding or renaming a tutorial.
+    "parameters_base",
     "parameters_duke_heart_labelmaps",
     "parameters_heart_ct_kcl",
     "parameters_lung_ct_dirlab",
@@ -394,7 +410,7 @@ addopts = [
     "--cov-report=xml"
 ]
 testpaths = ["tests"]
-pythonpath = ["."]
+pythonpath = [".", "tutorials"]
 # Surface every warning by default ("always"), then silence the third-party
 # ITK/SWIG binding noise emitted while wrapped C++ types are defined at import
 # on CPython >=3.12 ("builtin type Swig... has no __module__ attribute").
@@ -445,7 +461,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 88
 extend-exclude = [
     ".git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,9 @@ dev = [
     "pre-commit>=3.0.0",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    # See the [test] extra: conftest.py needs a pluggy new enough for
+    # pytest.hookimpl(wrapper=True), which pytest>=7.0 alone does not pin.
+    "pluggy>=1.2.0",
     "mypy>=2.1.0",
     "ruff>=0.1.0",
     "scipy-stubs>=1.14.0.0,<1.16.0.0",
@@ -201,6 +204,10 @@ test = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-xdist>=3.0.0",
+    # conftest.py's pytest_runtest_makereport uses pytest.hookimpl(wrapper=True),
+    # a new-style hook wrapper that pluggy only grew in 1.2.0. pytest>=7.0 alone
+    # permits an older pluggy, where that keyword raises at collection time.
+    "pluggy>=1.2.0",
     "pytest-timeout>=2.0.0",
     "coverage[toml]>=7.0.0",
 ]

--- a/src/physiotwin4d/test_tools.py
+++ b/src/physiotwin4d/test_tools.py
@@ -224,8 +224,10 @@ class TestTools(PhysioTwin4DBase):
         self,
     ) -> tuple[bool, int]:
         """
-        Return (pass, value) for number of values above tolerance from the most recent compare_result_to_baseline_transform call.
-        pass is True if value <= max_number_of_values_above_tol that was used in that call.
+        Return (pass, value) for number of values above tolerance from the
+        most recent compare_result_to_baseline_transform call.
+        pass is True if value <= max_number_of_values_above_tol that was used
+        in that call.
         """
         if (
             self._last_transform_number_of_values_above_tol is None
@@ -238,7 +240,8 @@ class TestTools(PhysioTwin4DBase):
 
     def transform_pass_fail_and_total_absolute_error(self) -> tuple[bool, float]:
         """
-        Return (pass, value) for total absolute error from the most recent compare_result_to_baseline_transform call.
+        Return (pass, value) for total absolute error from the most recent
+        compare_result_to_baseline_transform call.
         pass is True if value <= total_absolute_error_tol that was used in that call.
         """
         if (
@@ -251,7 +254,8 @@ class TestTools(PhysioTwin4DBase):
         return (passed, val)
 
     def transform_difference(self) -> Any:
-        """Return the difference transform (itk.Transform) from the most recent compare_result_to_baseline_transform call."""
+        """Return the difference transform (itk.Transform) from the most
+        recent compare_result_to_baseline_transform call."""
         if self._last_transform_difference_transform is None:
             raise RuntimeError("No previous compare_result_to_baseline_transform call")
         return self._last_transform_difference_transform
@@ -282,7 +286,8 @@ class TestTools(PhysioTwin4DBase):
         if not baseline_path.exists():
             if not _create_baseline_if_missing:
                 self.log_error(
-                    "Baseline transform missing: %s (run pytest with --create-baselines to create from current output)",
+                    "Baseline transform missing: %s (run pytest with "
+                    "--create-baselines to create from current output)",
                     baseline_path,
                 )
                 return False
@@ -328,7 +333,8 @@ class TestTools(PhysioTwin4DBase):
 
         if passed:
             self.log_info(
-                "PASS: number_of_values_above_tol=%d (max=%d), total_absolute_error=%.6g (tol=%.6g)",
+                "PASS: number_of_values_above_tol=%d (max=%d), "
+                "total_absolute_error=%.6g (tol=%.6g)",
                 self._last_transform_number_of_values_above_tol,
                 self._last_transform_max_number_of_values_above_tol,
                 self._last_transform_total_absolute_error,
@@ -336,7 +342,8 @@ class TestTools(PhysioTwin4DBase):
             )
         else:
             self.log_error(
-                "FAIL: number_of_values_above_tol=%d (max=%d), total_absolute_error=%.6g (tol=%.6g)",
+                "FAIL: number_of_values_above_tol=%d (max=%d), "
+                "total_absolute_error=%.6g (tol=%.6g)",
                 self._last_transform_number_of_values_above_tol,
                 self._last_transform_max_number_of_values_above_tol,
                 self._last_transform_total_absolute_error,
@@ -379,7 +386,8 @@ class TestTools(PhysioTwin4DBase):
         if not baseline_path.exists():
             if not _create_baseline_if_missing:
                 self.log_error(
-                    "Baseline image missing: %s (run pytest with --create-baselines to create from current output)",
+                    "Baseline image missing: %s (run pytest with "
+                    "--create-baselines to create from current output)",
                     baseline_path,
                 )
                 return False
@@ -400,7 +408,8 @@ class TestTools(PhysioTwin4DBase):
 
         if arr_result.shape != arr_baseline.shape:
             raise ValueError(
-                f"Shape mismatch: result {arr_result.shape} vs baseline {arr_baseline.shape}"
+                f"Shape mismatch: result {arr_result.shape} vs "
+                f"baseline {arr_baseline.shape}"
             )
 
         diff_magnitude = np.abs(arr_result - arr_baseline)
@@ -434,7 +443,8 @@ class TestTools(PhysioTwin4DBase):
 
         if passed:
             self.log_info(
-                "PASS: number_of_pixels_above_tol=%d (max=%d), total_absolute_error=%.6g (tol=%.6g)",
+                "PASS: number_of_pixels_above_tol=%d (max=%d), "
+                "total_absolute_error=%.6g (tol=%.6g)",
                 number_of_pixels_above_tol,
                 max_number_of_pixels_above_tol,
                 total_absolute_error,
@@ -442,7 +452,8 @@ class TestTools(PhysioTwin4DBase):
             )
         else:
             self.log_error(
-                "FAIL: number_of_pixels_above_tol=%d (max=%d), total_absolute_error=%.6g (tol=%.6g)",
+                "FAIL: number_of_pixels_above_tol=%d (max=%d), "
+                "total_absolute_error=%.6g (tol=%.6g)",
                 number_of_pixels_above_tol,
                 max_number_of_pixels_above_tol,
                 total_absolute_error,
@@ -494,7 +505,8 @@ class TestTools(PhysioTwin4DBase):
         if not baseline_path.exists():
             if not _create_baseline_if_missing:
                 self.log_error(
-                    "Baseline metrics missing: %s (run pytest with --create-baselines to create from current output)",
+                    "Baseline metrics missing: %s (run pytest with "
+                    "--create-baselines to create from current output)",
                     baseline_path,
                 )
                 return False

--- a/src/physiotwin4d/test_tools.py
+++ b/src/physiotwin4d/test_tools.py
@@ -8,6 +8,8 @@ passed as itk.Image at the API level.
 
 from __future__ import annotations
 
+import csv
+import json
 import logging
 import os
 import shutil
@@ -30,6 +32,69 @@ def set_create_baseline_if_missing(value: bool) -> None:
     """Set whether to create baseline files when missing (used by pytest conftest)."""
     global _create_baseline_if_missing
     _create_baseline_if_missing = value
+
+
+def _as_scalar(value: Any) -> Any:
+    """Return value as a float when it reads as one, otherwise unchanged."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return value
+    return value
+
+
+def _flatten_metrics(value: Any, prefix: str = "") -> dict[str, Any]:
+    """Flatten nested JSON into dotted keys holding one scalar each."""
+    flattened: dict[str, Any] = {}
+    if isinstance(value, dict):
+        for key, item in value.items():
+            flattened.update(
+                _flatten_metrics(item, f"{prefix}.{key}" if prefix else str(key))
+            )
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            flattened.update(_flatten_metrics(item, f"{prefix}[{index}]"))
+    else:
+        flattened[prefix] = _as_scalar(value)
+    return flattened
+
+
+def _read_metrics(path: Path) -> dict[str, Any]:
+    """
+    Read a JSON or CSV of metrics into one flat name -> scalar mapping.
+
+    CSV rows are keyed by their first column when that column's values are
+    unique, and by row index otherwise, so a metrics table keyed by case id
+    compares case to case rather than row to row.
+    """
+    if path.suffix.lower() == ".json":
+        with path.open(encoding="utf-8") as handle:
+            return _flatten_metrics(json.load(handle))
+
+    if path.suffix.lower() == ".csv":
+        with path.open(newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+        if not rows:
+            return {}
+        fieldnames = [name for name in (rows[0].keys()) if name is not None]
+        label_column = fieldnames[0]
+        labels = [row.get(label_column, "") or "" for row in rows]
+        use_labels = len(set(labels)) == len(labels)
+        flattened: dict[str, Any] = {}
+        for index, row in enumerate(rows):
+            row_key = labels[index] if use_labels else str(index)
+            for name in fieldnames:
+                if name == label_column and use_labels:
+                    continue
+                flattened[f"{row_key}.{name}"] = _as_scalar(row.get(name))
+        return flattened
+
+    raise ValueError(f"Unsupported metrics format (expected .json or .csv): {path}")
 
 
 class TestTools(PhysioTwin4DBase):
@@ -385,6 +450,107 @@ class TestTools(PhysioTwin4DBase):
             )
 
         return passed
+
+    def compare_result_to_baseline_metrics(
+        self,
+        filename: str,
+        *,
+        relative_tol: float = 0.0,
+        absolute_tol: float = 0.0,
+        ignore_keys: Optional[list[str]] = None,
+    ) -> bool:
+        """
+        Compare the scalar metrics in a JSON or CSV result against a baseline.
+
+        Catches the accuracy drift that a screenshot comparison cannot see: two
+        renderings can agree pixel for pixel while the numbers behind them move.
+
+        A value passes when it is within ``absolute_tol`` or within
+        ``relative_tol`` of the baseline, so a tolerance pair covers both the
+        metrics that live near zero and the ones that do not.  Non-numeric
+        values must match exactly; a key present in one file and not the other
+        is a failure, because a metric appearing or disappearing is a change in
+        what the tutorial reports.
+
+        If the baseline file does not exist and --create-baselines was given,
+        the result is copied as the new baseline.
+
+        Args:
+            filename: File name (relative to class results/baselines dirs), with
+                a ``.json`` or ``.csv`` suffix.
+            relative_tol: Allowed fractional difference per value.
+            absolute_tol: Allowed absolute difference per value.
+            ignore_keys: Metric names to skip, for values that legitimately
+                differ between runs (wall-clock timings, host paths).
+
+        Returns:
+            True if every compared value is within tolerance.
+        """
+        results_path = Path(self._results_dir / filename)
+        baseline_path = Path(self._baselines_dir / filename)
+        if not results_path.exists():
+            raise FileNotFoundError(f"Results metrics not found: {results_path}")
+
+        if not baseline_path.exists():
+            if not _create_baseline_if_missing:
+                self.log_error(
+                    "Baseline metrics missing: %s (run pytest with --create-baselines to create from current output)",
+                    baseline_path,
+                )
+                return False
+            baseline_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(str(results_path), str(baseline_path))
+            self.log_warning(
+                "Baseline file did not exist; copied result: %s", baseline_path
+            )
+            return True
+
+        skip = set(ignore_keys or [])
+        result_values = _read_metrics(results_path)
+        baseline_values = _read_metrics(baseline_path)
+
+        failures: list[str] = []
+        for key in sorted(set(result_values) | set(baseline_values)):
+            if key in skip:
+                continue
+            if key not in result_values:
+                failures.append(f"{key}: missing from result")
+                continue
+            if key not in baseline_values:
+                failures.append(f"{key}: not in baseline")
+                continue
+            result_value = result_values[key]
+            baseline_value = baseline_values[key]
+            if isinstance(result_value, float) and isinstance(baseline_value, float):
+                difference = abs(result_value - baseline_value)
+                if difference <= absolute_tol:
+                    continue
+                if difference <= relative_tol * abs(baseline_value):
+                    continue
+                failures.append(
+                    f"{key}: {result_value:.6g} vs baseline {baseline_value:.6g} "
+                    f"(difference {difference:.6g})"
+                )
+            elif result_value != baseline_value:
+                failures.append(
+                    f"{key}: {result_value!r} vs baseline {baseline_value!r}"
+                )
+
+        if failures:
+            self.log_error(
+                "FAIL: %s differs from baseline in %d value(s): %s",
+                filename,
+                len(failures),
+                "; ".join(failures[:10]),
+            )
+            return False
+
+        self.log_info(
+            "PASS: %s matches baseline in %d value(s)",
+            filename,
+            len(set(result_values) - skip),
+        )
+        return True
 
     def save_screenshot_mesh(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ in the tests directory via pytest's automatic fixture discovery.
 
 import logging
 import os
+import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Optional
@@ -15,6 +16,7 @@ import itk
 import numpy as np
 import pytest
 
+from parameters_base import ParametersBase
 from physiotwin4d.contour_tools import ContourTools
 from physiotwin4d.data_download_tools import DataDownloadTools
 from physiotwin4d.register_images_ants import RegisterImagesANTS
@@ -105,6 +107,41 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Create baseline files from current test outputs when missing (otherwise missing baseline fails)",
     )
+    parser.addoption(
+        "--max-test-seconds",
+        type=float,
+        default=0.0,
+        help=(
+            "Fail any test whose call phase runs longer than this many seconds. "
+            "Unlike the pytest-timeout backstop, the test is allowed to finish, "
+            "so the failure carries its duration and reaches the JUnit XML. "
+            "0 (the default) disables the budget."
+        ),
+    )
+    parser.addoption(
+        "--require-tutorial-data",
+        action="store_true",
+        default=False,
+        help=(
+            "Fail rather than skip when a tutorial's dataset is missing. For "
+            "runners that are supposed to have every dataset, where a skip "
+            "would report a green run that tested nothing."
+        ),
+    )
+
+
+def tutorial_data_is_required() -> bool:
+    """True when --require-tutorial-data turns missing-data skips into failures."""
+    if _pytest_config is None:
+        return False
+    return bool(_pytest_config.getoption("--require-tutorial-data", default=False))
+
+
+def skip_or_fail_missing_data(reason: str) -> None:
+    """Skip because a dataset is absent, or fail if the run demands it be there."""
+    if tutorial_data_is_required():
+        pytest.fail(f"{reason} (--require-tutorial-data is set)")
+    pytest.skip(reason)
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -194,6 +231,31 @@ def pytest_collection_modifyitems(
                     )
                 )
             )
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]) -> Any:
+    """Fail a test that passed but took longer than --max-test-seconds.
+
+    The pytest-timeout ``timeout`` setting in pyproject.toml is a backstop for a
+    genuine hang: on Windows it can only kill the whole process, which loses the
+    JUnit XML, the coverage data and every other test's result along with it. A
+    budget checked after the test has finished costs none of that -- the run
+    continues and the overrun is reported as an ordinary failure naming the
+    duration and the limit.
+    """
+    report = yield
+    if report.when != "call" or not report.passed or _pytest_config is None:
+        return report
+    limit = float(_pytest_config.getoption("--max-test-seconds", default=0.0) or 0.0)
+    if limit > 0.0 and report.duration > limit:
+        report.outcome = "failed"
+        report.longrepr = (
+            f"Exceeded the {limit:g}s runtime budget: took {report.duration:.1f}s. "
+            "Reduce the work this test does in test mode, or raise "
+            "--max-test-seconds if the cost is expected."
+        )
+    return report
 
 
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
@@ -349,7 +411,7 @@ def _format_duration(seconds: float) -> str:
 @pytest.fixture(scope="session")
 def test_directories() -> dict[str, Path]:
     """Set up test directories for data and results."""
-    data_dir = Path(__file__).parent.parent / "data" / "test"
+    data_dir = ParametersBase().data_directory(test_mode=True)
     slicer_heart_data_dir = data_dir / "slicer_heart"
     slicer_heart_small_data_dir = data_dir / "slicer_heart_small"
     output_dir = Path(__file__).parent / "results"
@@ -459,6 +521,140 @@ def test_images(
     images = [itk.imread(str(f)) for f in slice_files]
     logger.info("Loaded %d time points for testing", len(images))
     return images
+
+
+# Tutorial Test-Data Fixtures
+# ============================================================================
+#
+# The tutorials read data/<dataset> in a full run and data/test/<dataset> under
+# PHYSIOTWIN_RUNNING_AS_TEST.  These fixtures build the latter from the former,
+# small enough that a tutorial test finishes in minutes rather than hours.  Each
+# skips when its source dataset is absent, so a clone that has not downloaded
+# every dataset still runs whatever it can.
+
+
+def _downsample_image(source: Path, destination: Path, spacing_mm: float) -> None:
+    """Resample source to an isotropic pitch and write it to destination."""
+    image = itk.imread(str(source))
+    target_spacing = [spacing_mm] * 3
+    input_spacing = list(image.GetSpacing())
+    input_size = list(itk.size(image))
+    output_size = [
+        max(1, int(round(input_size[i] * input_spacing[i] / target_spacing[i])))
+        for i in range(3)
+    ]
+    resampler = itk.ResampleImageFilter.New(Input=image)
+    resampler.SetInterpolator(itk.LinearInterpolateImageFunction.New(image))
+    resampler.SetOutputSpacing(target_spacing)
+    resampler.SetSize(output_size)
+    resampler.SetOutputOrigin(image.GetOrigin())
+    resampler.SetOutputDirection(image.GetDirection())
+    resampler.Update()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    itk.imwrite(resampler.GetOutput(), str(destination), compression=True)
+
+
+def _downsample_labelmap(source: Path, destination: Path, spacing_mm: float) -> None:
+    """Resample a labelmap nearest-neighbour, so no label is interpolated away."""
+    image = itk.imread(str(source))
+    target_spacing = [spacing_mm] * 3
+    input_spacing = list(image.GetSpacing())
+    input_size = list(itk.size(image))
+    output_size = [
+        max(1, int(round(input_size[i] * input_spacing[i] / target_spacing[i])))
+        for i in range(3)
+    ]
+    resampler = itk.ResampleImageFilter.New(Input=image)
+    resampler.SetInterpolator(itk.NearestNeighborInterpolateImageFunction.New(image))
+    resampler.SetOutputSpacing(target_spacing)
+    resampler.SetSize(output_size)
+    resampler.SetOutputOrigin(image.GetOrigin())
+    resampler.SetOutputDirection(image.GetDirection())
+    resampler.Update()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    itk.imwrite(resampler.GetOutput(), str(destination), compression=True)
+
+
+# Cases kept in the test subsets.  Each list leads with the case the tutorials
+# hold out, and carries enough others that a model can still be built without it
+# (Tutorials 6 and 9 both refuse to run on fewer than three).
+_DIRLAB_TEST_CASES = ["Case1Pack", "Case2Pack", "Case3Pack"]
+_DUKE_HEART_TEST_CASES = ["pm0027", "pm0002", "pm0003", "pm0004"]
+
+
+@pytest.fixture(scope="session")
+def dirlab_test_data(test_directories: dict[str, Path]) -> Path:
+    """Build data/test/DirLab-4DCT: a few cases, downsampled to 3 mm."""
+    source_dir = ParametersBase().data_directory(test_mode=False) / "DirLab-4DCT"
+    target_dir = test_directories["data"] / "DirLab-4DCT"
+    if not source_dir.is_dir():
+        skip_or_fail_missing_data(
+            f"DIR-Lab data not found at {source_dir}. "
+            "See data/DirLab-4DCT/README.md; it must be downloaded by hand."
+        )
+
+    for case_id in _DIRLAB_TEST_CASES:
+        for phase_file in sorted(source_dir.glob(f"{case_id}_T??.mha")):
+            small_file = target_dir / phase_file.name
+            if not small_file.exists():
+                logger.info("Downsampling %s -> %s", phase_file.name, small_file)
+                _downsample_image(phase_file, small_file, 3.0)
+
+    if not list(target_dir.glob("*_T??.mha")):
+        skip_or_fail_missing_data(f"No DIR-Lab cases could be built under {target_dir}")
+    return target_dir
+
+
+@pytest.fixture(scope="session")
+def duke_heart_test_data(test_directories: dict[str, Path]) -> Path:
+    """Build data/test/Duke-Heart-4DLabelmaps: a few cases, downsampled to 2 mm."""
+    source_dir = (
+        ParametersBase().data_directory(test_mode=False) / "Duke-Heart-4DLabelmaps"
+    )
+    target_dir = test_directories["data"] / "Duke-Heart-4DLabelmaps"
+    if not source_dir.is_dir():
+        skip_or_fail_missing_data(f"Duke heart labelmaps not found at {source_dir}")
+
+    for case_id in _DUKE_HEART_TEST_CASES:
+        case_dir = source_dir / case_id
+        if not case_dir.is_dir():
+            continue
+        for labelmap_file in sorted(case_dir.glob("*_labelmap.nii.gz")):
+            small_file = target_dir / case_id / labelmap_file.name
+            if not small_file.exists():
+                logger.info("Downsampling %s -> %s", labelmap_file.name, small_file)
+                _downsample_labelmap(labelmap_file, small_file, 2.0)
+        # The landmarks are JSON in world coordinates, so resampling the
+        # labelmaps leaves them valid and they are copied as they are.
+        for landmark_file in sorted(case_dir.glob("*_landmark.mrk.json")):
+            small_file = target_dir / case_id / landmark_file.name
+            if not small_file.exists():
+                small_file.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(str(landmark_file), str(small_file))
+
+    built = [d for d in target_dir.glob("pm*") if d.is_dir()]
+    if len(built) < 3:
+        skip_or_fail_missing_data(
+            f"Only {len(built)} Duke heart case(s) under {target_dir}; need 3."
+        )
+    return target_dir
+
+
+@pytest.fixture(scope="session")
+def chest_ct_test_data(test_directories: dict[str, Path]) -> Path:
+    """Build data/test/Chest-CT: the single study, downsampled to 3 mm."""
+    source_file = (
+        ParametersBase().data_directory(test_mode=False) / "Chest-CT" / "Chest-CT.mha"
+    )
+    target_dir = test_directories["data"] / "Chest-CT"
+    if not source_file.exists():
+        skip_or_fail_missing_data(f"Chest-CT data not found at {source_file}")
+
+    target_file = target_dir / source_file.name
+    if not target_file.exists():
+        logger.info("Downsampling %s -> %s", source_file.name, target_file)
+        _downsample_image(source_file, target_file, 3.0)
+    return target_dir
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -526,8 +526,10 @@ def test_images(
 # Tutorial Test-Data Fixtures
 # ============================================================================
 #
-# The tutorials read data/<dataset> in a full run and data/test/<dataset> under
-# PHYSIOTWIN_RUNNING_AS_TEST.  These fixtures build the latter from the former,
+# The tutorials read <input root>/<dataset> in a full run and
+# <input root>/test/<dataset> under PHYSIOTWIN_RUNNING_AS_TEST, where the root is
+# ParametersBase().data_directory() -- PHYSIOTWIN_INPUT_DATA_DIR, or the clone's
+# data/ when that is unset.  These fixtures build the latter from the former,
 # small enough that a tutorial test finishes in minutes rather than hours.  Each
 # skips when its source dataset is absent, so a clone that has not downloaded
 # every dataset still runs whatever it can.
@@ -584,7 +586,12 @@ _DUKE_HEART_TEST_CASES = ["pm0027", "pm0002", "pm0003", "pm0004"]
 
 @pytest.fixture(scope="session")
 def dirlab_test_data(test_directories: dict[str, Path]) -> Path:
-    """Build data/test/DirLab-4DCT: a few cases, downsampled to 3 mm."""
+    """Build the DIR-Lab test subset: a few cases, downsampled to 3 mm.
+
+    Reads ``<input root>/DirLab-4DCT`` and writes ``<input root>/test/
+    DirLab-4DCT``, where the root is whatever ``PHYSIOTWIN_INPUT_DATA_DIR``
+    names and defaults to the clone's ``data/``.
+    """
     source_dir = ParametersBase().data_directory(test_mode=False) / "DirLab-4DCT"
     target_dir = test_directories["data"] / "DirLab-4DCT"
     if not source_dir.is_dir():
@@ -607,7 +614,12 @@ def dirlab_test_data(test_directories: dict[str, Path]) -> Path:
 
 @pytest.fixture(scope="session")
 def duke_heart_test_data(test_directories: dict[str, Path]) -> Path:
-    """Build data/test/Duke-Heart-4DLabelmaps: a few cases, downsampled to 2 mm."""
+    """Build the Duke heart test subset: a few cases, downsampled to 2 mm.
+
+    Reads ``<input root>/Duke-Heart-4DLabelmaps`` and writes ``<input root>/
+    test/Duke-Heart-4DLabelmaps``, where the root is whatever
+    ``PHYSIOTWIN_INPUT_DATA_DIR`` names and defaults to the clone's ``data/``.
+    """
     source_dir = (
         ParametersBase().data_directory(test_mode=False) / "Duke-Heart-4DLabelmaps"
     )
@@ -642,7 +654,12 @@ def duke_heart_test_data(test_directories: dict[str, Path]) -> Path:
 
 @pytest.fixture(scope="session")
 def chest_ct_test_data(test_directories: dict[str, Path]) -> Path:
-    """Build data/test/Chest-CT: the single study, downsampled to 3 mm."""
+    """Build the Chest-CT test subset: the single study, downsampled to 3 mm.
+
+    Reads ``<input root>/Chest-CT`` and writes ``<input root>/test/Chest-CT``,
+    where the root is whatever ``PHYSIOTWIN_INPUT_DATA_DIR`` names and
+    defaults to the clone's ``data/``.
+    """
     source_file = (
         ParametersBase().data_directory(test_mode=False) / "Chest-CT" / "Chest-CT.mha"
     )

--- a/tests/test_parameters_base.py
+++ b/tests/test_parameters_base.py
@@ -1,0 +1,150 @@
+"""Tests for the three directory roots every tutorial resolves paths through.
+
+Two properties matter here. First, a clone with no environment set must behave
+exactly as it always has, because the roots are read by every tutorial and a
+silent change of default would scatter results. Second, the ``test`` subtree
+must never coincide with the full root, because that separation is what stops a
+test run from overwriting the datasets, results and checkpoints of a full run.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from parameters_base import ParametersBase
+from parameters_duke_heart_labelmaps import DUKE_HEART
+from parameters_heart_ct_kcl import HEART_CT_KCL
+from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# (accessor name, environment variable, default relative to the repo root)
+_ROOTS = [
+    ("data_directory", "PHYSIOTWIN_INPUT_DATA_DIR", Path("data")),
+    ("output_directory", "PHYSIOTWIN_OUTPUT_DATA_DIR", Path("tutorials/output")),
+    (
+        "weights_directory",
+        "PHYSIOTWIN_WEIGHTS_DIR",
+        Path("tutorials/network_weights"),
+    ),
+]
+
+# Every parameters module a tutorial imports, plus the bare base the tutorials
+# with no dataset-specific module use.
+_PARAMETERS = [ParametersBase(), DUKE_HEART, LUNG_CT_DIRLAB, HEART_CT_KCL]
+
+
+def _resolver(parameters: ParametersBase, name: str) -> Callable[[bool], Path]:
+    """Return the named root accessor bound to this parameters object."""
+    resolver: Callable[[bool], Path] = getattr(parameters, name)
+    return resolver
+
+
+@pytest.mark.parametrize("parameters", _PARAMETERS, ids=lambda p: type(p).__name__)
+@pytest.mark.parametrize(("name", "variable", "default"), _ROOTS)
+def test_unset_variable_keeps_the_in_repo_default(
+    parameters: ParametersBase,
+    name: str,
+    variable: str,
+    default: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A clone with no environment set behaves exactly as it always has."""
+    monkeypatch.delenv(variable, raising=False)
+    assert _resolver(parameters, name)(False) == _REPO_ROOT / default
+
+
+@pytest.mark.parametrize("parameters", _PARAMETERS, ids=lambda p: type(p).__name__)
+@pytest.mark.parametrize(("name", "variable", "default"), _ROOTS)
+def test_empty_variable_is_treated_as_unset(
+    parameters: ParametersBase,
+    name: str,
+    variable: str,
+    default: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CI expression interpolating an undefined value yields the empty string.
+
+    Reading that as a path would resolve to the working directory, scattering
+    results wherever pytest happened to be invoked from.
+    """
+    monkeypatch.setenv(variable, "")
+    assert _resolver(parameters, name)(False) == _REPO_ROOT / default
+
+
+@pytest.mark.parametrize("parameters", _PARAMETERS, ids=lambda p: type(p).__name__)
+@pytest.mark.parametrize(("name", "variable", "default"), _ROOTS)
+def test_variable_redirects_both_run_modes(
+    parameters: ParametersBase,
+    name: str,
+    variable: str,
+    default: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Set a root and both the full and the test subtree move with it."""
+    monkeypatch.setenv(variable, str(tmp_path))
+    assert _resolver(parameters, name)(False) == tmp_path
+    assert _resolver(parameters, name)(True) == tmp_path / "test"
+
+
+@pytest.mark.parametrize(("name", "variable", "default"), _ROOTS)
+def test_test_subtree_is_never_the_full_root(
+    name: str,
+    variable: str,
+    default: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The separation that stops a test run overwriting a full run's files."""
+    monkeypatch.delenv(variable, raising=False)
+    resolve = _resolver(ParametersBase(), name)
+    assert resolve(True) != resolve(False)
+    assert resolve(True).parent == resolve(False)
+
+
+def test_the_three_roots_are_distinct() -> None:
+    """Datasets, results and trained networks must not share a directory."""
+    roots = {_resolver(ParametersBase(), name)(False) for name, _, _ in _ROOTS}
+    assert len(roots) == 3
+
+
+@pytest.mark.parametrize("parameters", _PARAMETERS[1:], ids=lambda p: type(p).__name__)
+def test_every_parameters_module_derives_from_the_base(
+    parameters: ParametersBase,
+) -> None:
+    """Each dataset module inherits the roots rather than restating them."""
+    assert isinstance(parameters, ParametersBase)
+
+
+@pytest.mark.parametrize("parameters", _PARAMETERS[1:], ids=lambda p: type(p).__name__)
+def test_dataset_paths_hang_off_the_roots(
+    parameters: ParametersBase,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Redirecting a root moves every path a module derives from it.
+
+    This is the property that lets a runner keep its data off the checkout: no
+    dataset path may be pinned to the repository independently of its root.
+    """
+    monkeypatch.setenv("PHYSIOTWIN_INPUT_DATA_DIR", str(tmp_path / "in"))
+    monkeypatch.setenv("PHYSIOTWIN_OUTPUT_DATA_DIR", str(tmp_path / "out"))
+    monkeypatch.setenv("PHYSIOTWIN_WEIGHTS_DIR", str(tmp_path / "weights"))
+
+    for name in (
+        "input_directory",
+        "hold_out_directory",
+        "pca_model_file",
+        "pca_mean_surface_file",
+        "mgn_weights_directory",
+    ):
+        accessor = getattr(parameters, name, None)
+        if accessor is None:  # ParametersHeartCTKCL trains no network.
+            continue
+        for test_mode in (False, True):
+            assert tmp_path in accessor(test_mode).parents, (
+                f"{type(parameters).__name__}.{name}({test_mode}) escaped the "
+                "redirected roots"
+            )

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -1,22 +1,38 @@
-"""Tutorial tests that run each tutorial end-to-end and compare screenshots.
+"""Tutorial tests that run each tutorial end-to-end and compare its output.
 
 Each test class maps to one tutorial script.  Tests are gated behind
 ``--run-tutorials`` (handled by conftest.py) and require the relevant dataset
-to be present (see data/README.md).
+to be present; the ``*_test_data`` fixtures in conftest.py build the small
+subsets a tutorial reads when run as a test.
 
-Screenshot comparison uses the existing ITK-based baseline infrastructure:
+Every tutorial runs with ``PHYSIOTWIN_RUNNING_AS_TEST`` set, which sends its
+reads and writes to the ``test`` subtree of each root in
+``parameters_base.ParametersBase``: it reads the downsampled datasets under
+``<input root>/test``, writes its results under ``<output root>/test`` and
+trains its networks into ``<weights root>/test``.  Running this suite therefore
+cannot read or overwrite the datasets, results or checkpoints of a full run.
+Each root defaults to its current in-repo location and is overridable by
+environment variable, so a runner can keep them off the checkout.
 
-1. Each tutorial script saves PNGs directly to its ``OUTPUT_DIR``.
-2. ``TestTools.compare_result_to_baseline_image`` reads each PNG from that
-   directory and compares it against a stored baseline with loose tolerances.
+Output is compared two ways, because neither catches what the other does:
 
-Run all tutorial tests::
+1. Screenshots.  Each tutorial saves PNGs to its output directory, which
+   ``TestTools.compare_result_to_baseline_image`` compares against a stored
+   baseline with tolerances loose enough to survive a driver change.
+2. Metrics.  The JSON and CSV of numbers each tutorial already reports, which
+   ``TestTools.compare_result_to_baseline_metrics`` compares within tolerance.
+   Two renderings can agree pixel for pixel while the numbers behind them move,
+   and only this catches that.  Wall-clock files (``*_runtimes.csv``) are left
+   out, being a property of the host rather than of the result.
 
-    pytest tests/test_tutorials.py --run-tutorials -v
+Run all tutorial tests (they are marked ``slow`` as well as ``tutorial``)::
 
-Create baselines on first run::
+    pytest tests/test_tutorials.py --run-all -v
 
-    pytest tests/test_tutorials.py --run-tutorials --create-baselines -v
+Create baselines on first run, then review the generated PNGs before
+committing them -- ``--create-baselines`` blesses whatever came out::
+
+    pytest tests/test_tutorials.py --run-all --create-baselines -v
 """
 
 from __future__ import annotations
@@ -29,17 +45,30 @@ from typing import Any
 
 import pytest
 
+from parameters_base import ParametersBase
 from physiotwin4d.test_tools import TestTools
+
+from .conftest import skip_or_fail_missing_data
 
 # Tolerances for screenshot comparison. Loose to survive minor rendering
 # differences across OS / GPU / driver versions.
 _PX_TOL = 10.0  # per-pixel absolute error (0-255 range)
 _MAX_PX = 2000  # maximum number of pixels allowed above _PX_TOL
 _TOT_TOL = float("inf")  # use the pixel-count criterion only
+# Tolerances for the numeric metrics each tutorial reports.  Loose enough to
+# survive the nondeterminism of GPU reductions and a driver change, tight
+# enough that a real change in accuracy shows up.  The absolute term is what
+# covers the metrics that sit near zero, where a relative one never triggers.
+_METRIC_REL_TOL = 0.05
+_METRIC_ABS_TOL = 1.0e-3
 _REPO_ROOT = Path(__file__).parent.parent
-# Where every tutorial writes, and where Tutorial 9 trains its networks to.
-_TUTORIAL_OUTPUT = _REPO_ROOT / "tutorials" / "output"
-_TUTORIAL_WEIGHTS = _REPO_ROOT / "tutorials" / "network_weights"
+# Where every tutorial writes under ``PHYSIOTWIN_RUNNING_AS_TEST``, and where
+# Tutorial 9 trains its networks to.  Kept apart from the ``output`` and
+# ``network_weights`` directories a full run uses, so that running the suite
+# cannot overwrite a full run's results or its trained checkpoints.
+_TUTORIAL_PATHS = ParametersBase()
+_TUTORIAL_OUTPUT = _TUTORIAL_PATHS.output_directory(test_mode=True)
+_TUTORIAL_WEIGHTS = _TUTORIAL_PATHS.weights_directory(test_mode=True)
 
 
 @pytest.fixture(autouse=True)
@@ -67,6 +96,20 @@ def _compare_screenshots(
         ), f"Screenshot baseline mismatch: {png_path.name}"
 
 
+def _compare_metrics(tt: TestTools, filenames: list[str]) -> None:
+    """Compare each reported metrics file against its baseline.
+
+    Screenshots catch what a rendering shows; these catch the accuracy drift
+    that a rendering can hide.
+    """
+    for filename in filenames:
+        assert tt.compare_result_to_baseline_metrics(
+            filename,
+            relative_tol=_METRIC_REL_TOL,
+            absolute_tol=_METRIC_ABS_TOL,
+        ), f"Metrics baseline mismatch: {filename}"
+
+
 def _run_tutorial_script(script_name: str) -> dict[str, Any]:
     """Run a tutorial script with no command-line arguments."""
     # runpy does not put the script's own directory on sys.path the way the
@@ -87,9 +130,14 @@ def _run_tutorial_script(script_name: str) -> dict[str, Any]:
 
 
 def _require_files(directory: Path, pattern: str, reason: str) -> None:
-    """Skip unless ``directory`` holds at least one entry matching ``pattern``."""
+    """Skip unless ``directory`` holds at least one entry matching ``pattern``.
+
+    Under ``--require-tutorial-data`` this fails instead, so a runner that is
+    supposed to hold every dataset cannot report a green run that tested
+    nothing.
+    """
     if not list(directory.glob(pattern)):
-        pytest.skip(f"No {pattern} under {directory}. {reason}")
+        skip_or_fail_missing_data(f"No {pattern} under {directory}. {reason}")
 
 
 def _baseline_tools(class_name: str, out_dir: Path, baselines_root: Path) -> TestTools:
@@ -109,7 +157,7 @@ class TestTutorial01HeartGatedCTToUSD:
     _class_name = "tutorial_01_heart_gated_ct_to_usd"
 
     def test_run(self, test_directories: dict[str, Path]) -> None:
-        out_dir = _REPO_ROOT / "tutorials" / "output" / "tutorial_01_heart"
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_01_heart"
         results = _run_tutorial_script("tutorial_01_heart_gated_ct_to_usd.py")
         assert results["usd_file"], "USD file path should not be empty"
         assert Path(results["usd_file"]).exists(), "USD file should exist"
@@ -130,10 +178,13 @@ class TestTutorial01LungGatedCTToUSD:
 
     _class_name = "tutorial_01_lung_gated_ct_to_usd"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
-        # This script reads the full dataset directory in either mode.
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+    ) -> None:
         _require_files(
-            _REPO_ROOT / "data" / "DirLab-4DCT",
+            _TUTORIAL_PATHS.data_directory(test_mode=True) / "DirLab-4DCT",
             "Case1Pack_T??.mha",
             "DirLab-4DCT is acquired manually; see data/README.md.",
         )
@@ -164,7 +215,11 @@ class TestTutorial02DukeHeartDistancemapFinetuneICON:
 
     _class_name = "tutorial_02_duke_heart_distancemap_finetune_icon"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        duke_heart_test_data: Path,
+    ) -> None:
         _require_files(
             test_directories["data"] / "Duke-Heart-4DLabelmaps",
             "pm*",
@@ -192,7 +247,11 @@ class TestTutorial02LungDistancemapFinetuneICON:
 
     _class_name = "tutorial_02_lung_distancemap_finetune_icon"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+    ) -> None:
         _require_files(
             test_directories["data"] / "DirLab-4DCT",
             "Case*_T??.mha",
@@ -218,7 +277,11 @@ class TestTutorial02LungFinetuneICON:
 
     _class_name = "tutorial_02_lung_finetune_icon"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+    ) -> None:
         _require_files(
             test_directories["data"] / "DirLab-4DCT",
             "Case*_T??.mha",
@@ -251,7 +314,7 @@ class TestTutorial03HeartReconstructHighres4DCT:
     def test_run(
         self, test_directories: dict[str, Path], test_images: list[Any]
     ) -> None:
-        out_dir = _REPO_ROOT / "tutorials" / "output" / "tutorial_03_heart"
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_03_heart"
         results = _run_tutorial_script("tutorial_03_heart_reconstruct_highres_4d_ct.py")
         assert results["reconstructed_files"], (
             "At least one reconstructed frame expected"
@@ -274,7 +337,11 @@ class TestTutorial03LungReconstructHighres4DCT:
 
     _class_name = "tutorial_03_lung_reconstruct_highres_4d_ct"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+    ) -> None:
         # Match the phase files the script itself globs, not a directory layout
         # it never uses.
         dirlab_dir = test_directories["data"] / "DirLab-4DCT"
@@ -284,7 +351,7 @@ class TestTutorial03LungReconstructHighres4DCT:
                 "for instructions."
             )
 
-        out_dir = _REPO_ROOT / "tutorials" / "output" / "tutorial_03_lung"
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_03_lung"
         results = _run_tutorial_script("tutorial_03_lung_reconstruct_highres_4d_ct.py")
         assert results["reconstructed_files"], (
             "At least one reconstructed frame expected"
@@ -315,7 +382,7 @@ class TestTutorial04HeartCTToVTK:
     def test_run(
         self, test_directories: dict[str, Path], test_images: list[Any]
     ) -> None:
-        out_dir = _REPO_ROOT / "tutorials" / "output" / "tutorial_04_heart"
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_04_heart"
         results = _run_tutorial_script("tutorial_04_heart_ct_to_vtk.py")
         assert results["surface_file"].exists(), "Combined VTP surface should exist"
 
@@ -334,7 +401,11 @@ class TestTutorial04DukeHeartLabelmapToVTK:
 
     _class_name = "tutorial_04_duke_heart_labelmap_to_vtk"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        duke_heart_test_data: Path,
+    ) -> None:
         _require_files(
             test_directories["data"] / "Duke-Heart-4DLabelmaps",
             "pm[0-9][0-9][0-9][0-9]",
@@ -359,7 +430,11 @@ class TestTutorial04LungCTToVTK:
 
     _class_name = "tutorial_04_lung"  # the script's project_name, its TestTools key
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+    ) -> None:
         _require_files(
             test_directories["data"] / "DirLab-4DCT",
             "Case*_T??.mha",
@@ -394,14 +469,14 @@ class TestTutorial05HeartVTKToUSD:
     ) -> None:
         # The script reads this exact directory and offers no input override,
         # so bootstrap Tutorial 4 rather than pointing it at other surfaces.
-        input_dir = _REPO_ROOT / "tutorials" / "output" / "tutorial_04_heart"
+        input_dir = _TUTORIAL_OUTPUT / "tutorial_04_heart"
         if not list(input_dir.glob("patient_*.vtp")):
             _run_tutorial_script("tutorial_04_heart_ct_to_vtk.py")
             assert list(input_dir.glob("patient_*.vtp")), (
                 f"Tutorial 4 bootstrap did not create surfaces in: {input_dir}"
             )
 
-        out_dir = _REPO_ROOT / "tutorials" / "output" / "tutorial_05_heart"
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_05_heart"
         results = _run_tutorial_script("tutorial_05_heart_vtk_to_usd.py")
         assert results["usd_file"], "USD file path should not be empty"
         assert Path(results["usd_file"]).exists(), "USD file should exist"
@@ -469,7 +544,7 @@ class TestTutorial06CreateStatisticalModel:
     def test_run(
         self, test_directories: dict[str, Path], download_kcl_heart_model: Path
     ) -> None:
-        out_dir = _REPO_ROOT / "tutorials" / "output" / "tutorial_06_heart"
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_06_heart"
         results = _run_tutorial_script("tutorial_06_heart_create_statistical_model.py")
         assert results["model_file"].exists(), "pca_model.json should exist"
         assert results["mean_surface_file"].exists(), "Mean surface VTP should exist"
@@ -517,7 +592,11 @@ class TestTutorial06LungCreateStatisticalModel:
 
     _class_name = "tutorial_06_lung_create_statistical_model"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+    ) -> None:
         # This variant segments the T70 phases itself, so the images are input.
         _require_files(
             test_directories["data"] / "DirLab-4DCT",
@@ -544,7 +623,10 @@ class TestTutorial07FitStatisticalModelToPatient:
     _class_name = "tutorial_07_heart_fit_statistical_model_to_patient"
 
     def test_run(
-        self, test_directories: dict[str, Path], download_kcl_heart_model: Path
+        self,
+        test_directories: dict[str, Path],
+        download_kcl_heart_model: Path,
+        dirlab_test_data: Path,
     ) -> None:
         # The patient scan comes from DIR-Lab, which must be acquired manually.
         if not (
@@ -555,9 +637,7 @@ class TestTutorial07FitStatisticalModelToPatient:
                 "for instructions."
             )
 
-        pca_json = (
-            _REPO_ROOT / "tutorials" / "output" / "tutorial_06_heart" / "pca_model.json"
-        )
+        pca_json = _TUTORIAL_OUTPUT / "tutorial_06_heart" / "pca_model.json"
         if not pca_json.exists():
             _run_tutorial_script("tutorial_06_heart_create_statistical_model.py")
             assert pca_json.exists(), (
@@ -565,7 +645,7 @@ class TestTutorial07FitStatisticalModelToPatient:
                 f"{pca_json}"
             )
 
-        out_dir = _REPO_ROOT / "tutorials" / "output" / "tutorial_07_heart"
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_07_heart"
         results = _run_tutorial_script(
             "tutorial_07_heart_fit_statistical_model_to_patient.py"
         )
@@ -581,6 +661,10 @@ class TestTutorial07FitStatisticalModelToPatient:
             baselines_dir=test_directories["baselines"] / self._class_name,
         )
         _compare_screenshots(results["screenshots"], tt)
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            ["tutorial_07_heart_registered_coefficients.json"],
+        )
 
 
 @pytest.mark.tutorial
@@ -590,7 +674,11 @@ class TestTutorial07DukeHeartFitStatisticalModelToPatient:
 
     _class_name = "tutorial_07_duke_heart"  # the script's project_name
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        duke_heart_test_data: Path,
+    ) -> None:
         _require_files(
             test_directories["data"] / "Duke-Heart-4DLabelmaps",
             "pm*",
@@ -615,6 +703,10 @@ class TestTutorial07DukeHeartFitStatisticalModelToPatient:
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
         )
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            ["tutorial_07_duke_heart_registered_coefficients.json"],
+        )
 
 
 @pytest.mark.tutorial
@@ -624,7 +716,12 @@ class TestTutorial07LungFitStatisticalModelToPatient:
 
     _class_name = "tutorial_07_lung"  # the script's project_name
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+        chest_ct_test_data: Path,
+    ) -> None:
         # The lung variant fits the ungated Chest-CT scan, which the
         # download CLI provides, rather than a gated DIR-Lab phase.
         _require_files(
@@ -650,6 +747,10 @@ class TestTutorial07LungFitStatisticalModelToPatient:
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
         )
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            ["tutorial_07_lung_registered_coefficients.json"],
+        )
 
 
 # -----------------------------------------------------------------------------
@@ -664,7 +765,11 @@ class TestTutorial08DukeHeartFitModelTo4DPatients:
 
     _class_name = "tutorial_08_duke_heart_fit_model_to_4d_patients"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        duke_heart_test_data: Path,
+    ) -> None:
         _require_files(
             test_directories["data"] / "Duke-Heart-4DLabelmaps",
             "pm*",
@@ -699,10 +804,13 @@ class TestTutorial08LungFitModelTo4DPatients:
 
     _class_name = "tutorial_08_lung_fit_model_to_4d_patients"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
-        # This script reads the full dataset directory in either mode.
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+    ) -> None:
         _require_files(
-            _REPO_ROOT / "data" / "DirLab-4DCT",
+            _TUTORIAL_PATHS.data_directory(test_mode=True) / "DirLab-4DCT",
             "Case*_T70.mha",
             "DirLab-4DCT is acquired manually; see data/README.md.",
         )
@@ -737,9 +845,11 @@ class TestTutorial08LungFitModelTo4DPatients:
 def _require_physicsnemo() -> None:
     """Skip unless both MGN dependencies are installed."""
     if importlib.util.find_spec("physicsnemo") is None:
-        pytest.skip("PhysicsNeMo not installed (optional [physicsnemo] extra).")
+        skip_or_fail_missing_data(
+            "PhysicsNeMo not installed (optional [physicsnemo] extra)."
+        )
     if importlib.util.find_spec("torch_geometric") is None:
-        pytest.skip(
+        skip_or_fail_missing_data(
             "PyTorch Geometric not installed; the MGN trainer needs it in addition "
             'to PhysicsNeMo. Install with: pip install "physiotwin4d[physicsnemo]" '
             "&& pip install torch-geometric"
@@ -749,10 +859,11 @@ def _require_physicsnemo() -> None:
 def _require_physicsnemo_and_tutorial_08() -> Path:
     """Skip unless the MGN dependencies and three Tutorial 8 cases are present."""
     _require_physicsnemo()
-    data_dir = _REPO_ROOT / "tutorials" / "output" / "tutorial_08_lung"
+    data_dir = _TUTORIAL_OUTPUT / "tutorial_08_lung"
     if len(list(data_dir.glob("Case*Pack"))) < 3:
-        pytest.skip(
-            "Fewer than three Tutorial 8 cases under tutorials/output/tutorial_08_lung. "
+        skip_or_fail_missing_data(
+            "Fewer than three Tutorial 8 cases under "
+            "the Tutorial 8 lung output directory. "
             "Run tutorial_08_lung_fit_model_to_4d_patients.py first."
         )
     return data_dir
@@ -764,7 +875,7 @@ def _require_physicsnemo_and_tutorial_08_duke() -> Path:
     data_dir = _TUTORIAL_OUTPUT / "tutorial_08_duke_heart"
     if not list(data_dir.glob("pm*")):
         pytest.skip(
-            "No Tutorial 8 cases under tutorials/output/tutorial_08_duke_heart. "
+            "No Tutorial 8 cases under the Tutorial 8 Duke heart output directory. "
             "Run tutorial_08_duke_heart_fit_model_to_4d_patients.py first."
         )
     return data_dir
@@ -790,7 +901,7 @@ class TestTutorial09LungTrainPhysicsNeMoMGN:
         # evaluation and the screenshots stay under the tutorial's output.
         tt = TestTools(
             class_name=self._class_name,
-            results_dir=_REPO_ROOT / "tutorials" / "output" / "tutorial_09_lung_mgn",
+            results_dir=_TUTORIAL_OUTPUT / "tutorial_09_lung_mgn",
             baselines_dir=test_directories["baselines"] / self._class_name,
         )
         _compare_screenshots(results["screenshots"], tt)
@@ -837,7 +948,7 @@ class TestTutorial10LungInferPhysicsNeMoMGN:
     def test_run(self, test_directories: dict[str, Path]) -> None:
         _require_physicsnemo_and_tutorial_08()
 
-        # ParametersLungCTDirLab.mgn_weights_dir, where Tutorial 9 trains to.
+        # ParametersLungCTDirLab.mgn_weights_directory, where Tutorial 9 trains to.
         model_dir = (
             _REPO_ROOT / "tutorials" / "network_weights" / "physicsnemo_mgn_lung_motion"
         )
@@ -854,9 +965,7 @@ class TestTutorial10LungInferPhysicsNeMoMGN:
         )
         assert Path(results["usd_file"]).exists(), "USD file should exist"
 
-        out_dir = (
-            _REPO_ROOT / "tutorials" / "output" / "tutorial_10_lung_mgn" / "Case1Pack"
-        )
+        out_dir = _TUTORIAL_OUTPUT / "tutorial_10_lung_mgn" / "Case1Pack"
         tt = TestTools(
             class_name=self._class_name,
             results_dir=out_dir,
@@ -873,10 +982,15 @@ class TestTutorial10DukeHeartInferPhysicsNeMoMGN:
 
     _class_name = "tutorial_10_duke_heart_infer_physicsnemo_mgn"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        duke_heart_test_data: Path,
+    ) -> None:
         _require_physicsnemo_and_tutorial_08_duke()
 
-        # ParametersDukeHeartLabelmaps.mgn_weights_dir, where Tutorial 9 trains to.
+        # ParametersDukeHeartLabelmaps.mgn_weights_directory, where Tutorial 9
+        # trains to.
         model_dir = _TUTORIAL_WEIGHTS / "physicsnemo_mgn_duke_heart_motion"
         if not (model_dir / "mgn_stage_model.pt").exists():
             _run_tutorial_script("tutorial_09_duke_heart_train_physicsnemo_mgn.py")
@@ -911,7 +1025,11 @@ class TestTutorial11DukeHeartEvaluatePhysicsNeMo:
 
     _class_name = "tutorial_11_duke_heart_evaluate_physicsnemo"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        duke_heart_test_data: Path,
+    ) -> None:
         _require_physicsnemo_and_tutorial_08_duke()
         # The acquired labelmaps every metric is measured against.
         _require_files(
@@ -938,6 +1056,10 @@ class TestTutorial11DukeHeartEvaluatePhysicsNeMo:
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
         )
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            ["evaluation_metrics.csv"],
+        )
 
 
 @pytest.mark.tutorial
@@ -948,7 +1070,11 @@ class TestTutorial11LungEvaluatePhysicsNeMo:
 
     _class_name = "tutorial_11_lung_evaluate_physicsnemo"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+    ) -> None:
         _require_physicsnemo_and_tutorial_08()
         # The acquired phases this variant segments to get its ground truth.
         _require_files(
@@ -976,6 +1102,10 @@ class TestTutorial11LungEvaluatePhysicsNeMo:
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
         )
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            ["evaluation_metrics.csv"],
+        )
 
 
 # -----------------------------------------------------------------------------
@@ -991,7 +1121,11 @@ class TestTutorial12DukeHeartEndToEndInference:
 
     _class_name = "tutorial_12_duke_heart_end_to_end_inference"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        duke_heart_test_data: Path,
+    ) -> None:
         _require_physicsnemo()
         # This tutorial starts from the raw labelmaps, so it needs Tutorial 6's
         # model and Tutorial 9's weights but not Tutorial 8's fits.
@@ -1022,6 +1156,10 @@ class TestTutorial12DukeHeartEndToEndInference:
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
         )
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            ["pm0027_ssm_pca_coefficients.json"],
+        )
 
 
 @pytest.mark.tutorial
@@ -1032,7 +1170,12 @@ class TestTutorial12LungEndToEndInference:
 
     _class_name = "tutorial_12_lung_end_to_end_inference"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+        chest_ct_test_data: Path,
+    ) -> None:
         _require_physicsnemo()
         _require_files(
             test_directories["data"] / "DirLab-4DCT",
@@ -1061,6 +1204,10 @@ class TestTutorial12LungEndToEndInference:
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
         )
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            ["Case1Pack_ssm_pca_coefficients.json"],
+        )
 
 
 # -----------------------------------------------------------------------------
@@ -1080,7 +1227,13 @@ class TestTutorial13HeartAndLungMotion:
 
     _class_name = "tutorial_13_heart_and_lung_motion"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+        duke_heart_test_data: Path,
+        chest_ct_test_data: Path,
+    ) -> None:
         _require_physicsnemo()
         # The ungated clinical scan both rhythms are inferred onto.
         _require_files(
@@ -1140,7 +1293,11 @@ class TestTutorial14DukeHeartShapeParameterSweep:
 
     _class_name = "tutorial_14_duke_heart_shape_parameter_sweep"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        duke_heart_test_data: Path,
+    ) -> None:
         _require_physicsnemo_and_tutorial_08_duke()
         # The acquired labelmaps every metric is measured against.
         _require_files(
@@ -1170,6 +1327,13 @@ class TestTutorial14DukeHeartShapeParameterSweep:
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
         )
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            [
+                "shape_sweep_metrics.csv",
+                "shape_sweep_summary.csv",
+            ],
+        )
 
 
 @pytest.mark.tutorial
@@ -1180,7 +1344,11 @@ class TestTutorial14LungShapeParameterSweep:
 
     _class_name = "tutorial_14_lung_shape_parameter_sweep"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+    ) -> None:
         _require_physicsnemo_and_tutorial_08()
         # The acquired phases this variant segments to get its ground truth.
         _require_files(
@@ -1209,6 +1377,13 @@ class TestTutorial14LungShapeParameterSweep:
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
         )
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            [
+                "shape_sweep_metrics.csv",
+                "shape_sweep_summary.csv",
+            ],
+        )
 
 
 # Both Tutorial 15 variants clamp themselves to this many folds under
@@ -1224,7 +1399,11 @@ class TestTutorial15LungLeaveOneOut:
 
     _class_name = "tutorial_15_lung_leave_one_out"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        dirlab_test_data: Path,
+    ) -> None:
         _require_physicsnemo()
         # Nothing from Tutorials 6, 8 or 9 is needed: every fold builds its own
         # shape model, fits and network. The cohort itself is the only input.
@@ -1249,6 +1428,10 @@ class TestTutorial15LungLeaveOneOut:
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
         )
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            ["loo_metrics.csv"],
+        )
 
 
 @pytest.mark.tutorial
@@ -1259,7 +1442,11 @@ class TestTutorial15DukeHeartLeaveOneOut:
 
     _class_name = "tutorial_15_duke_heart_leave_one_out"
 
-    def test_run(self, test_directories: dict[str, Path]) -> None:
+    def test_run(
+        self,
+        test_directories: dict[str, Path],
+        duke_heart_test_data: Path,
+    ) -> None:
         _require_physicsnemo()
         _require_files(
             test_directories["data"] / "Duke-Heart-4DLabelmaps",
@@ -1282,4 +1469,8 @@ class TestTutorial15DukeHeartLeaveOneOut:
         _compare_screenshots(
             results["screenshots"],
             _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+        )
+        _compare_metrics(
+            _baseline_tools(self._class_name, out_dir, test_directories["baselines"]),
+            ["loo_metrics.csv"],
         )

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -948,10 +948,10 @@ class TestTutorial10LungInferPhysicsNeMoMGN:
     def test_run(self, test_directories: dict[str, Path]) -> None:
         _require_physicsnemo_and_tutorial_08()
 
-        # ParametersLungCTDirLab.mgn_weights_directory, where Tutorial 9 trains to.
-        model_dir = (
-            _REPO_ROOT / "tutorials" / "network_weights" / "physicsnemo_mgn_lung_motion"
-        )
+        # ParametersLungCTDirLab.mgn_weights_directory under test mode, which is
+        # where Tutorial 9 trains to. Reading the full-run directory instead
+        # would look for a checkpoint the test run never writes.
+        model_dir = _TUTORIAL_WEIGHTS / "physicsnemo_mgn_lung_motion"
         if not (model_dir / "mgn_stage_model.pt").exists():
             _run_tutorial_script("tutorial_09_lung_train_physicsnemo_mgn.py")
             assert (model_dir / "mgn_stage_model.pt").exists(), (

--- a/tutorials/parameters_base.py
+++ b/tutorials/parameters_base.py
@@ -1,0 +1,99 @@
+"""Base class holding the three directory roots every tutorial reads and writes.
+
+The dataset-specific parameter modules (:mod:`parameters_duke_heart_labelmaps`,
+:mod:`parameters_lung_ct_dirlab`, :mod:`parameters_heart_ct_kcl`) derive from
+:class:`ParametersBase`, so a tutorial resolves every path through the same
+object it already imports for its label ids and iteration counts. A tutorial
+that needs only the roots -- one that reads a dataset no shape model is built
+from, say -- instantiates :class:`ParametersBase` directly.
+
+Each root is overridable by environment variable, so a machine that keeps them
+outside the clone -- a CI runner whose checkout is wiped every run, for
+instance -- can point at them without editing any script:
+
+===================================  =====================================
+Variable                             Default
+===================================  =====================================
+``PHYSIOTWIN_INPUT_DATA_DIR``        ``<repo>/data``
+``PHYSIOTWIN_OUTPUT_DATA_DIR``       ``<repo>/tutorials/output``
+``PHYSIOTWIN_WEIGHTS_DIR``           ``<repo>/tutorials/network_weights``
+===================================  =====================================
+
+Every root has a ``test`` subdirectory holding the small, fast counterpart used
+when a tutorial runs under ``TestTools.running_as_test``. Keeping the test data,
+the test results and the test checkpoints in their own subtree is what stops a
+test run from reading or overwriting the datasets, results and trained networks
+of a full run.
+
+The weights root is kept apart from the output root because a trained network is
+not a per-run result: Tutorial 9 trains one and Tutorial 10 loads it, so it
+outlives the run that produced it. The pretrained weights ICON fetches for
+itself are not here either; ICON resolves those on its own.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# tutorials/parameters_base.py -> tutorials -> repo root
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class ParametersBase:
+    """The dataset, result and trained-network roots, per run mode.
+
+    Not a dataclass: it carries no settings of its own, only the resolution the
+    dataset-specific subclasses build their paths on. Those subclasses are
+    frozen dataclasses, which a plain base class supports and a non-frozen
+    dataclass base would not.
+    """
+
+    @staticmethod
+    def _root(variable: str, default: Path, test_mode: bool) -> Path:
+        """Return the root ``variable`` names, or ``default``, plus any test subtree.
+
+        An unset variable and one set to nothing are treated alike, because a CI
+        expression that interpolates an undefined value yields the empty string,
+        and reading that as a path would silently resolve to the working
+        directory.
+        """
+        value = os.environ.get(variable, "").strip()
+        root = Path(value) if value else default
+        return root / "test" if test_mode else root
+
+    def data_directory(self, test_mode: bool) -> Path:
+        """Return the root every dataset is read from.
+
+        Args:
+            test_mode: Return the ``test`` subtree, holding the downsampled
+                subsets the pytest fixtures build, rather than the full
+                datasets.
+        """
+        return self._root("PHYSIOTWIN_INPUT_DATA_DIR", _REPO_ROOT / "data", test_mode)
+
+    def output_directory(self, test_mode: bool) -> Path:
+        """Return the root every tutorial writes its results to.
+
+        Args:
+            test_mode: Return the ``test`` subtree, so that a test run cannot
+                overwrite the results a full run left behind.
+        """
+        return self._root(
+            "PHYSIOTWIN_OUTPUT_DATA_DIR",
+            _REPO_ROOT / "tutorials" / "output",
+            test_mode,
+        )
+
+    def weights_directory(self, test_mode: bool) -> Path:
+        """Return the root the tutorials train their networks into.
+
+        Args:
+            test_mode: Return the ``test`` subtree, so that the two-epoch models
+                a test run trains cannot overwrite a real checkpoint.
+        """
+        return self._root(
+            "PHYSIOTWIN_WEIGHTS_DIR",
+            _REPO_ROOT / "tutorials" / "network_weights",
+            test_mode,
+        )

--- a/tutorials/parameters_duke_heart_labelmaps.py
+++ b/tutorials/parameters_duke_heart_labelmaps.py
@@ -7,9 +7,10 @@ on purpose: Tutorial 2 finetunes uniGradICON on distance maps whose appearance
 is fixed by ``mask_dilation_mm`` and ``distancemap_squared_max``, and Tutorial 7
 infers with those weights, so the two must agree.
 
-The directories and the shape-model files the tutorials read and write live here
-too, so that Tutorial 6 writes the model where Tutorial 7 looks for it.  Every
-path is derived from this file's location, so they hold wherever the clone is.
+The shape-model files the tutorials read and write live here too, so that
+Tutorial 6 writes the model where Tutorial 7 looks for it.  Every path hangs off
+one of the three roots :class:`parameters_base.ParametersBase` resolves, so
+pointing an environment variable at another disk moves them all together.
 """
 
 from __future__ import annotations
@@ -17,15 +18,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from parameters_base import ParametersBase
 from physiotwin4d import SegmentAnatomyBase, SegmentHeartSimplewareTrimmedBranches
-
-_REPO_ROOT = Path(__file__).resolve().parent.parent
-_TUTORIAL_OUTPUT = _REPO_ROOT / "tutorials" / "output"
-_TUTORIAL_WEIGHTS = _REPO_ROOT / "tutorials" / "network_weights"
 
 
 @dataclass(frozen=True)
-class ParametersDukeHeartLabelmaps:
+class ParametersDukeHeartLabelmaps(ParametersBase):
     """Settings shared by the Duke heart tutorials.
 
     Attributes:
@@ -71,20 +69,6 @@ class ParametersDukeHeartLabelmaps:
             coronaries (7-10) vary too much in extent between patients to be
             part of a shape model.  What remains is the myocardium (5) and the
             heart wall (6).
-        input_dir: Surfaces Tutorial 6 builds the model from, which are what
-            Tutorial 4 wrote; ``input_dir_test`` is its counterpart under
-            ``TestTools.running_as_test``.
-        hold_out_dir: Labelmaps the held-out case is read from by Tutorials 2
-            and 7, and ``hold_out_dir_test`` its counterpart under
-            ``TestTools.running_as_test``.
-        pca_json_file: Shape model Tutorial 6 writes and Tutorials 7, 8 and 9
-            read.
-        pca_mean_file: Mean surface of that model, written and read the same way.
-        mgn_weights_dir: MeshGraphNet Tutorial 9 trains and Tutorial 10 infers
-            with, alongside the normalization statistics and PCA assets that
-            make that directory self-contained.  It sits beside the finetuned
-            ICON checkpoints rather than under ``output/``, because it is a
-            trained network rather than a per-run result.
         hold_out_case: Case held out of every fit: Tutorial 6 builds the shape
             model without it and Tutorial 7 fits that model to it, so the fit
             measures generalization rather than reconstruction.  Tutorial 2
@@ -117,27 +101,43 @@ class ParametersDukeHeartLabelmaps:
 
     hold_out_case: str = "pm0027"
 
-    input_dir: Path = _TUTORIAL_OUTPUT / "tutorial_04_duke_heart_labelmap"
-    input_dir_test: Path = _TUTORIAL_OUTPUT / "tutorial_04_duke_heart_labelmap"
-    hold_out_dir: Path = _REPO_ROOT / "data" / "Duke-Heart-4DLabelmaps"
-    hold_out_dir_test: Path = _REPO_ROOT / "data" / "test" / "Duke-Heart-4DLabelmaps"
-    pca_json_file: Path = _TUTORIAL_OUTPUT / "tutorial_06_duke_heart" / "pca_model.json"
-    pca_mean_file: Path = (
-        _TUTORIAL_OUTPUT / "tutorial_06_duke_heart" / "pca_mean_surface.vtp"
-    )
-    mgn_weights_dir: Path = _TUTORIAL_WEIGHTS / "physicsnemo_mgn_duke_heart_motion"
-
     def input_directory(self, test_mode: bool) -> Path:
-        """Return the model population directory for this run mode.
+        """Return the population Tutorial 6 builds the model from.
 
-        Tutorial 4 writes to one directory whichever mode it ran in, so both
-        modes read the same one.
+        These are the surfaces Tutorial 4 wrote, so each mode reads whichever
+        directory its own mode wrote.
         """
-        return self.input_dir_test if test_mode else self.input_dir
+        return self.output_directory(test_mode) / "tutorial_04_duke_heart_labelmap"
 
     def hold_out_directory(self, test_mode: bool) -> Path:
-        """Return the held-out case's directory for this run mode."""
-        return self.hold_out_dir_test if test_mode else self.hold_out_dir
+        """Return the labelmaps Tutorials 2 and 7 read the held-out case from."""
+        return self.data_directory(test_mode) / "Duke-Heart-4DLabelmaps"
+
+    def pca_model_file(self, test_mode: bool) -> Path:
+        """Return the shape model Tutorial 6 writes and 7, 8 and 9 read."""
+        return (
+            self.output_directory(test_mode)
+            / "tutorial_06_duke_heart"
+            / "pca_model.json"
+        )
+
+    def pca_mean_surface_file(self, test_mode: bool) -> Path:
+        """Return that model's mean surface, written and read the same way."""
+        return (
+            self.output_directory(test_mode)
+            / "tutorial_06_duke_heart"
+            / "pca_mean_surface.vtp"
+        )
+
+    def mgn_weights_directory(self, test_mode: bool) -> Path:
+        """Return the MeshGraphNet Tutorial 9 trains and Tutorial 10 infers with.
+
+        Holds the normalization statistics and PCA assets alongside the
+        checkpoint, which is what makes the directory self-contained. It sits
+        under the weights root rather than the output root because a trained
+        network outlives the run that produced it.
+        """
+        return self.weights_directory(test_mode) / "physicsnemo_mgn_duke_heart_motion"
 
     def pca_components(self, test_mode: bool) -> int:
         """Return the PCA component count for this run mode."""

--- a/tutorials/parameters_heart_ct_kcl.py
+++ b/tutorials/parameters_heart_ct_kcl.py
@@ -7,9 +7,10 @@ That is why the heart has its own distance-map finetuning tutorial rather than
 reusing the lung one's weights -- the two organs' distance maps do not share an
 intensity distribution.
 
-The directories and the shape-model files the tutorials read and write live here
-too, so that Tutorial 6 writes the model where Tutorial 7 looks for it.  Every
-path is derived from this file's location, so they hold wherever the clone is.
+The shape-model files the tutorials read and write live here too, so that
+Tutorial 6 writes the model where Tutorial 7 looks for it.  Every path hangs off
+one of the three roots :class:`parameters_base.ParametersBase` resolves, so
+pointing an environment variable at another disk moves them all together.
 """
 
 from __future__ import annotations
@@ -17,14 +18,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from parameters_base import ParametersBase
 from physiotwin4d import SegmentAnatomyBase, SegmentChestTotalSegmentator
-
-_REPO_ROOT = Path(__file__).resolve().parent.parent
-_OUTPUT_ROOT = _REPO_ROOT / "tutorials" / "output" / "tutorial_06_heart"
 
 
 @dataclass(frozen=True)
-class ParametersHeartCTKCL:
+class ParametersHeartCTKCL(ParametersBase):
     """Settings shared by the heart tutorials.
 
     Attributes:
@@ -102,20 +101,29 @@ class ParametersHeartCTKCL:
 
     hold_out_case: str = "Case1Pack"
 
-    input_dir: Path = _REPO_ROOT / "data" / "KCL-Heart-Model"
-    input_dir_test: Path = _REPO_ROOT / "data" / "test" / "KCL-Heart-Model"
-    hold_out_dir: Path = _REPO_ROOT / "data" / "DirLab-4DCT"
-    hold_out_dir_test: Path = _REPO_ROOT / "data" / "test" / "DirLab-4DCT"
-    pca_json_file: Path = _OUTPUT_ROOT / "pca_model.json"
-    pca_mean_file: Path = _OUTPUT_ROOT / "pca_mean_surface.vtp"
-
     def input_directory(self, test_mode: bool) -> Path:
-        """Return the model population directory for this run mode."""
-        return self.input_dir_test if test_mode else self.input_dir
+        """Return the population Tutorial 6 builds the model from."""
+        return self.data_directory(test_mode) / "KCL-Heart-Model"
 
     def hold_out_directory(self, test_mode: bool) -> Path:
-        """Return the held-out case's directory for this run mode."""
-        return self.hold_out_dir_test if test_mode else self.hold_out_dir
+        """Return the dataset Tutorial 7 reads the held-out case from.
+
+        A different dataset from ``input_directory``: the model is built from
+        KCL meshes and fitted to a DIR-Lab patient.
+        """
+        return self.data_directory(test_mode) / "DirLab-4DCT"
+
+    def pca_model_file(self, test_mode: bool) -> Path:
+        """Return the shape model Tutorial 6 writes and Tutorial 7 reads."""
+        return self.output_directory(test_mode) / "tutorial_06_heart" / "pca_model.json"
+
+    def pca_mean_surface_file(self, test_mode: bool) -> Path:
+        """Return that model's mean surface, written and read the same way."""
+        return (
+            self.output_directory(test_mode)
+            / "tutorial_06_heart"
+            / "pca_mean_surface.vtp"
+        )
 
     def pca_components(self, test_mode: bool) -> int:
         """Return the PCA component count for this run mode."""

--- a/tutorials/parameters_lung_ct_dirlab.py
+++ b/tutorials/parameters_lung_ct_dirlab.py
@@ -6,10 +6,11 @@ tutorials that later register them rasterize theirs.  A saturation radius or a
 dilation that drifts between two of these scripts silently trains on one image
 distribution and infers on another.
 
-The directories and the shape-model files the tutorials read and write live here
-too, so that Tutorial 6 writes the model where Tutorials 7 and 8 look for it.
-Every path is derived from this file's location, so they hold wherever the clone
-is.
+The shape-model files the tutorials read and write live here too, so that
+Tutorial 6 writes the model where Tutorials 7 and 8 look for it.  Every path
+hangs off one of the three roots :class:`parameters_base.ParametersBase`
+resolves, so pointing an environment variable at another disk moves them all
+together.
 """
 
 from __future__ import annotations
@@ -17,14 +18,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from parameters_base import ParametersBase
 from physiotwin4d import SegmentAnatomyBase, SegmentNVSegmentCTMRI
-
-_REPO_ROOT = Path(__file__).resolve().parent.parent
-_OUTPUT_ROOT = _REPO_ROOT / "tutorials" / "output" / "tutorial_06_lung"
 
 
 @dataclass(frozen=True)
-class ParametersLungCTDirLab:
+class ParametersLungCTDirLab(ParametersBase):
     """Settings shared by the DIR-Lab lung tutorials.
 
     Attributes:
@@ -55,14 +54,6 @@ class ParametersLungCTDirLab:
         segmenter_class: Segmenter every lung tutorial instantiates, so the
             surfaces they compare share a definition of "lung".
         anatomy_group: Anatomy group name that segmenter registers for lungs.
-        input_dir: Population Tutorial 6 builds the model from, and
-            ``input_dir_test`` its counterpart under
-            ``TestTools.running_as_test``.
-        hold_out_dir: Dataset the held-out study is read from by Tutorial 7, and
-            ``hold_out_dir_test`` its counterpart under
-            ``TestTools.running_as_test``.
-        pca_json_file: Shape model Tutorial 6 writes and Tutorials 7 and 8 read.
-        pca_mean_file: Mean surface of that model, written and read the same way.
         hold_out_case: Image fitted by Tutorial 7 and therefore kept out of the
             population Tutorial 6 builds the model from, so that the fit
             measures generalization rather than reconstruction.  It is a Chest-CT
@@ -71,11 +62,6 @@ class ParametersLungCTDirLab:
             study to that population cannot slip it in.  Tutorial 2 holds out a
             DIR-Lab case of its own, which measures registration rather than
             shape.
-        mgn_weights_dir: Directory the lung-motion MeshGraphNet is trained into
-            by Tutorial 9 and loaded from by Tutorial 10, beside the ICON
-            weights the registration tutorials finetune.  Tutorial 9 writes to a
-            numbered sibling of it when resuming from a checkpoint, in which
-            case Tutorial 10 has to be pointed at that sibling.
         mgn_hold_out_case: DIR-Lab case kept out of the Tutorial 9 training and
             predicted by Tutorial 10, so that the prediction measures
             generalization.  Distinct from ``hold_out_case``, which is the
@@ -111,23 +97,35 @@ class ParametersLungCTDirLab:
     hold_out_case: str = "Chest-CT.mha"
     mgn_hold_out_case: str = "Case1Pack"
 
-    input_dir: Path = _REPO_ROOT / "data" / "DirLab-4DCT"
-    input_dir_test: Path = _REPO_ROOT / "data" / "test" / "DirLab-4DCT"
-    hold_out_dir: Path = _REPO_ROOT / "data" / "Chest-CT"
-    hold_out_dir_test: Path = _REPO_ROOT / "data" / "test" / "Chest-CT"
-    pca_json_file: Path = _OUTPUT_ROOT / "pca_model.json"
-    pca_mean_file: Path = _OUTPUT_ROOT / "pca_mean_surface.vtp"
-    mgn_weights_dir: Path = (
-        _REPO_ROOT / "tutorials" / "network_weights" / "physicsnemo_mgn_lung_motion"
-    )
-
     def input_directory(self, test_mode: bool) -> Path:
-        """Return the model population directory for this run mode."""
-        return self.input_dir_test if test_mode else self.input_dir
+        """Return the population Tutorial 6 builds the model from."""
+        return self.data_directory(test_mode) / "DirLab-4DCT"
 
     def hold_out_directory(self, test_mode: bool) -> Path:
-        """Return the held-out study's directory for this run mode."""
-        return self.hold_out_dir_test if test_mode else self.hold_out_dir
+        """Return the dataset Tutorial 7 reads the held-out study from."""
+        return self.data_directory(test_mode) / "Chest-CT"
+
+    def pca_model_file(self, test_mode: bool) -> Path:
+        """Return the shape model Tutorial 6 writes and 7 and 8 read."""
+        return self.output_directory(test_mode) / "tutorial_06_lung" / "pca_model.json"
+
+    def pca_mean_surface_file(self, test_mode: bool) -> Path:
+        """Return that model's mean surface, written and read the same way."""
+        return (
+            self.output_directory(test_mode)
+            / "tutorial_06_lung"
+            / "pca_mean_surface.vtp"
+        )
+
+    def mgn_weights_directory(self, test_mode: bool) -> Path:
+        """Return the lung-motion MeshGraphNet directory for this run mode.
+
+        Trained into by Tutorial 9 and loaded from by Tutorial 10, beside the
+        ICON weights the registration tutorials finetune.  Tutorial 9 writes to
+        a numbered sibling of it when resuming from a checkpoint, in which case
+        Tutorial 10 has to be pointed at that sibling.
+        """
+        return self.weights_directory(test_mode) / "physicsnemo_mgn_lung_motion"
 
     def pca_components(self, test_mode: bool) -> int:
         """Return the PCA component count for this run mode."""

--- a/tutorials/tutorial_01_heart_gated_ct_to_usd.py
+++ b/tutorials/tutorial_01_heart_gated_ct_to_usd.py
@@ -89,20 +89,19 @@ from physiotwin4d import (
 # Python's spawn-cascade detector raises RuntimeError.
 if __name__ == "__main__":
     # Data directory specification
-    repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_01_heart_gated_ct_to_usd"
 
-    output_dir = tutorials_dir / "output" / "tutorial_01_heart"
-
     test_mode = TestTools.running_as_test()
+
+    output_dir = HEART_CT_KCL.output_directory(test_mode) / "tutorial_01_heart"
+
     if test_mode:
-        data_dir = repo_root / "data" / "test" / "slicer_heart_small"
+        data_dir = HEART_CT_KCL.data_directory(test_mode) / "slicer_heart_small"
         number_of_iterations_greedy = [1, 0]
         frame_files = sorted(data_dir.glob("slice_???.mha"))[0:2]
     else:
-        data_dir = repo_root / "data" / "Slicer-Heart-CT"
+        data_dir = HEART_CT_KCL.data_directory(test_mode) / "Slicer-Heart-CT"
         number_of_iterations_greedy = [30, 15, 7, 3]
         frame_files = sorted(data_dir.glob("slice_???.mha"))
 

--- a/tutorials/tutorial_01_lung_gated_ct_to_usd.py
+++ b/tutorials/tutorial_01_lung_gated_ct_to_usd.py
@@ -87,18 +87,17 @@ from physiotwin4d import (
 # Python's spawn-cascade detector raises RuntimeError.
 if __name__ == "__main__":
     # Data directory specification
-    repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_01_lung_gated_ct_to_usd"
 
-    output_dir = tutorials_dir / "output" / "tutorial_01_lung"
+    test_mode = TestTools.running_as_test()
 
-    data_dir = repo_root / "data" / "DirLab-4DCT"
+    output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_01_lung"
+
+    data_dir = LUNG_CT_DIRLAB.data_directory(test_mode) / "DirLab-4DCT"
 
     # .mha files are DirLab-4DCT data already converted to HU by
     # data/DirLab-4DCT/fix_downloaded_data.py.
-    test_mode = TestTools.running_as_test()
     if test_mode:
         number_of_iterations_greedy = [1, 0]
         frame_files = sorted(data_dir.glob("Case1Pack_T??.mha"))[0:2]

--- a/tutorials/tutorial_02_duke_heart_distancemap_finetune_icon.py
+++ b/tutorials/tutorial_02_duke_heart_distancemap_finetune_icon.py
@@ -75,18 +75,22 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_02_duke_heart_distancemap_finetune_icon"
 
-    output_dir = tutorials_dir / "output" / "tutorial_02_heart_distancemap"
+    test_mode = TestTools.running_as_test()
+
+    output_dir = (
+        DUKE_HEART.output_directory(test_mode) / "tutorial_02_heart_distancemap"
+    )
+    # The workflow writes its dataset JSON, YAML config, and checkpoint tree
+    # under ``weights_dir / finetune_name``.
+    weights_dir = DUKE_HEART.weights_directory(test_mode)
+
     # Rasterized distance maps, cached so re-runs skip the rasterization.
     derived_dir = output_dir / "distance_maps"
     baselines_dir = repo_root / "tests" / "baselines"
 
-    # The workflow writes its dataset JSON, YAML config, and checkpoint tree
-    # under ``weights_dir / finetune_name``.
-    weights_dir = tutorials_dir / "network_weights"
     finetune_name = "icon_duke_heart_distancemap"
 
     # Distance-map normalization, shared with every heart tutorial that later
@@ -98,7 +102,6 @@ if __name__ == "__main__":
     # including any checkpoint a previous run left there.
     run_finetuning = True
 
-    test_mode = TestTools.running_as_test()
     data_dir = DUKE_HEART.hold_out_directory(test_mode)
     if test_mode:
         number_of_iterations_icon: Optional[int] = 1

--- a/tutorials/tutorial_02_lung_distancemap_finetune_icon.py
+++ b/tutorials/tutorial_02_lung_distancemap_finetune_icon.py
@@ -104,19 +104,23 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_02_lung_distancemap_finetune_icon"
 
-    output_dir = tutorials_dir / "output" / "tutorial_02_lung_distancemap"
+    test_mode = TestTools.running_as_test()
+
+    output_dir = (
+        LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_02_lung_distancemap"
+    )
+    # The workflow writes its dataset JSON, YAML config, and checkpoint tree
+    # under ``weights_dir / finetune_name``.
+    weights_dir = LUNG_CT_DIRLAB.weights_directory(test_mode)
+
     # Segmented labelmaps, lung surfaces, and rasterized distance maps.  Cached
     # so re-runs skip the segmentation, which dominates this tutorial's runtime.
     derived_dir = output_dir / "distance_maps"
     baselines_dir = repo_root / "tests" / "baselines"
 
-    # The workflow writes its dataset JSON, YAML config, and checkpoint tree
-    # under ``weights_dir / finetune_name``.
-    weights_dir = tutorials_dir / "network_weights"
     finetune_name = "icon_dirlab_4dct_distancemap"
 
     # Distance-map normalization, shared with every lung tutorial that later
@@ -130,13 +134,12 @@ if __name__ == "__main__":
     # selection still spans inhale through exhale.
     phase_stride = 2
 
-    test_mode = TestTools.running_as_test()
     if test_mode:
-        data_dir = repo_root / "data" / "test" / "DirLab-4DCT"
+        data_dir = LUNG_CT_DIRLAB.data_directory(test_mode) / "DirLab-4DCT"
         number_of_iterations_icon: Optional[int] = 1
         epochs = 1
     else:
-        data_dir = repo_root / "data" / "DirLab-4DCT"
+        data_dir = LUNG_CT_DIRLAB.data_directory(test_mode) / "DirLab-4DCT"
         number_of_iterations_icon = 10
         epochs = 200
     number_of_iterations_greedy = LUNG_CT_DIRLAB.greedy_iterations(test_mode)

--- a/tutorials/tutorial_02_lung_finetune_icon.py
+++ b/tutorials/tutorial_02_lung_finetune_icon.py
@@ -89,6 +89,7 @@ from typing import Any, Optional
 import itk
 import numpy as np
 
+from parameters_base import ParametersBase
 from physiotwin4d import (
     PhysioTwin4DBase,
     RegisterImagesBase,
@@ -109,32 +110,36 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_02_lung_finetune_icon"
 
-    output_dir = tutorials_dir / "output" / "tutorial_02_lung"
+    # Only the shared directory roots are needed here; no dataset-specific
+    # parameters module applies to this tutorial.
+    tutorial_paths = ParametersBase()
+    test_mode = TestTools.running_as_test()
+
+    output_dir = tutorial_paths.output_directory(test_mode) / "tutorial_02_lung"
+    # The workflow writes its dataset JSON, YAML config, and checkpoint tree
+    # under ``weights_dir / finetune_name``.
+    weights_dir = tutorial_paths.weights_directory(test_mode)
+
     # Segmented labelmaps, cached so re-runs skip the segmentation.
     labelmaps_dir = output_dir / "labelmaps"
     baselines_dir = repo_root / "tests" / "baselines"
 
-    # The workflow writes its dataset JSON, YAML config, and checkpoint tree
-    # under ``weights_dir / finetune_name``.
-    weights_dir = tutorials_dir / "network_weights"
     finetune_name = "icon_dirlab_4dct"
 
     # Set True to finetune from scratch.  That deletes experiment_dir below,
     # including any checkpoint a previous run left there.
     run_finetuning = True
 
-    test_mode = TestTools.running_as_test()
     if test_mode:
-        data_dir = repo_root / "data" / "test" / "DirLab-4DCT"
+        data_dir = tutorial_paths.data_directory(test_mode) / "DirLab-4DCT"
         number_of_iterations_greedy: Optional[list[int]] = [1, 0]
         number_of_iterations_icon = None  # [1]
         epochs = 1
     else:
-        data_dir = repo_root / "data" / "DirLab-4DCT"
+        data_dir = tutorial_paths.data_directory(test_mode) / "DirLab-4DCT"
         number_of_iterations_greedy = None  # [60, 30, 20]
         number_of_iterations_icon = None  # [10]
         epochs = 100

--- a/tutorials/tutorial_03_heart_reconstruct_highres_4d_ct.py
+++ b/tutorials/tutorial_03_heart_reconstruct_highres_4d_ct.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import itk
 
+from parameters_base import ParametersBase
 from physiotwin4d import (
     RegisterImagesGreedy,
     TestTools,
@@ -38,21 +39,24 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_03_heart_reconstruct_highres_4d_ct"
 
-    output_dir = tutorials_dir / "output" / "tutorial_03_heart"
+    # Only the shared directory roots are needed here; no dataset-specific
+    # parameters module applies to this tutorial.
+    tutorial_paths = ParametersBase()
+    test_mode = TestTools.running_as_test()
+
+    output_dir = tutorial_paths.output_directory(test_mode) / "tutorial_03_heart"
     baselines_dir = repo_root / "tests" / "baselines"
 
     case_glob = "slice_???.mha"
 
-    test_mode = TestTools.running_as_test()
     if test_mode:
-        data_dir = repo_root / "data" / "test" / "slicer_heart_small"
+        data_dir = tutorial_paths.data_directory(test_mode) / "slicer_heart_small"
         number_of_iterations_greedy = [1, 0]
     else:
-        data_dir = repo_root / "data" / "Slicer-Heart-CT"
+        data_dir = tutorial_paths.data_directory(test_mode) / "Slicer-Heart-CT"
         number_of_iterations_greedy = [30, 15, 7, 3]
 
     log_level = logging.INFO

--- a/tutorials/tutorial_03_lung_reconstruct_highres_4d_ct.py
+++ b/tutorials/tutorial_03_lung_reconstruct_highres_4d_ct.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 import itk
 
+from parameters_base import ParametersBase
 from physiotwin4d import (
     RegisterImagesGreedy,
     TestTools,
@@ -44,23 +45,26 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_03_lung_reconstruct_highres_4d_ct"
 
-    output_dir = tutorials_dir / "output" / "tutorial_03_lung"
+    # Only the shared directory roots are needed here; no dataset-specific
+    # parameters module applies to this tutorial.
+    tutorial_paths = ParametersBase()
+    test_mode = TestTools.running_as_test()
+
+    output_dir = tutorial_paths.output_directory(test_mode) / "tutorial_03_lung"
     baselines_dir = repo_root / "tests" / "baselines"
 
     # .mha files are DirLab-4DCT data already converted to HU by
     # data/DirLab-4DCT/fix_downloaded_data.py.
     case_glob = "Case1Pack_T??.mha"
 
-    test_mode = TestTools.running_as_test()
     if test_mode:
-        data_dir = repo_root / "data" / "test" / "DirLab-4DCT"
+        data_dir = tutorial_paths.data_directory(test_mode) / "DirLab-4DCT"
         number_of_iterations_greedy = [1, 0]
     else:
-        data_dir = repo_root / "data" / "DirLab-4DCT"
+        data_dir = tutorial_paths.data_directory(test_mode) / "DirLab-4DCT"
         number_of_iterations_greedy = [30, 15, 7, 3]
 
     log_level = logging.INFO

--- a/tutorials/tutorial_04_duke_heart_labelmap_to_vtk.py
+++ b/tutorials/tutorial_04_duke_heart_labelmap_to_vtk.py
@@ -76,12 +76,14 @@ from physiotwin4d import (
 # Only run if this script is not imported as a module
 if __name__ == "__main__":
     # Data directory specification
-    repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_04_duke_heart_labelmap_to_vtk"
 
-    output_dir = tutorials_dir / "output" / "tutorial_04_duke_heart_labelmap"
+    test_mode = TestTools.running_as_test()
+
+    output_dir = (
+        DUKE_HEART.output_directory(test_mode) / "tutorial_04_duke_heart_labelmap"
+    )
 
     # How much to build; see this module's docstring.  "shape_model" is what
     # Tutorial 6 (Duke Heart) consumes and runs in minutes over the cohort;
@@ -114,11 +116,10 @@ if __name__ == "__main__":
     # Set False to keep outputs a previous run already wrote.
     overwrite = True
 
-    test_mode = TestTools.running_as_test()
     if test_mode:
-        data_dir = repo_root / "data" / "test" / "Duke-Heart-4DLabelmaps"
+        data_dir = DUKE_HEART.data_directory(test_mode) / "Duke-Heart-4DLabelmaps"
     else:
-        data_dir = repo_root / "data" / "Duke-Heart-4DLabelmaps"
+        data_dir = DUKE_HEART.data_directory(test_mode) / "Duke-Heart-4DLabelmaps"
 
     log_level = logging.INFO
     reporter = PhysioTwin4DBase(class_name=class_name, log_level=log_level)

--- a/tutorials/tutorial_04_heart_ct_to_vtk.py
+++ b/tutorials/tutorial_04_heart_ct_to_vtk.py
@@ -41,12 +41,12 @@ from physiotwin4d import (
 # spawn-cascade detector raises RuntimeError.
 if __name__ == "__main__":
     # Data directory specification
-    repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_04_heart_ct_to_vtk"
 
-    output_dir = tutorials_dir / "output" / "tutorial_04_heart"
+    test_mode = TestTools.running_as_test()
+
+    output_dir = HEART_CT_KCL.output_directory(test_mode) / "tutorial_04_heart"
 
     # In addition to the combined surface file always saved below, also
     # save one VTP per anatomy group (e.g. heart.vtp, lung.vtp) and/or one
@@ -57,11 +57,10 @@ if __name__ == "__main__":
     use_simpleware = False
     use_totalsegmentator_academic_license = True
 
-    test_mode = TestTools.running_as_test()
     if test_mode:
-        data_dir = repo_root / "data" / "test" / "slicer_heart_small"
+        data_dir = HEART_CT_KCL.data_directory(test_mode) / "slicer_heart_small"
     else:
-        data_dir = repo_root / "data" / "Slicer-Heart-CT"
+        data_dir = HEART_CT_KCL.data_directory(test_mode) / "Slicer-Heart-CT"
 
     frame_files = sorted(data_dir.glob("slice_???.mha"))
 

--- a/tutorials/tutorial_04_lung_ct_to_vtk.py
+++ b/tutorials/tutorial_04_lung_ct_to_vtk.py
@@ -40,12 +40,12 @@ from physiotwin4d import (
 # spawn-cascade detector raises RuntimeError.
 if __name__ == "__main__":
     # Data directory specification
-    repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     project_name = "tutorial_04_lung"
 
-    output_dir = tutorials_dir / "output" / project_name
+    test_mode = TestTools.running_as_test()
+
+    output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / project_name
 
     # In addition to the combined surface file always saved below, also
     # save one VTP per anatomy group (e.g. heart.vtp, lung.vtp) and/or one
@@ -53,11 +53,10 @@ if __name__ == "__main__":
     save_group_surfaces = True
     save_label_surfaces = True
 
-    test_mode = TestTools.running_as_test()
     if test_mode:
-        data_dir = repo_root / "data" / "test" / "DirLab-4DCT"
+        data_dir = LUNG_CT_DIRLAB.data_directory(test_mode) / "DirLab-4DCT"
     else:
-        data_dir = repo_root / "data" / "DirLab-4DCT"
+        data_dir = LUNG_CT_DIRLAB.data_directory(test_mode) / "DirLab-4DCT"
 
     frame_files = sorted(data_dir.glob("Case1Pack_T??.mha"))
 

--- a/tutorials/tutorial_05_duke_heart_vtk_to_usd.py
+++ b/tutorials/tutorial_05_duke_heart_vtk_to_usd.py
@@ -40,6 +40,7 @@ from typing import cast
 import numpy as np
 import pyvista as pv
 
+from parameters_base import ParametersBase
 from physiotwin4d import (
     PhysioTwin4DBase,
     SegmentHeartSimplewareTrimmedBranches,
@@ -50,12 +51,18 @@ from physiotwin4d import (
 # Only run if this script is not imported as a module
 if __name__ == "__main__":
     # Data directory specification
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_05_duke_heart_vtk_to_usd"
 
-    input_dir = tutorials_dir / "output" / "tutorial_04_duke_heart_labelmap"
-    output_dir = tutorials_dir / "output" / "tutorial_05_duke_heart"
+    # Only the shared directory roots are needed here; no dataset-specific
+    # parameters module applies to this tutorial.
+    tutorial_paths = ParametersBase()
+    test_mode = TestTools.running_as_test()
+
+    input_dir = (
+        tutorial_paths.output_directory(test_mode) / "tutorial_04_duke_heart_labelmap"
+    )
+    output_dir = tutorial_paths.output_directory(test_mode) / "tutorial_05_duke_heart"
 
     log_level = logging.INFO
     reporter = PhysioTwin4DBase(class_name=class_name, log_level=log_level)

--- a/tutorials/tutorial_05_heart_vtk_to_usd.py
+++ b/tutorials/tutorial_05_heart_vtk_to_usd.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import pyvista as pv
 
+from parameters_base import ParametersBase
 from physiotwin4d import (
     TestTools,
     WorkflowConvertVTKToUSD,
@@ -41,17 +42,21 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_05_heart_vtk_to_usd"
 
-    output_dir = tutorials_dir / "output" / "tutorial_05_heart"
+    # Only the shared directory roots are needed here; no dataset-specific
+    # parameters module applies to this tutorial.
+    tutorial_paths = ParametersBase()
+    test_mode = TestTools.running_as_test()
+
+    output_dir = tutorial_paths.output_directory(test_mode) / "tutorial_05_heart"
     baselines_dir = repo_root / "tests" / "baselines"
 
     project_name = "tutorial_04_heart"
 
     # Preferred input: the per-structure surfaces saved by Tutorial 4.
-    input_dir = tutorials_dir / "output" / "tutorial_04_heart"
+    input_dir = tutorial_paths.output_directory(test_mode) / "tutorial_04_heart"
 
     log_level = logging.INFO
 

--- a/tutorials/tutorial_06_duke_heart_create_statistical_model.py
+++ b/tutorials/tutorial_06_duke_heart_create_statistical_model.py
@@ -57,14 +57,16 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_06_duke_heart_create_statistical_model"
 
-    output_dir = tutorials_dir / "output" / "tutorial_06_duke_heart"
+    test_mode = TestTools.running_as_test()
+
+    output_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_06_duke_heart"
+    weights_dir = DUKE_HEART.weights_directory(test_mode)
+
     baselines_dir = repo_root / "tests" / "baselines"
 
-    test_mode = TestTools.running_as_test()
     input_dir = DUKE_HEART.input_directory(test_mode)
     number_of_pca_components = DUKE_HEART.pca_components(test_mode)
 
@@ -82,8 +84,7 @@ if __name__ == "__main__":
     # and the modes come out far too tight.  Tutorial 7 fits with the same
     # checkpoint.
     icon_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_duke_heart_distancemap"
         / "icon_duke_heart_distancemap_model"
         / "checkpoints"
@@ -200,13 +201,13 @@ if __name__ == "__main__":
 
     # Result saving
     pca_model: dict[str, Any] = result["pca_model"]
-    model_file = DUKE_HEART.pca_json_file
+    model_file = DUKE_HEART.pca_model_file(test_mode)
     model_file.parent.mkdir(parents=True, exist_ok=True)
     with model_file.open("w", encoding="utf-8") as f:
         json.dump(pca_model, f, indent=2)
 
     mean_surface = result["pca_mean_surface"]
-    mean_surface_file = DUKE_HEART.pca_mean_file
+    mean_surface_file = DUKE_HEART.pca_mean_surface_file(test_mode)
     mean_surface.save(str(mean_surface_file))
 
     # Testing

--- a/tutorials/tutorial_06_heart_create_statistical_model.py
+++ b/tutorials/tutorial_06_heart_create_statistical_model.py
@@ -40,14 +40,16 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_06_heart_create_statistical_model"
 
-    output_dir = tutorials_dir / "output" / "tutorial_06_heart"
+    test_mode = TestTools.running_as_test()
+
+    output_dir = HEART_CT_KCL.output_directory(test_mode) / "tutorial_06_heart"
+    weights_dir = HEART_CT_KCL.weights_directory(test_mode)
+
     baselines_dir = repo_root / "tests" / "baselines"
 
-    test_mode = TestTools.running_as_test()
     data_dir = HEART_CT_KCL.input_directory(test_mode)
     number_of_pca_components = HEART_CT_KCL.pca_components(test_mode)
 
@@ -58,8 +60,7 @@ if __name__ == "__main__":
     # and the modes come out far too tight.  Tutorial 7 fits with the same
     # checkpoint.
     icon_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_duke_heart_distancemap"
         / "icon_duke_heart_distancemap_model"
         / "checkpoints"
@@ -135,12 +136,12 @@ if __name__ == "__main__":
     pca_model: dict[str, Any] = result["pca_model"]
     mean_surface: pv.PolyData = result["pca_mean_surface"]
 
-    model_file = HEART_CT_KCL.pca_json_file
+    model_file = HEART_CT_KCL.pca_model_file(test_mode)
     model_file.parent.mkdir(parents=True, exist_ok=True)
     with model_file.open("w", encoding="utf-8") as f:
         json.dump(pca_model, f, indent=2)
 
-    mean_surface_file = HEART_CT_KCL.pca_mean_file
+    mean_surface_file = HEART_CT_KCL.pca_mean_surface_file(test_mode)
     mean_surface.save(str(mean_surface_file))
 
     # Testing

--- a/tutorials/tutorial_06_lung_create_statistical_model.py
+++ b/tutorials/tutorial_06_lung_create_statistical_model.py
@@ -61,14 +61,16 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_06_lung_create_statistical_model"
 
-    output_dir = tutorials_dir / "output" / "tutorial_06_lung"
+    test_mode = TestTools.running_as_test()
+
+    output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_06_lung"
+    weights_dir = LUNG_CT_DIRLAB.weights_directory(test_mode)
+
     baselines_dir = repo_root / "tests" / "baselines"
 
-    test_mode = TestTools.running_as_test()
     data_dir = LUNG_CT_DIRLAB.input_directory(test_mode)
 
     number_of_pca_components = LUNG_CT_DIRLAB.pca_components(test_mode)
@@ -84,8 +86,7 @@ if __name__ == "__main__":
     # and the modes come out far too tight.  Tutorial 7 fits with the same
     # checkpoint.
     icon_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_dirlab_4dct_distancemap"
         / "icon_dirlab_4dct_distancemap_model"
         / "checkpoints"
@@ -209,13 +210,13 @@ if __name__ == "__main__":
 
     # Result saving
     pca_model: dict[str, Any] = result["pca_model"]
-    model_file = LUNG_CT_DIRLAB.pca_json_file
+    model_file = LUNG_CT_DIRLAB.pca_model_file(test_mode)
     model_file.parent.mkdir(parents=True, exist_ok=True)
     with model_file.open("w", encoding="utf-8") as f:
         json.dump(pca_model, f, indent=2)
 
     mean_surface = result["pca_mean_surface"]
-    mean_surface_file = LUNG_CT_DIRLAB.pca_mean_file
+    mean_surface_file = LUNG_CT_DIRLAB.pca_mean_surface_file(test_mode)
     mean_surface.save(str(mean_surface_file))
 
     # Testing

--- a/tutorials/tutorial_07_duke_heart_fit_statistical_model_to_patient.py
+++ b/tutorials/tutorial_07_duke_heart_fit_statistical_model_to_patient.py
@@ -53,22 +53,24 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     project_name = "tutorial_07_duke_heart"
 
-    output_dir = tutorials_dir / "output" / project_name
+    test_mode = TestTools.running_as_test()
+
+    output_dir = DUKE_HEART.output_directory(test_mode) / project_name
+    weights_dir = DUKE_HEART.weights_directory(test_mode)
+
     baselines_dir = repo_root / "tests" / "baselines"
 
     # PCA model + mean surface produced by Tutorial 6 (Duke Heart).
-    pca_json = DUKE_HEART.pca_json_file
-    pca_mean_file = DUKE_HEART.pca_mean_file
+    pca_json = DUKE_HEART.pca_model_file(test_mode)
+    pca_mean_file = DUKE_HEART.pca_mean_surface_file(test_mode)
 
     # The case whose reference frame plays the patient: the one Tutorial 6
     # leaves out of the model, so this fit is out of sample.
     patient_case = DUKE_HEART.hold_out_case
 
-    test_mode = TestTools.running_as_test()
     number_of_pca_components = DUKE_HEART.pca_components(test_mode)
     data_dir = DUKE_HEART.hold_out_directory(test_mode)
 
@@ -88,8 +90,7 @@ if __name__ == "__main__":
     # registration mask is far tighter, so heart distance maps saturate over a
     # shorter radius and do not share an intensity distribution with lung ones.
     icon_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_duke_heart_distancemap"
         / "icon_duke_heart_distancemap_model"
         / "checkpoints"

--- a/tutorials/tutorial_07_heart_fit_statistical_model_to_patient.py
+++ b/tutorials/tutorial_07_heart_fit_statistical_model_to_patient.py
@@ -44,18 +44,20 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     project_name = "tutorial_07_heart"
 
-    output_dir = tutorials_dir / "output" / project_name
+    test_mode = TestTools.running_as_test()
+
+    output_dir = HEART_CT_KCL.output_directory(test_mode) / project_name
+    weights_dir = HEART_CT_KCL.weights_directory(test_mode)
+
     baselines_dir = repo_root / "tests" / "baselines"
 
     # PCA model + mean surface produced by Tutorial 6.
-    pca_json = HEART_CT_KCL.pca_json_file
-    pca_mean_file = HEART_CT_KCL.pca_mean_file
+    pca_json = HEART_CT_KCL.pca_model_file(test_mode)
+    pca_mean_file = HEART_CT_KCL.pca_mean_surface_file(test_mode)
 
-    test_mode = TestTools.running_as_test()
     data_dir = HEART_CT_KCL.hold_out_directory(test_mode)
     # The case Tutorial 6 leaves out of the model, so this fit is out of sample.
     patient_image_file = data_dir / f"{HEART_CT_KCL.hold_out_case}_T70.mha"
@@ -66,8 +68,7 @@ if __name__ == "__main__":
     # mask is far tighter, so heart distance maps saturate over a shorter radius
     # and do not share an intensity distribution with lung ones.
     icon_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_duke_heart_distancemap"
         / "icon_duke_heart_distancemap_model"
         / "checkpoints"

--- a/tutorials/tutorial_07_lung_fit_statistical_model_to_patient.py
+++ b/tutorials/tutorial_07_lung_fit_statistical_model_to_patient.py
@@ -51,18 +51,20 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     project_name = "tutorial_07_lung"
 
-    output_dir = tutorials_dir / "output" / project_name
+    test_mode = TestTools.running_as_test()
+
+    output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / project_name
+    weights_dir = LUNG_CT_DIRLAB.weights_directory(test_mode)
+
     baselines_dir = repo_root / "tests" / "baselines"
 
     # PCA model + mean surface produced by Tutorial 6 (lung).
-    pca_json = LUNG_CT_DIRLAB.pca_json_file
-    pca_mean_file = LUNG_CT_DIRLAB.pca_mean_file
+    pca_json = LUNG_CT_DIRLAB.pca_model_file(test_mode)
+    pca_mean_file = LUNG_CT_DIRLAB.pca_mean_surface_file(test_mode)
 
-    test_mode = TestTools.running_as_test()
     number_of_pca_components = LUNG_CT_DIRLAB.pca_components(test_mode)
 
     # The study Tutorial 6 leaves out of the model, so this fit is out of sample.
@@ -74,8 +76,7 @@ if __name__ == "__main__":
     # tutorial_02_lung_distancemap_finetune_icon.py; see
     # WorkflowFinetuneICONRegistration.expected_weights_path().
     icon_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_dirlab_4dct_distancemap"
         / "icon_dirlab_4dct_distancemap_model"
         / "checkpoints"

--- a/tutorials/tutorial_08_duke_heart_fit_model_to_4d_patients.py
+++ b/tutorials/tutorial_08_duke_heart_fit_model_to_4d_patients.py
@@ -86,22 +86,24 @@ LABELMAP_SUFFIX = "_labelmap.nii.gz"
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_08_duke_heart_fit_model_to_4d_patients"
 
-    output_dir = tutorials_dir / "output" / "tutorial_08_duke_heart"
+    test_mode = TestTools.running_as_test()
+
+    output_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_08_duke_heart"
+    weights_dir = DUKE_HEART.weights_directory(test_mode)
+
     baselines_dir = repo_root / "tests" / "baselines"
 
-    test_mode = TestTools.running_as_test()
     # The gated labelmaps, one directory per case.
     data_dir = DUKE_HEART.hold_out_directory(test_mode)
     # Tutorial 4's surfaces, read when its "full" pass wrote the frame.
     tutorial_04_dir = DUKE_HEART.input_directory(test_mode)
 
     # PCA model + mean surface produced by Tutorial 6 (Duke Heart).
-    pca_model_file = DUKE_HEART.pca_json_file
-    pca_mean_file = DUKE_HEART.pca_mean_file
+    pca_model_file = DUKE_HEART.pca_model_file(test_mode)
+    pca_mean_file = DUKE_HEART.pca_mean_surface_file(test_mode)
 
     number_of_pca_components = DUKE_HEART.pca_components(test_mode)
 
@@ -122,8 +124,7 @@ if __name__ == "__main__":
     # tutorial_02_duke_heart_distancemap_finetune_icon.py, used both by the
     # labelmap-to-labelmap stage of the SSM fit and by the phase registrations.
     icon_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_duke_heart_distancemap"
         / "icon_duke_heart_distancemap_model"
         / "checkpoints"

--- a/tutorials/tutorial_08_lung_fit_model_to_4d_patients.py
+++ b/tutorials/tutorial_08_lung_fit_model_to_4d_patients.py
@@ -77,18 +77,21 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_08_lung_fit_model_to_4d_patients"
 
-    data_dir = repo_root / "data" / "DirLab-4DCT"
+    test_mode = TestTools.running_as_test()
 
-    output_dir = tutorials_dir / "output" / "tutorial_08_lung"
+    data_dir = LUNG_CT_DIRLAB.input_directory(test_mode)
+
+    output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_08_lung"
+    weights_dir = LUNG_CT_DIRLAB.weights_directory(test_mode)
+
     baselines_dir = repo_root / "tests" / "baselines"
 
     # PCA model + mean surface produced by Tutorial 6 (lung).
-    pca_model_file = LUNG_CT_DIRLAB.pca_json_file
-    pca_mean_file = LUNG_CT_DIRLAB.pca_mean_file
+    pca_model_file = LUNG_CT_DIRLAB.pca_model_file(test_mode)
+    pca_mean_file = LUNG_CT_DIRLAB.pca_mean_surface_file(test_mode)
     # Tutorial 6 caches one segmentation per case beside its model.
     tutorial_06_dir = pca_model_file.parent
 
@@ -96,17 +99,14 @@ if __name__ == "__main__":
     # tutorial_02_lung_distancemap_finetune_icon.py, used by the
     # labelmap-to-labelmap stage of the SSM fit.
     icon_distancemap_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_dirlab_4dct_distancemap"
         / "icon_dirlab_4dct_distancemap_model"
         / "checkpoints"
         / "network_weights_final.trch"
     )
 
-    number_of_pca_components = LUNG_CT_DIRLAB.pca_components(
-        TestTools.running_as_test()
-    )
+    number_of_pca_components = LUNG_CT_DIRLAB.pca_components(test_mode)
 
     # Phase the SSM is fitted to; Tutorial 6 builds the lung PCA model from the
     # T70 surfaces, so the same phase is used here as the fitting reference.

--- a/tutorials/tutorial_09_duke_heart_train_physicsnemo_mgn.py
+++ b/tutorials/tutorial_09_duke_heart_train_physicsnemo_mgn.py
@@ -61,7 +61,7 @@ Manifests and per-frame targets are written under
 The evaluation of the held-out cases lands in
 ``output/tutorial_09_duke_heart_mgn/eval_mgn/pm????/``.
 
-The model itself is written to ``ParametersDukeHeartLabelmaps.mgn_weights_dir``
+The model itself is written to ``ParametersDukeHeartLabelmaps.mgn_weights_directory``
 (``network_weights/physicsnemo_mgn_duke_heart_motion/``), or to a fresh ``..._1``
 sibling when resuming (see ``resume_from``), which is what ``tutorial_results``
 reports as ``model_directory``:
@@ -188,17 +188,19 @@ def _write_case_manifest(
 if __name__ == "__main__":
     # Data directory specification
     tutorials_dir = Path(__file__).resolve().parent
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
     # Fitted SSM surfaces and PCA coefficients written by Tutorial 8 (Duke Heart).
-    data_dir = tutorials_dir / "output" / "tutorial_08_duke_heart"
+    data_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_08_duke_heart"
     # PCA mean surface written by Tutorial 6 (Duke Heart); pca_model.json must
     # sit beside it, which is how Tutorial 6 writes them.
-    ssm_mean_surface_file = DUKE_HEART.pca_mean_file
+    ssm_mean_surface_file = DUKE_HEART.pca_mean_surface_file(test_mode)
     # Manifests, targets and the held-out evaluation are written here.
-    output_dir = tutorials_dir / "output" / "tutorial_09_duke_heart_mgn"
+    output_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_09_duke_heart_mgn"
     manifests_dir = output_dir / "manifests_mgn"
     eval_dir = output_dir / "eval_mgn"
     # The trained network is kept with the other trained networks instead.
-    model_output_dir = DUKE_HEART.mgn_weights_dir
+    model_output_dir = DUKE_HEART.mgn_weights_directory(test_mode)
 
     # Warm-start from a previous run's checkpoint; None trains from scratch.
     # When resuming, training writes to a fresh sibling directory (``..._1``).
@@ -231,7 +233,6 @@ if __name__ == "__main__":
     logger = logging.getLogger(class_name)
 
     # In test mode, train for a couple of epochs to keep the run tractable.
-    test_mode = TestTools.running_as_test()
     if test_mode:
         epochs = 2
 

--- a/tutorials/tutorial_09_lung_train_physicsnemo_mgn.py
+++ b/tutorials/tutorial_09_lung_train_physicsnemo_mgn.py
@@ -66,7 +66,7 @@ Manifests, the held-out evaluation and the screenshots are written under
   * ``eval_mgn/Case*Pack/``     - predicted surfaces per held-out case
   * ``predicted_surface.png``   - screenshot of the held-out prediction
 
-The model lands in ``ParametersLungCTDirLab.mgn_weights_dir``
+The model lands in ``ParametersLungCTDirLab.mgn_weights_directory``
 (``network_weights/physicsnemo_mgn_lung_motion/``), where Tutorial 10 reads it:
 
   * ``mgn_stage_model.pt``      - trained MeshGraphNet checkpoint
@@ -190,19 +190,19 @@ def _write_case_manifest(
 if __name__ == "__main__":
     # Data directory specification
     tutorials_dir = Path(__file__).resolve().parent
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
     # Fitted SSM surfaces and PCA coefficients written by Tutorial 8 (lung).
-    data_dir = tutorials_dir / "output" / "tutorial_08_lung"
+    data_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_08_lung"
     # PCA mean surface written by Tutorial 6 (lung); pca_model.json must sit
     # beside it, which is how Tutorial 6 writes them.
-    ssm_mean_surface_file = (
-        tutorials_dir / "output" / "tutorial_06_lung" / "pca_mean_surface.vtp"
-    )
+    ssm_mean_surface_file = LUNG_CT_DIRLAB.pca_mean_surface_file(test_mode)
     # Manifests, evaluation surfaces and screenshots are written here.
-    output_dir = tutorials_dir / "output" / "tutorial_09_lung_mgn"
+    output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_09_lung_mgn"
     manifests_dir = output_dir / "manifests_mgn"
     # The trained model goes to the shared weights directory Tutorial 10 loads
     # it from, beside the ICON weights the registration tutorials finetune.
-    weights_dir = LUNG_CT_DIRLAB.mgn_weights_dir
+    weights_dir = LUNG_CT_DIRLAB.mgn_weights_directory(test_mode)
 
     # Warm-start from a previous run's checkpoint; None trains from scratch. When
     # resuming, training writes to a fresh sibling of weights_dir, e.g.
@@ -231,7 +231,6 @@ if __name__ == "__main__":
     logger = logging.getLogger(class_name)
 
     # In test mode, train for a couple of epochs to keep the run tractable.
-    test_mode = TestTools.running_as_test()
     if test_mode:
         epochs = 2
 

--- a/tutorials/tutorial_10_duke_heart_infer_physicsnemo_mgn.py
+++ b/tutorials/tutorial_10_duke_heart_infer_physicsnemo_mgn.py
@@ -45,7 +45,7 @@ Data Required
     - reference frame that is warped
   * ``network_weights/physicsnemo_mgn_duke_heart_motion/mgn_stage_model.pt``
     - Tutorial 9 checkpoint
-    (``ParametersDukeHeartLabelmaps.mgn_weights_dir``)
+    (``ParametersDukeHeartLabelmaps.mgn_weights_directory``)
 
 Outputs (under ``output/tutorial_10_duke_heart_mgn/<case>/``)
 ------------------------------------------------------------
@@ -94,10 +94,12 @@ def _cardiac_stage_from_filename(surface_file: Path) -> float:
 if __name__ == "__main__":
     # Data directory specification
     tutorials_dir = Path(__file__).resolve().parent
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
     # Fitted SSM surfaces and PCA coefficients written by Tutorial 8 (Duke Heart).
-    data_dir = tutorials_dir / "output" / "tutorial_08_duke_heart"
+    data_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_08_duke_heart"
     # The network Tutorial 9 (Duke Heart) trained.
-    model_dir = DUKE_HEART.mgn_weights_dir
+    model_dir = DUKE_HEART.mgn_weights_directory(test_mode)
     # Intermittent-checkpoint epoch to load; None uses the final weights.
     epoch: Optional[int] = None
 
@@ -107,14 +109,15 @@ if __name__ == "__main__":
     # into the continuous field the reference frame is resampled through.
     smoothing_sigma_mm = 10.0
 
-    output_dir = tutorials_dir / "output" / "tutorial_10_duke_heart_mgn" / case_id
+    output_dir = (
+        DUKE_HEART.output_directory(test_mode) / "tutorial_10_duke_heart_mgn" / case_id
+    )
     log_level = logging.INFO
 
     class_name = "tutorial_10_duke_heart_infer_physicsnemo_mgn"
     logging.basicConfig(level=log_level)
     logger = logging.getLogger(class_name)
 
-    test_mode = TestTools.running_as_test()
     labelmap_dir = DUKE_HEART.hold_out_directory(test_mode) / case_id
 
     # Directory setup and data reading

--- a/tutorials/tutorial_10_lung_infer_physicsnemo_mgn.py
+++ b/tutorials/tutorial_10_lung_infer_physicsnemo_mgn.py
@@ -42,7 +42,7 @@ Data Required
   * ``output/tutorial_08_lung/<case>/``  - Tutorial 8 SSM surfaces
   * ``data/DirLab-4DCT/<case>_T70.mha``  - reference-phase CT that is warped
   * ``network_weights/physicsnemo_mgn_lung_motion/mgn_stage_model.pt``
-    - Tutorial 9 checkpoint (``ParametersLungCTDirLab.mgn_weights_dir``)
+    - Tutorial 9 checkpoint (``ParametersLungCTDirLab.mgn_weights_directory``)
 
 Outputs (under ``output/tutorial_10_lung_mgn/<case>/``)
 -------------------------------------------------------
@@ -85,13 +85,14 @@ def _respiratory_stage_from_filename(surface_file: Path) -> float:
 # restart the prediction in every worker.
 if __name__ == "__main__":
     # Data directory specification
-    repo_root = Path(__file__).resolve().parent.parent
     tutorials_dir = Path(__file__).resolve().parent
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
     # Fitted SSM surfaces and PCA coefficients written by Tutorial 8 (lung).
-    data_dir = tutorials_dir / "output" / "tutorial_08_lung"
+    data_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_08_lung"
     # Weights Tutorial 9 trained. A resumed Tutorial 9 run writes to a numbered
     # sibling of this directory, which is what would be evaluated instead.
-    model_dir = LUNG_CT_DIRLAB.mgn_weights_dir
+    model_dir = LUNG_CT_DIRLAB.mgn_weights_directory(test_mode)
     # Intermittent-checkpoint epoch to load; None uses the final weights.
     epoch: Optional[int] = None
 
@@ -104,7 +105,9 @@ if __name__ == "__main__":
     # into the continuous field the CT is resampled through.
     smoothing_sigma_mm = 10.0
 
-    output_dir = tutorials_dir / "output" / "tutorial_10_lung_mgn" / case_id
+    output_dir = (
+        LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_10_lung_mgn" / case_id
+    )
     log_level = logging.INFO
 
     class_name = "tutorial_10_lung_infer_physicsnemo_mgn"
@@ -129,7 +132,9 @@ if __name__ == "__main__":
     fitted_reference_mesh_file = case_dir / f"{case_id}_ssm_surface.vtp"
     pca_file = case_dir / f"{case_id}_ssm_pca_coefficients.json"
     reference_ct_file = (
-        repo_root / "data" / "DirLab-4DCT" / (f"{case_id}_{reference_phase}.mha")
+        LUNG_CT_DIRLAB.data_directory(test_mode)
+        / "DirLab-4DCT"
+        / (f"{case_id}_{reference_phase}.mha")
     )
     phase_files = sorted(case_dir.glob(f"{case_id}_T??_ssm_surface.vtp"))
     for required_file in (fitted_reference_mesh_file, pca_file):

--- a/tutorials/tutorial_11_duke_heart_evaluate_physicsnemo.py
+++ b/tutorials/tutorial_11_duke_heart_evaluate_physicsnemo.py
@@ -91,7 +91,6 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_11_duke_heart_evaluate_physicsnemo"
 
@@ -99,10 +98,14 @@ if __name__ == "__main__":
     case_id = DUKE_HEART.hold_out_case
 
     # Fitted SSM surface and PCA coefficients written by Tutorial 8 (Duke Heart).
-    case_dir = tutorials_dir / "output" / "tutorial_08_duke_heart" / case_id
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
+    case_dir = (
+        DUKE_HEART.output_directory(test_mode) / "tutorial_08_duke_heart" / case_id
+    )
     # Weights Tutorial 9 trained, and the checkpoint epoch Tutorial 10 infers
     # with; None uses the final weights.
-    model_dir = DUKE_HEART.mgn_weights_dir
+    model_dir = DUKE_HEART.mgn_weights_directory(test_mode)
     epoch: Optional[int] = None
 
     # Gaussian sigma, in mm, that spreads the predicted surface displacements
@@ -125,13 +128,14 @@ if __name__ == "__main__":
     # in the wrong direction cannot hide in, and it costs one mesh read a frame.
     include_displacement_error = True
 
-    output_dir = tutorials_dir / "output" / "tutorial_11_duke_heart" / case_id
+    output_dir = (
+        DUKE_HEART.output_directory(test_mode) / "tutorial_11_duke_heart" / case_id
+    )
     log_level = logging.INFO
 
     logging.basicConfig(level=log_level)
     logger = logging.getLogger(class_name)
 
-    test_mode = TestTools.running_as_test()
     labelmap_dir = DUKE_HEART.hold_out_directory(test_mode) / case_id
 
     # Directory setup and data reading

--- a/tutorials/tutorial_11_lung_evaluate_physicsnemo.py
+++ b/tutorials/tutorial_11_lung_evaluate_physicsnemo.py
@@ -92,7 +92,6 @@ from physiotwin4d import (
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_11_lung_evaluate_physicsnemo"
 
@@ -103,10 +102,12 @@ if __name__ == "__main__":
     reference_phase = "T70"
 
     # Fitted SSM surface and PCA coefficients written by Tutorial 8 (lung).
-    case_dir = tutorials_dir / "output" / "tutorial_08_lung" / case_id
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
+    case_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_08_lung" / case_id
     # Weights Tutorial 9 trained, and the checkpoint epoch Tutorial 10 infers
     # with; None uses the final weights.
-    model_dir = LUNG_CT_DIRLAB.mgn_weights_dir
+    model_dir = LUNG_CT_DIRLAB.mgn_weights_directory(test_mode)
     epoch: Optional[int] = None
 
     # Gaussian sigma, in mm, that spreads the predicted surface displacements
@@ -129,14 +130,15 @@ if __name__ == "__main__":
     # in the wrong direction cannot hide in, and it costs one mesh read a phase.
     include_displacement_error = True
 
-    output_dir = tutorials_dir / "output" / "tutorial_11_lung" / case_id
+    output_dir = (
+        LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_11_lung" / case_id
+    )
     ground_truth_dir = output_dir / "ground_truth"
     log_level = logging.INFO
 
     logging.basicConfig(level=log_level)
     logger = logging.getLogger(class_name)
 
-    test_mode = TestTools.running_as_test()
     data_dir = LUNG_CT_DIRLAB.input_directory(test_mode)
 
     # Directory setup and data reading

--- a/tutorials/tutorial_12_duke_heart_end_to_end_inference.py
+++ b/tutorials/tutorial_12_duke_heart_end_to_end_inference.py
@@ -115,27 +115,29 @@ def _record_step(times_s: dict[str, float], step: str, started: float) -> float:
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_12_duke_heart_end_to_end_inference"
 
     # Case to predict: the case held out of every fit in this chain.
     case_id = DUKE_HEART.hold_out_case
 
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
+    weights_dir = DUKE_HEART.weights_directory(test_mode)
+
     # PCA model + mean surface produced by Tutorial 6 (Duke Heart).
-    pca_model_file = DUKE_HEART.pca_json_file
-    pca_mean_file = DUKE_HEART.pca_mean_file
+    pca_model_file = DUKE_HEART.pca_model_file(test_mode)
+    pca_mean_file = DUKE_HEART.pca_mean_surface_file(test_mode)
     # Weights Tutorial 9 trained, and the checkpoint epoch to infer with; None
     # uses the final weights.
-    model_dir = DUKE_HEART.mgn_weights_dir
+    model_dir = DUKE_HEART.mgn_weights_directory(test_mode)
     epoch: Optional[int] = None
 
     # Distance-map weights finetuned by
     # tutorial_02_duke_heart_distancemap_finetune_icon.py, used by the
     # labelmap-to-labelmap stage of the SSM fit.
     icon_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_duke_heart_distancemap"
         / "icon_duke_heart_distancemap_model"
         / "checkpoints"
@@ -146,7 +148,9 @@ if __name__ == "__main__":
     # into the continuous field the labelmap is resampled through.
     smoothing_sigma_mm = 10.0
 
-    output_dir = tutorials_dir / "output" / "tutorial_12_duke_heart" / case_id
+    output_dir = (
+        DUKE_HEART.output_directory(test_mode) / "tutorial_12_duke_heart" / case_id
+    )
     log_level = logging.INFO
 
     logging.basicConfig(level=log_level)
@@ -157,7 +161,6 @@ if __name__ == "__main__":
     step_times_s: dict[str, float] = {}
     step_start = time.perf_counter()
 
-    test_mode = TestTools.running_as_test()
     labelmap_dir = DUKE_HEART.hold_out_directory(test_mode) / case_id
     number_of_pca_components = DUKE_HEART.pca_components(test_mode)
 

--- a/tutorials/tutorial_12_lung_end_to_end_inference.py
+++ b/tutorials/tutorial_12_lung_end_to_end_inference.py
@@ -111,7 +111,6 @@ def _record_step(times_s: dict[str, float], step: str, started: float) -> float:
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_12_lung_end_to_end_inference"
 
@@ -122,20 +121,23 @@ if __name__ == "__main__":
     # phase, so the network's reference frame is this one.
     reference_phase = "T70"
 
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
+    weights_dir = LUNG_CT_DIRLAB.weights_directory(test_mode)
+
     # PCA model + mean surface produced by Tutorial 6 (lung).
-    pca_model_file = LUNG_CT_DIRLAB.pca_json_file
-    pca_mean_file = LUNG_CT_DIRLAB.pca_mean_file
+    pca_model_file = LUNG_CT_DIRLAB.pca_model_file(test_mode)
+    pca_mean_file = LUNG_CT_DIRLAB.pca_mean_surface_file(test_mode)
     # Weights Tutorial 9 trained, and the checkpoint epoch to infer with; None
     # uses the final weights.
-    model_dir = LUNG_CT_DIRLAB.mgn_weights_dir
+    model_dir = LUNG_CT_DIRLAB.mgn_weights_directory(test_mode)
     epoch: Optional[int] = None
 
     # Distance-map weights finetuned on DIR-Lab by
     # tutorial_02_lung_distancemap_finetune_icon.py, used by the
     # labelmap-to-labelmap stage of the SSM fit.
     icon_distancemap_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_dirlab_4dct_distancemap"
         / "icon_dirlab_4dct_distancemap_model"
         / "checkpoints"
@@ -146,7 +148,9 @@ if __name__ == "__main__":
     # into the continuous field the CT is resampled through.
     smoothing_sigma_mm = 10.0
 
-    output_dir = tutorials_dir / "output" / "tutorial_12_lung" / case_id
+    output_dir = (
+        LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_12_lung" / case_id
+    )
     log_level = logging.INFO
 
     logging.basicConfig(level=log_level)
@@ -157,7 +161,6 @@ if __name__ == "__main__":
     step_times_s: dict[str, float] = {}
     step_start = time.perf_counter()
 
-    test_mode = TestTools.running_as_test()
     data_dir = LUNG_CT_DIRLAB.input_directory(test_mode)
     number_of_pca_components = LUNG_CT_DIRLAB.pca_components(test_mode)
 

--- a/tutorials/tutorial_13_heart_and_lung_motion.py
+++ b/tutorials/tutorial_13_heart_and_lung_motion.py
@@ -169,6 +169,8 @@ if __name__ == "__main__":
 
     # ---- Inputs ------------------------------------------------------------
     test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
+    weights_dir = DUKE_HEART.weights_directory(test_mode)
 
     # The ungated clinical scan every rhythm is inferred onto.
     patient_image_file = (
@@ -177,14 +179,14 @@ if __name__ == "__main__":
 
     # Tutorial 9 weights for each rhythm, and the Tutorial 6 shape model the
     # cardiac one was trained on.
-    lung_model_dir = LUNG_CT_DIRLAB.mgn_weights_dir
-    heart_model_dir = DUKE_HEART.mgn_weights_dir
-    heart_pca_json = DUKE_HEART.pca_json_file
-    heart_pca_mean_file = DUKE_HEART.pca_mean_file
+    lung_model_dir = LUNG_CT_DIRLAB.mgn_weights_directory(test_mode)
+    heart_model_dir = DUKE_HEART.mgn_weights_directory(test_mode)
+    heart_pca_json = DUKE_HEART.pca_model_file(test_mode)
+    heart_pca_mean_file = DUKE_HEART.pca_mean_surface_file(test_mode)
 
     # Tutorial 7 (lung) fit of this same scan: the network's reference geometry
     # and the shape parameters it is conditioned on.
-    tutorial_07_lung_dir = tutorials_dir / "output" / "tutorial_07_lung"
+    tutorial_07_lung_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_07_lung"
     lung_coefficients_file = (
         tutorial_07_lung_dir / "tutorial_07_lung_registered_coefficients.json"
     )
@@ -196,8 +198,7 @@ if __name__ == "__main__":
     # tutorial_02_duke_heart_distancemap_finetune_icon.py, used by the heart fit
     # below; optional, the stock uniGradICON weights are used without them.
     heart_icon_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_duke_heart_distancemap"
         / "icon_duke_heart_distancemap_model"
         / "checkpoints"
@@ -206,7 +207,7 @@ if __name__ == "__main__":
 
     # Needs about 43 GB free: a hundred frames of warped CT is 40 GB of it,
     # since resampling costs the compression the original scan had.
-    output_dir = tutorials_dir / "output" / "tutorial_13_heart_and_lung"
+    output_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_13_heart_and_lung"
 
     # ---- Parameters --------------------------------------------------------
     # Respiratory stages, the DIR-Lab T00..T90 phases the lung network was

--- a/tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
+++ b/tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
@@ -152,7 +152,6 @@ def _mean_of_measured(values: list[float]) -> float:
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_14_duke_heart_shape_parameter_sweep"
 
@@ -160,10 +159,14 @@ if __name__ == "__main__":
     case_id = DUKE_HEART.hold_out_case
 
     # Fitted SSM surface and PCA coefficients written by Tutorial 8 (Duke Heart).
-    case_dir = tutorials_dir / "output" / "tutorial_08_duke_heart" / case_id
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
+    case_dir = (
+        DUKE_HEART.output_directory(test_mode) / "tutorial_08_duke_heart" / case_id
+    )
     # Weights Tutorial 9 trained, and the checkpoint epoch to infer with; None
     # uses the final weights.
-    model_dir = DUKE_HEART.mgn_weights_dir
+    model_dir = DUKE_HEART.mgn_weights_directory(test_mode)
     epoch: Optional[int] = None
 
     # Gaussian sigma, in mm, that spreads the predicted surface displacements
@@ -174,13 +177,14 @@ if __name__ == "__main__":
     # and still below the thinnest wall of the heart.
     evaluation_spacing_mm = 1.0
 
-    output_dir = tutorials_dir / "output" / "tutorial_14_duke_heart" / case_id
+    output_dir = (
+        DUKE_HEART.output_directory(test_mode) / "tutorial_14_duke_heart" / case_id
+    )
     log_level = logging.INFO
 
     logging.basicConfig(level=log_level)
     logger = logging.getLogger(class_name)
 
-    test_mode = TestTools.running_as_test()
     labelmap_dir = DUKE_HEART.hold_out_directory(test_mode) / case_id
 
     # The sweep itself.  The first modes carry the most variance, so varying

--- a/tutorials/tutorial_14_lung_shape_parameter_sweep.py
+++ b/tutorials/tutorial_14_lung_shape_parameter_sweep.py
@@ -160,7 +160,6 @@ def _mean_of_measured(values: list[float]) -> float:
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_14_lung_shape_parameter_sweep"
 
@@ -171,10 +170,12 @@ if __name__ == "__main__":
     reference_phase = "T70"
 
     # Fitted SSM surface and PCA coefficients written by Tutorial 8 (lung).
-    case_dir = tutorials_dir / "output" / "tutorial_08_lung" / case_id
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
+    case_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_08_lung" / case_id
     # Weights Tutorial 9 trained, and the checkpoint epoch to infer with; None
     # uses the final weights.
-    model_dir = LUNG_CT_DIRLAB.mgn_weights_dir
+    model_dir = LUNG_CT_DIRLAB.mgn_weights_directory(test_mode)
     epoch: Optional[int] = None
 
     # Gaussian sigma, in mm, that spreads the predicted surface displacements
@@ -185,14 +186,15 @@ if __name__ == "__main__":
     # that a lobe boundary is not quantized away.
     evaluation_spacing_mm = 2.0
 
-    output_dir = tutorials_dir / "output" / "tutorial_14_lung" / case_id
+    output_dir = (
+        LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_14_lung" / case_id
+    )
     ground_truth_dir = output_dir / "ground_truth"
     log_level = logging.INFO
 
     logging.basicConfig(level=log_level)
     logger = logging.getLogger(class_name)
 
-    test_mode = TestTools.running_as_test()
     data_dir = LUNG_CT_DIRLAB.input_directory(test_mode)
 
     # The sweep itself.  The first modes carry the most variance, so varying

--- a/tutorials/tutorial_15_duke_heart_leave_one_out.py
+++ b/tutorials/tutorial_15_duke_heart_leave_one_out.py
@@ -388,7 +388,6 @@ def _plot_metrics_by_label(
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_15_duke_heart_leave_one_out"
 
@@ -421,7 +420,11 @@ if __name__ == "__main__":
     # reported, and still below the thinnest wall of the heart.
     evaluation_spacing_mm = 1.0
 
-    output_dir = tutorials_dir / "output" / "tutorial_15_duke_heart"
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
+    weights_dir = DUKE_HEART.weights_directory(test_mode)
+
+    output_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_15_duke_heart"
     shared_dir = output_dir / "shared"
     log_level = logging.INFO
 
@@ -433,7 +436,6 @@ if __name__ == "__main__":
     # process.
     context = distributed_context()
 
-    test_mode = TestTools.running_as_test()
     data_dir = DUKE_HEART.hold_out_directory(test_mode)
     tutorial_04_dir = DUKE_HEART.input_directory(test_mode)
     number_of_pca_components = DUKE_HEART.pca_components(test_mode)
@@ -453,8 +455,7 @@ if __name__ == "__main__":
     # tutorial_02_duke_heart_distancemap_finetune_icon.py, used both by the
     # labelmap-to-labelmap stage of the SSM fit and by the frame registrations.
     icon_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_duke_heart_distancemap"
         / "icon_duke_heart_distancemap_model"
         / "checkpoints"

--- a/tutorials/tutorial_15_lung_leave_one_out.py
+++ b/tutorials/tutorial_15_lung_leave_one_out.py
@@ -389,7 +389,6 @@ def _plot_metrics_by_label(
 if __name__ == "__main__":
     # Data directory specification
     repo_root = Path(__file__).resolve().parent.parent
-    tutorials_dir = Path(__file__).resolve().parent
 
     class_name = "tutorial_15_lung_leave_one_out"
 
@@ -422,7 +421,11 @@ if __name__ == "__main__":
     # that a lobe boundary is not quantized away.
     evaluation_spacing_mm = 2.0
 
-    output_dir = tutorials_dir / "output" / "tutorial_15_lung"
+    test_mode = TestTools.running_as_test()
+    # Keep a test run out of the directories a full run reads and writes.
+    weights_dir = LUNG_CT_DIRLAB.weights_directory(test_mode)
+
+    output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_15_lung"
     shared_dir = output_dir / "shared"
     log_level = logging.INFO
 
@@ -434,7 +437,6 @@ if __name__ == "__main__":
     # process.
     context = distributed_context()
 
-    test_mode = TestTools.running_as_test()
     data_dir = LUNG_CT_DIRLAB.input_directory(test_mode)
     number_of_pca_components = LUNG_CT_DIRLAB.pca_components(test_mode)
 
@@ -448,15 +450,14 @@ if __name__ == "__main__":
     # Tutorial 6 caches one segmentation per case beside its model, and
     # Tutorial 8 one set of phase transforms per case; both are reused when
     # present because neither depends on which case is held out.
-    tutorial_06_dir = LUNG_CT_DIRLAB.pca_json_file.parent
-    tutorial_08_dir = tutorials_dir / "output" / "tutorial_08_lung"
+    tutorial_06_dir = LUNG_CT_DIRLAB.pca_model_file(test_mode).parent
+    tutorial_08_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_08_lung"
 
     # Distance-map weights finetuned on DIR-Lab by
     # tutorial_02_lung_distancemap_finetune_icon.py, used by the
     # labelmap-to-labelmap stage of the SSM fit.
     icon_distancemap_weights_path = (
-        tutorials_dir
-        / "network_weights"
+        weights_dir
         / "icon_dirlab_4dct_distancemap"
         / "icon_dirlab_4dct_distancemap_model"
         / "checkpoints"

--- a/utils/setup_feature_worktree.py
+++ b/utils/setup_feature_worktree.py
@@ -16,6 +16,10 @@ Usage:
   py utils/setup_feature_worktree.py my-feature --base-branch main
   py utils/setup_feature_worktree.py my-feature --worktree-root C:/worktrees
   py utils/setup_feature_worktree.py my-feature --dependency-mode editable
+
+Dependency modes: 'requirements' reads requirements.txt, 'pyproject' does a bare
+'-e .', and 'editable' does a full '-e .[all]' (staging setuptools/wheel and CUDA
+torch first, since the cuda13 and physicsnemo extras need them preinstalled).
 """
 
 from __future__ import annotations
@@ -123,11 +127,12 @@ def require_no_active_venv() -> None:
         sys.exit(1)
 
 
-def check_prerequisites() -> tuple[str, str]:
+def check_prerequisites() -> str:
     """Check that git and py.exe are available on PATH and no venv is active.
 
     Returns:
-        Tuple of (git_path, py_path).
+        The resolved path to py.exe. git is only checked, not returned — git is
+        always invoked as a bare "git" so it resolves through PATH.
     """
     print("[*] Checking prerequisites...")
     require_no_active_venv()
@@ -135,7 +140,7 @@ def check_prerequisites() -> tuple[str, str]:
     py_path = require_tool("py")
     print(f"    git : {git_path}")
     print(f"    py  : {py_path}")
-    return git_path, py_path
+    return py_path
 
 
 # ---------------------------------------------------------------------------
@@ -307,14 +312,14 @@ def create_venv(worktree_path: Path, py_path: str) -> Path:
     return venv_dir
 
 
-def install_uv(venv_dir: Path) -> Path:
+def install_uv(venv_dir: Path) -> tuple[Path, Path]:
     """Install uv into the venv using pip.
 
     Args:
         venv_dir: Path to the venv directory.
 
     Returns:
-        Path to the uv.exe executable inside the venv.
+        Tuple of (uv_exe, venv_python) — both inside the venv.
     """
     venv_python = venv_dir / "Scripts" / "python.exe"
     uv_exe = venv_dir / "Scripts" / "uv.exe"
@@ -334,7 +339,7 @@ def install_uv(venv_dir: Path) -> Path:
         sys.exit(1)
 
     print("    Done.")
-    return uv_exe
+    return uv_exe, venv_python
 
 
 # ---------------------------------------------------------------------------
@@ -365,13 +370,21 @@ def detect_dependency_mode(worktree_path: Path) -> str:
 
 def install_dependencies(
     uv_exe: Path,
+    venv_python: Path,
     worktree_path: Path,
     mode: str,
 ) -> None:
     """Install project dependencies using uv.
 
+    Every uv invocation passes ``--python venv_python`` explicitly. uv does not
+    infer the target environment from the uv.exe that runs it: it looks at
+    VIRTUAL_ENV, CONDA_PREFIX, then a directory named ``.venv``. The worktree venv
+    is named ``venv`` and ``require_no_active_venv`` guarantees VIRTUAL_ENV is
+    unset, so without ``--python`` uv aborts with "No virtual environment found".
+
     Args:
         uv_exe: Absolute path to the uv executable inside the venv.
+        venv_python: Absolute path to python.exe inside the venv.
         worktree_path: Root of the worktree (used as the working directory).
         mode: One of 'requirements', 'pyproject', 'editable', 'auto'.
 
@@ -384,13 +397,15 @@ def install_dependencies(
 
     print(f"[*] Installing dependencies (mode: {mode})...")
 
+    uv_pip_install = [str(uv_exe), "pip", "install", "--python", str(venv_python)]
+
     if mode == "requirements":
         req_file = worktree_path / "requirements.txt"
         if not req_file.exists():
             print(f"[ERROR] requirements.txt not found at: {req_file}")
             sys.exit(1)
         run(
-            [str(uv_exe), "pip", "install", "-r", str(req_file)],
+            uv_pip_install + ["-r", str(req_file)],
             cwd=worktree_path,
             description="uv pip install -r requirements.txt",
         )
@@ -400,8 +415,8 @@ def install_dependencies(
         # that the project uses uv's project workflow (uv sync). The most robust
         # fallback that works with any PEP 517 build backend is an editable install,
         # which reads [project.dependencies] from pyproject.toml and installs them.
-        # If the caller truly wants a non-editable install, they should use
-        # --dependency-mode editable and adjust afterwards.
+        # If the caller wants the project's optional extras as well, they should
+        # use --dependency-mode editable.
         pyproject_file = worktree_path / "pyproject.toml"
         if not pyproject_file.exists():
             print(f"[ERROR] pyproject.toml not found at: {pyproject_file}")
@@ -410,16 +425,43 @@ def install_dependencies(
             "    (pyproject mode: using editable install to read [project.dependencies])"
         )
         run(
-            [str(uv_exe), "pip", "install", "-e", "."],
+            uv_pip_install + ["-e", "."],
             cwd=worktree_path,
             description="uv pip install -e . (pyproject)",
         )
 
     elif mode == "editable":
+        # ".[all]" pulls in [cuda13] and [physicsnemo], which per the comment above
+        # the "all" extra in pyproject.toml require torch and setuptools to already
+        # be installed, plus --no-build-isolation when torch-scatter has no matching
+        # wheel. A brand-new venv has neither, so stage the prerequisites first.
+        # This mirrors .github/workflows/nightly-health.yml.
+        print("    Installing build prerequisites (setuptools, wheel)...")
         run(
-            [str(uv_exe), "pip", "install", "-e", "."],
+            uv_pip_install + ["setuptools", "wheel"],
             cwd=worktree_path,
-            description="uv pip install -e .",
+            description="uv pip install setuptools wheel",
+        )
+        print("    Installing torch from the CUDA 13.0 index.")
+        print("    This downloads several GB and can take many minutes.")
+        run(
+            uv_pip_install
+            + [
+                "torch",
+                "torchvision",
+                "torchaudio",
+                "--index-url",
+                "https://download.pytorch.org/whl/cu130",
+            ],
+            cwd=worktree_path,
+            description="uv pip install torch (cu130)",
+        )
+        print("    Installing the project with all extras...")
+        run(
+            uv_pip_install
+            + ["-e", ".[all]", "--no-build-isolation-package", "torch-scatter"],
+            cwd=worktree_path,
+            description="uv pip install -e .[all]",
         )
 
     else:
@@ -511,8 +553,9 @@ Examples:
             "How to install dependencies. "
             "auto (default): detect from project files. "
             "requirements: use requirements.txt. "
-            "pyproject: use pyproject.toml (via editable install). "
-            "editable: pip install -e ."
+            "pyproject: use pyproject.toml (via a bare editable install). "
+            'editable: editable install with all extras ("-e .[all]", '
+            "staging setuptools/wheel and CUDA torch first; downloads several GB)."
         ),
     )
 
@@ -529,7 +572,7 @@ def main() -> None:
     args = parse_args()
 
     # --- Prerequisites ---
-    git_path, py_path = check_prerequisites()
+    py_path = check_prerequisites()
 
     # --- Resolve repository root ---
     repo_root = get_repo_root()
@@ -568,10 +611,10 @@ def main() -> None:
     venv_dir = create_venv(worktree_path, py_path)
 
     # --- Install uv ---
-    uv_exe = install_uv(venv_dir)
+    uv_exe, venv_python = install_uv(venv_dir)
 
     # --- Install dependencies ---
-    install_dependencies(uv_exe, worktree_path, args.dependency_mode)
+    install_dependencies(uv_exe, venv_python, worktree_path, args.dependency_mode)
 
     # --- Summary ---
     print_summary(branch_name, worktree_path, venv_dir)


### PR DESCRIPTION
These directories now consume tens of gigabytes.   These changes
allow the source and data directories to be separate.

Also allows testing to wipe the source directory without having to re-download data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tutorial data, outputs, and model weights can now be redirected through environment settings.
  * Test runs use isolated directories and support configurable tutorial datasets.
  * Tutorial validation now includes metric comparisons alongside screenshot checks.

* **Bug Fixes**
  * Improved detection of test timeouts, hangs, and unsuccessful nightly runs.

* **Documentation**
  * Updated supported Python versions to 3.11–3.13.
  * Added guidance for relocating tutorial and test data.

* **Tests**
  * Added coverage for configurable paths, cached datasets, and baseline metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->