### PR TITLE
ENH: Enable reconstruction using Mean/Max over time

### DIFF
--- a/docs/cli_scripts/4dct_reconstruction.rst
+++ b/docs/cli_scripts/4dct_reconstruction.rst
@@ -52,6 +52,23 @@ Registration Options
        --prior-weight 0.5 \
        --output-dir ./results
 
+Composite Mode
+===============
+
+By default, the high-resolution reference image is warped back to each time
+point. ``--composite-mode mean`` or ``--composite-mode max`` instead build a
+pixel-by-pixel mean or max composite of the reference image and every
+registered time-series image first, then warp that composite back to each
+time point — useful when anatomy or contrast is only visible in some frames.
+
+.. code-block:: bash
+
+   physiotwin4d-reconstruct-highres-4d-ct \
+       --time-series-images frame_*.mha \
+       --fixed-image highres_reference.mha \
+       --composite-mode mean \
+       --output-dir ./results
+
 Outputs
 =======
 

--- a/src/physiotwin4d/cli/reconstruct_highres_4d_ct.py
+++ b/src/physiotwin4d/cli/reconstruct_highres_4d_ct.py
@@ -62,6 +62,13 @@ Examples:
     --registration-method ICON \\
     --ICON-iterations 50 \\
     --output-dir ./results
+
+  # Reconstruction using a mean composite instead of the reference image
+  %(prog)s \\
+    --time-series-images frame_*.mha \\
+    --fixed-image highres.mha \\
+    --composite-mode mean \\
+    --output-dir ./results
         """,
     )
 
@@ -139,6 +146,19 @@ Examples:
         "--modality",
         default="ct",
         help="Imaging modality for registration optimization (default: ct)",
+    )
+
+    # Reconstruction options
+    parser.add_argument(
+        "--composite-mode",
+        choices=["reference", "mean", "max"],
+        default="reference",
+        help=(
+            "Image warped back to each time point: 'reference' uses the "
+            "fixed image as-is (default); 'mean'/'max' first build a "
+            "pixel-by-pixel mean/max composite of the fixed image and all "
+            "registered time-series images"
+        ),
     )
 
     # Output options
@@ -302,6 +322,7 @@ Examples:
         print("\nStarting reconstruction pipeline...")
         print("=" * 70)
         workflow.set_upsample_to_fixed_resolution(True)
+        workflow.set_composite_mode(args.composite_mode)
         result = workflow.process()
 
         # Save results

--- a/src/physiotwin4d/register_time_series_images.py
+++ b/src/physiotwin4d/register_time_series_images.py
@@ -395,7 +395,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         if composite_mode == "reference":
             source_image = self.fixed_image
-        else:
+        elif composite_mode in ("mean", "max"):
             if forward_transforms is None or len(forward_transforms) != len(
                 moving_images
             ):
@@ -406,6 +406,11 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 )
             source_image = self._compute_composite_reference(
                 moving_images, forward_transforms, composite_mode
+            )
+        else:
+            raise ValueError(
+                "composite_mode must be 'reference', 'mean', or 'max', "
+                f"got {composite_mode!r}"
             )
 
         reconstructed_images: list[itk.Image] = []
@@ -418,7 +423,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                     moving_image, self.fixed_image
                 )
             else:
-                # Use fixed image as reference
+                # Use the moving image's own grid as the output space
                 reference_image = moving_image
 
             # Transform the source image to the reference space.  The source
@@ -456,7 +461,14 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             itk.Image: Composite image on the fixed image's grid
         """
         assert self.fixed_image is not None
-        arrays = [itk.array_from_image(self.fixed_image)]
+        fixed_arr = itk.array_from_image(self.fixed_image)
+        dtype = fixed_arr.dtype
+
+        if mode == "mean":
+            accumulator = fixed_arr.astype(np.float64)
+        else:
+            accumulator = fixed_arr.copy()
+
         for moving_image, forward_transform in zip(moving_images, forward_transforms):
             registered = self.transform_tools.transform_image(
                 moving_image,
@@ -464,13 +476,15 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 self.fixed_image,
                 background_value=self._prewarp_background_value(moving_image),
             )
-            arrays.append(itk.array_from_image(registered))
+            registered_arr = itk.array_from_image(registered)
+            if mode == "mean":
+                accumulator += registered_arr
+            else:
+                np.maximum(accumulator, registered_arr, out=accumulator)
 
-        stacked = np.stack(arrays, axis=0)
-        reduced = (
-            np.mean(stacked, axis=0) if mode == "mean" else np.max(stacked, axis=0)
-        )
-        reduced = reduced.astype(arrays[0].dtype)
+        if mode == "mean":
+            accumulator /= len(moving_images) + 1
+        reduced = accumulator.astype(dtype)
 
         composite = itk.image_from_array(np.ascontiguousarray(reduced))
         composite.CopyInformation(self.fixed_image)

--- a/src/physiotwin4d/register_time_series_images.py
+++ b/src/physiotwin4d/register_time_series_images.py
@@ -469,14 +469,15 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         fixed_arr = itk.GetArrayViewFromImage(self.fixed_image)
         dtype = fixed_arr.dtype
 
+        # float32 keeps peak memory bounded for large volumes; only widen to
+        # float64 when the source data already needs it. A float accumulator
+        # (rather than the fixed image's own dtype) also keeps np.maximum
+        # from raising when a moving image's pixel type is floating point
+        # but the fixed image's is integer.
+        accumulator_dtype = np.float64 if dtype == np.float64 else np.float32
+        accumulator = fixed_arr.astype(accumulator_dtype)
         if mode == "mean":
-            # float32 keeps peak memory bounded for large volumes; only
-            # widen to float64 when the source data already needs it.
-            accumulator_dtype = np.float64 if dtype == np.float64 else np.float32
-            accumulator = fixed_arr.astype(accumulator_dtype)
             valid_count = np.ones_like(accumulator)
-        else:
-            accumulator = fixed_arr.copy()
 
         for moving_image, forward_transform in zip(moving_images, forward_transforms):
             registered = self.transform_tools.transform_image(
@@ -487,9 +488,8 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             )
             registered_arr = itk.GetArrayViewFromImage(registered)
 
-            coverage_image = itk.image_from_array(
-                np.ones(itk.GetArrayViewFromImage(moving_image).shape, dtype=np.uint8)
-            )
+            moving_shape = itk.GetArrayViewFromImage(moving_image).shape
+            coverage_image = itk.image_from_array(np.ones(moving_shape, dtype=np.uint8))
             coverage_image.CopyInformation(moving_image)
             registered_coverage = self.transform_tools.transform_image(
                 coverage_image,

--- a/src/physiotwin4d/register_time_series_images.py
+++ b/src/physiotwin4d/register_time_series_images.py
@@ -11,9 +11,10 @@ CT where sequential frames need to be registered to a common frame.
 """
 
 import logging
-from typing import Optional, Union, cast
+from typing import Literal, Optional, Union, cast
 
 import itk
+import numpy as np
 
 from .register_images_base import RegisterImagesBase
 from .register_images_greedy import RegisterImagesGreedy
@@ -320,6 +321,8 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         moving_images: list[itk.Image],
         inverse_transforms: list[itk.Transform],
         upsample_to_fixed_resolution: bool = False,
+        forward_transforms: Optional[list[itk.Transform]] = None,
+        composite_mode: Literal["reference", "mean", "max"] = "reference",
     ) -> list[itk.Image]:
         """Reconstruct time series images using inverse transforms.
 
@@ -327,6 +330,14 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         in the fixed image space. If upsample_to_fixed_resolution is enabled,
         the reconstructed images will use isotropic spacing (mean of fixed image's
         X and Y spacing) while maintaining each moving image's original origin and direction.
+
+        By default (composite_mode="reference"), the fixed/reference image is
+        warped back to each time point. When composite_mode is "mean" or
+        "max", a single composite image is built first -- the pixel-by-pixel
+        mean or max across the fixed image and every moving image warped onto
+        the fixed grid via forward_transforms -- and that composite is warped
+        back to each time point instead. This lets anatomy or contrast only
+        visible in some frames propagate into every reconstructed time point.
 
         Args:
             moving_images (list[itk.Image]): List of moving images to reconstruct
@@ -337,6 +348,14 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 images will be upsampled to isotropic resolution (mean of fixed image's
                 X and Y spacing) while maintaining their original origin and direction.
                 Default: False
+            forward_transforms (list[itk.Transform], optional): List of forward
+                transforms (one per moving image), each used to warp that moving
+                image onto the fixed grid. Required when composite_mode is
+                "mean" or "max". Default: None
+            composite_mode (Literal["reference", "mean", "max"], optional):
+                Which image to warp back to each time point. "reference" uses
+                the fixed image as-is (default). "mean"/"max" build a composite
+                of the fixed image and all registered moving images first.
 
         Returns:
             list[itk.Image]: List of reconstructed images in fixed image space
@@ -344,6 +363,8 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         Raises:
             ValueError: If fixed_image is not set
             ValueError: If lengths of moving_images and inverse_transforms don't match
+            ValueError: If composite_mode is "mean"/"max" and forward_transforms
+                is not provided or its length doesn't match moving_images
 
         Example:
             >>> greedy = RegisterImagesGreedy()
@@ -372,6 +393,21 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 f"number of inverse transforms ({len(inverse_transforms)})"
             )
 
+        if composite_mode == "reference":
+            source_image = self.fixed_image
+        else:
+            if forward_transforms is None or len(forward_transforms) != len(
+                moving_images
+            ):
+                raise ValueError(
+                    "forward_transforms must be provided and match "
+                    "moving_images length when composite_mode is "
+                    f"{composite_mode!r}"
+                )
+            source_image = self._compute_composite_reference(
+                moving_images, forward_transforms, composite_mode
+            )
+
         reconstructed_images: list[itk.Image] = []
 
         for moving_image, inverse_transform in zip(moving_images, inverse_transforms):
@@ -385,18 +421,60 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 # Use fixed image as reference
                 reference_image = moving_image
 
-            # Transform the moving image to the reference space.  The fixed
+            # Transform the source image to the reference space.  The source
             # image is an intensity image, so voxels sampled outside it take the
             # modality's "no tissue" value, not 0.
             reconstructed = self.transform_tools.transform_image(
-                self.fixed_image,
+                source_image,
                 inverse_transform,
                 reference_image,
-                background_value=self._prewarp_background_value(self.fixed_image),
+                background_value=self._prewarp_background_value(source_image),
             )
             reconstructed_images.append(reconstructed)
 
         return reconstructed_images
+
+    def _compute_composite_reference(
+        self,
+        moving_images: list[itk.Image],
+        forward_transforms: list[itk.Transform],
+        mode: Literal["mean", "max"],
+    ) -> itk.Image:
+        """Build a composite reference image from the fixed image and moving images.
+
+        Warps every moving image onto the fixed grid using its
+        forward_transform, then combines those registered images with the
+        fixed image pixel-by-pixel using the given reduction.
+
+        Args:
+            moving_images (list[itk.Image]): Moving images to warp and combine
+            forward_transforms (list[itk.Transform]): One forward transform per
+                moving image, warping it onto the fixed grid
+            mode (Literal["mean", "max"]): Pixel-wise reduction to apply
+
+        Returns:
+            itk.Image: Composite image on the fixed image's grid
+        """
+        assert self.fixed_image is not None
+        arrays = [itk.array_from_image(self.fixed_image)]
+        for moving_image, forward_transform in zip(moving_images, forward_transforms):
+            registered = self.transform_tools.transform_image(
+                moving_image,
+                forward_transform,
+                self.fixed_image,
+                background_value=self._prewarp_background_value(moving_image),
+            )
+            arrays.append(itk.array_from_image(registered))
+
+        stacked = np.stack(arrays, axis=0)
+        reduced = (
+            np.mean(stacked, axis=0) if mode == "mean" else np.max(stacked, axis=0)
+        )
+        reduced = reduced.astype(arrays[0].dtype)
+
+        composite = itk.image_from_array(np.ascontiguousarray(reduced))
+        composite.CopyInformation(self.fixed_image)
+        return composite
 
     def _create_upsampled_reference(
         self, moving_image: itk.Image, fixed_image: itk.Image

--- a/src/physiotwin4d/register_time_series_images.py
+++ b/src/physiotwin4d/register_time_series_images.py
@@ -449,7 +449,12 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         Warps every moving image onto the fixed grid using its
         forward_transform, then combines those registered images with the
-        fixed image pixel-by-pixel using the given reduction.
+        fixed image pixel-by-pixel using the given reduction. Moving images
+        whose extent does not fully cover the fixed grid contribute only
+        where they actually have data -- voxels resampled from outside a
+        moving image's bounds (extrapolated fill) are excluded from the
+        reduction rather than treated as real samples. The fixed image
+        counts as one valid sample at every voxel.
 
         Args:
             moving_images (list[itk.Image]): Moving images to warp and combine
@@ -461,11 +466,15 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             itk.Image: Composite image on the fixed image's grid
         """
         assert self.fixed_image is not None
-        fixed_arr = itk.array_from_image(self.fixed_image)
+        fixed_arr = itk.GetArrayViewFromImage(self.fixed_image)
         dtype = fixed_arr.dtype
 
         if mode == "mean":
-            accumulator = fixed_arr.astype(np.float64)
+            # float32 keeps peak memory bounded for large volumes; only
+            # widen to float64 when the source data already needs it.
+            accumulator_dtype = np.float64 if dtype == np.float64 else np.float32
+            accumulator = fixed_arr.astype(accumulator_dtype)
+            valid_count = np.ones_like(accumulator)
         else:
             accumulator = fixed_arr.copy()
 
@@ -476,14 +485,30 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 self.fixed_image,
                 background_value=self._prewarp_background_value(moving_image),
             )
-            registered_arr = itk.array_from_image(registered)
+            registered_arr = itk.GetArrayViewFromImage(registered)
+
+            coverage_image = itk.image_from_array(
+                np.ones(itk.GetArrayViewFromImage(moving_image).shape, dtype=np.uint8)
+            )
+            coverage_image.CopyInformation(moving_image)
+            registered_coverage = self.transform_tools.transform_image(
+                coverage_image,
+                forward_transform,
+                self.fixed_image,
+                interpolation_method="nearest",
+                background_value=0,
+            )
+            valid_mask = itk.GetArrayViewFromImage(registered_coverage) != 0
+
             if mode == "mean":
-                accumulator += registered_arr
+                accumulator += np.where(valid_mask, registered_arr, 0)
+                valid_count += valid_mask
             else:
-                np.maximum(accumulator, registered_arr, out=accumulator)
+                masked = np.where(valid_mask, registered_arr, accumulator)
+                np.maximum(accumulator, masked, out=accumulator)
 
         if mode == "mean":
-            accumulator /= len(moving_images) + 1
+            accumulator /= valid_count
         reduced = accumulator.astype(dtype)
 
         composite = itk.image_from_array(np.ascontiguousarray(reduced))

--- a/src/physiotwin4d/register_time_series_images.py
+++ b/src/physiotwin4d/register_time_series_images.py
@@ -509,6 +509,8 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         if mode == "mean":
             accumulator /= valid_count
+            if np.issubdtype(dtype, np.integer):
+                accumulator = np.round(accumulator)
         reduced = accumulator.astype(dtype)
 
         composite = itk.image_from_array(np.ascontiguousarray(reduced))

--- a/src/physiotwin4d/workflow_reconstruct_highres_4d_ct.py
+++ b/src/physiotwin4d/workflow_reconstruct_highres_4d_ct.py
@@ -24,7 +24,7 @@ Key Features:
 """
 
 import logging
-from typing import Optional
+from typing import Literal, Optional
 
 import itk
 
@@ -64,6 +64,10 @@ class WorkflowReconstructHighres4DCT(PhysioTwin4DBase):
         register_reference_time_frame_to_reference_image (bool): Whether to register
             the reference time frame to the reference image
         upsample_to_fixed_resolution (bool): Whether to upsample reconstruction
+        composite_mode (Literal["reference", "mean", "max"]): Which image is
+            warped back to each time point during reconstruction: the
+            reference image as-is, or a pixel-by-pixel mean/max composite of
+            the reference image and all registered time-series images
         registrar (RegisterTimeSeriesImages): Internal registration object
         forward_transforms (list[itk.Transform]): one per frame; each warps its
             moving image onto the reference grid
@@ -151,6 +155,7 @@ class WorkflowReconstructHighres4DCT(PhysioTwin4DBase):
 
         # Initialize parameters with defaults
         self.upsample_to_fixed_resolution: bool = True
+        self.composite_mode: Literal["reference", "mean", "max"] = "reference"
         self.modality: str = "ct"
         self.mask_dilation_mm: float = 0.0
         self.fixed_mask: Optional[itk.Image] = None
@@ -285,6 +290,30 @@ class WorkflowReconstructHighres4DCT(PhysioTwin4DBase):
         """
         self.upsample_to_fixed_resolution = upsample_to_fixed_resolution
 
+    def set_composite_mode(
+        self, composite_mode: Literal["reference", "mean", "max"]
+    ) -> None:
+        """Set which image is warped back to each time point during reconstruction.
+
+        Args:
+            composite_mode (Literal["reference", "mean", "max"]): "reference"
+                warps the reference image back to each time point (default).
+                "mean"/"max" first build a composite of the reference image
+                and every registered time-series image (pixel-by-pixel mean
+                or max on the reference grid), then warp that composite back
+                to each time point instead.
+
+        Raises:
+            ValueError: If composite_mode is not one of "reference", "mean",
+                or "max"
+        """
+        if composite_mode not in ("reference", "mean", "max"):
+            raise ValueError(
+                f"composite_mode must be 'reference', 'mean', or 'max', "
+                f"got {composite_mode!r}"
+            )
+        self.composite_mode = composite_mode
+
     def reconstruct_time_series(self) -> dict:
         """Reconstruct high-resolution time series using inverse transforms.
 
@@ -312,12 +341,15 @@ class WorkflowReconstructHighres4DCT(PhysioTwin4DBase):
         self.log_info(
             f"Upsampling to fixed resolution: {self.upsample_to_fixed_resolution}"
         )
+        self.log_info(f"Composite mode: {self.composite_mode}")
 
         # Reconstruct time series
         self.reconstructed_images = self.registrar.reconstruct_time_series(
             moving_images=self.time_series_images,
             inverse_transforms=self.inverse_transforms,
             upsample_to_fixed_resolution=self.upsample_to_fixed_resolution,
+            forward_transforms=self.forward_transforms,
+            composite_mode=self.composite_mode,
         )
 
         self.log_info("Stage 2 complete: Time series reconstruction finished.")

--- a/tests/test_register_time_series_images.py
+++ b/tests/test_register_time_series_images.py
@@ -510,9 +510,9 @@ class TestRegisterTimeSeriesImages:
         print(f"  All {len(forward_transforms)} transforms generated")
 
 
-def _make_constant_image(value: float, size: int = 4) -> Any:
-    """Build a tiny constant-valued float image for composite-mode tests."""
-    arr = np.full((size, size, size), value, dtype=np.float32)
+def _make_constant_image(value: float, size: int = 4, dtype: Any = np.float32) -> Any:
+    """Build a tiny constant-valued image for composite-mode tests."""
+    arr = np.full((size, size, size), value, dtype=dtype)
     image = itk.image_from_array(arr)
     return image
 
@@ -613,6 +613,25 @@ class TestReconstructTimeSeriesCompositeMode:
             "uncovered voxels should keep the fixed image's value, not "
             "extrapolated background fill"
         )
+
+    def test_composite_mode_mean_integer_dtype_rounds(self) -> None:
+        """Integer pixel types round to nearest, not truncate toward zero."""
+        fixed_image = _make_constant_image(-1000, dtype=np.int16)
+        moving_image = _make_constant_image(-1007, dtype=np.int16)
+
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
+        registrar.set_fixed_image(fixed_image)
+
+        composite = registrar._compute_composite_reference(
+            moving_images=[moving_image],
+            forward_transforms=self._identity_transforms(1),
+            mode="mean",
+        )
+        arr = itk.array_from_image(composite)
+
+        # True mean is -1003.5; rounding gives -1004, truncation toward zero
+        # (plain astype) would wrongly give -1003.
+        assert np.all(arr == -1004), f"expected rounded mean -1004, got {arr.flat[0]}"
 
     def test_composite_mode_invalid_value(self) -> None:
         """An unrecognized composite_mode raises ValueError instead of

--- a/tests/test_register_time_series_images.py
+++ b/tests/test_register_time_series_images.py
@@ -510,5 +510,95 @@ class TestRegisterTimeSeriesImages:
         print(f"  All {len(forward_transforms)} transforms generated")
 
 
+def _make_constant_image(value: float, size: int = 4) -> Any:
+    """Build a tiny constant-valued float image for composite-mode tests."""
+    arr = np.full((size, size, size), value, dtype=np.float32)
+    image = itk.image_from_array(arr)
+    return image
+
+
+class TestReconstructTimeSeriesCompositeMode:
+    """Test suite for the composite_mode option of reconstruct_time_series."""
+
+    def _identity_transforms(self, n: int) -> list[Any]:
+        return [itk.IdentityTransform[itk.D, 3].New() for _ in range(n)]
+
+    def test_composite_mode_reference_matches_default(self) -> None:
+        """composite_mode='reference' warps the fixed image back, unchanged."""
+        fixed_image = _make_constant_image(10.0)
+        moving_images = [_make_constant_image(20.0), _make_constant_image(30.0)]
+
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
+        registrar.set_fixed_image(fixed_image)
+
+        reconstructed = registrar.reconstruct_time_series(
+            moving_images=moving_images,
+            inverse_transforms=self._identity_transforms(len(moving_images)),
+            composite_mode="reference",
+        )
+
+        for img in reconstructed:
+            arr = itk.array_from_image(img)
+            assert np.allclose(arr, 10.0), (
+                "reference mode should warp fixed image as-is"
+            )
+
+    def test_composite_mode_mean(self) -> None:
+        """composite_mode='mean' warps back the mean of fixed + registered images."""
+        fixed_image = _make_constant_image(10.0)
+        moving_images = [_make_constant_image(20.0), _make_constant_image(30.0)]
+        n = len(moving_images)
+
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
+        registrar.set_fixed_image(fixed_image)
+
+        reconstructed = registrar.reconstruct_time_series(
+            moving_images=moving_images,
+            inverse_transforms=self._identity_transforms(n),
+            forward_transforms=self._identity_transforms(n),
+            composite_mode="mean",
+        )
+
+        expected_mean = (10.0 + 20.0 + 30.0) / 3.0
+        for img in reconstructed:
+            arr = itk.array_from_image(img)
+            assert np.allclose(arr, expected_mean), "mean composite value mismatch"
+
+    def test_composite_mode_max(self) -> None:
+        """composite_mode='max' warps back the max of fixed + registered images."""
+        fixed_image = _make_constant_image(10.0)
+        moving_images = [_make_constant_image(20.0), _make_constant_image(5.0)]
+        n = len(moving_images)
+
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
+        registrar.set_fixed_image(fixed_image)
+
+        reconstructed = registrar.reconstruct_time_series(
+            moving_images=moving_images,
+            inverse_transforms=self._identity_transforms(n),
+            forward_transforms=self._identity_transforms(n),
+            composite_mode="max",
+        )
+
+        for img in reconstructed:
+            arr = itk.array_from_image(img)
+            assert np.allclose(arr, 20.0), "max composite value mismatch"
+
+    def test_composite_mode_requires_forward_transforms(self) -> None:
+        """mean/max composite_mode without forward_transforms raises ValueError."""
+        fixed_image = _make_constant_image(10.0)
+        moving_images = [_make_constant_image(20.0)]
+
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
+        registrar.set_fixed_image(fixed_image)
+
+        with pytest.raises(ValueError, match="forward_transforms"):
+            registrar.reconstruct_time_series(
+                moving_images=moving_images,
+                inverse_transforms=self._identity_transforms(1),
+                composite_mode="mean",
+            )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/test_register_time_series_images.py
+++ b/tests/test_register_time_series_images.py
@@ -584,6 +584,53 @@ class TestReconstructTimeSeriesCompositeMode:
             arr = itk.array_from_image(img)
             assert np.allclose(arr, 20.0), "max composite value mismatch"
 
+    def test_composite_mode_mean_mismatched_extents(self) -> None:
+        """Voxels outside a smaller moving image's extent are excluded from
+        the mean rather than diluted by extrapolated background fill."""
+        fixed_size = 6
+        moving_size = 4
+        fixed_image = _make_constant_image(10.0, size=fixed_size)
+        moving_image = _make_constant_image(20.0, size=moving_size)
+
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
+        registrar.set_fixed_image(fixed_image)
+
+        composite = registrar._compute_composite_reference(
+            moving_images=[moving_image],
+            forward_transforms=self._identity_transforms(1),
+            mode="mean",
+        )
+        arr = itk.array_from_image(composite)
+
+        # Voxels covered by the smaller moving image average fixed + moving.
+        covered = arr[:moving_size, :moving_size, :moving_size]
+        assert np.allclose(covered, 15.0), "covered voxels should average to 15"
+
+        # Voxels outside the moving image's extent must not be pulled toward
+        # the -1000 HU "no tissue" fill value used for extrapolated regions.
+        uncovered = arr[moving_size:, :, :]
+        assert np.allclose(uncovered, 10.0), (
+            "uncovered voxels should keep the fixed image's value, not "
+            "extrapolated background fill"
+        )
+
+    def test_composite_mode_invalid_value(self) -> None:
+        """An unrecognized composite_mode raises ValueError instead of
+        silently falling back to mean/max behavior."""
+        fixed_image = _make_constant_image(10.0)
+        moving_images = [_make_constant_image(20.0)]
+
+        registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
+        registrar.set_fixed_image(fixed_image)
+
+        with pytest.raises(ValueError, match="composite_mode"):
+            registrar.reconstruct_time_series(
+                moving_images=moving_images,
+                inverse_transforms=self._identity_transforms(1),
+                forward_transforms=self._identity_transforms(1),
+                composite_mode="bogus",  # type: ignore[arg-type]
+            )
+
     def test_composite_mode_requires_forward_transforms(self) -> None:
         """mean/max composite_mode without forward_transforms raises ValueError."""
         fixed_image = _make_constant_image(10.0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added composite reconstruction modes for 4D CT: reference, mean, and maximum.
  - Mean and maximum modes combine the reference and registered time-series images before reconstructing each time point.
  - Added a command-line option and usage guidance for selecting the composite mode.

- **Documentation**
  - Documented composite mode behavior and provided an example using mean composition.

- **Tests**
  - Added coverage for reference, mean, and maximum modes, including required transform validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->