### PR TITLE
ENH: Verify tetmesh quality after fit to patient

### DIFF
--- a/src/monai_physio/contour_tools.py
+++ b/src/monai_physio/contour_tools.py
@@ -755,6 +755,83 @@ class ContourTools(MONAIPhysioBase):
             points = np.array(relaxed.points)
         return relaxed
 
+    def repair_inverted_tetrahedra(
+        self,
+        tetrahedra: pv.UnstructuredGrid,
+        max_iterations: int = 20,
+    ) -> pv.UnstructuredGrid:
+        """Relax the nodes of any inverted or degenerate tetrahedron.
+
+        :meth:`trim_tetrahedra_to_surface` holds every cell of the *template*
+        above a scaled Jacobian of 0.1, but warping that template onto a
+        specific subject -- a statistical-model fit, say -- carries no such
+        constraint, and can flip a handful of elements even though the
+        template it started from was clean. Only the nodes touching a bad
+        element are moved, each to the mean of its mesh neighbors, which
+        leaves geometry the fit got right alone.
+
+        Args:
+            tetrahedra: Volume mesh to repair; its cell and field data
+                survive.
+            max_iterations: Smoothing passes to attempt before giving up.
+
+        Returns:
+            The repaired mesh, or *tetrahedra* unchanged if every cell
+            already clears zero volume.
+
+        Raises:
+            ValueError: If elements are still inverted or degenerate after
+                *max_iterations* passes.
+        """
+        connectivity = tetrahedra.cells_dict[np.uint8(pv.CellType.TETRA)]
+
+        def volumes(points: np.ndarray) -> np.ndarray:
+            corners = points[connectivity]
+            edges = corners[:, 1:, :] - corners[:, 0:1, :]
+            return cast(np.ndarray, np.linalg.det(edges) / 6.0)
+
+        points = np.array(tetrahedra.points)
+        n_inverted = int(np.sum(volumes(points) <= 0.0))
+        if n_inverted == 0:
+            return tetrahedra
+
+        edges = np.vstack(
+            [
+                connectivity[:, pair]
+                for pair in ((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3))
+            ]
+        )
+        starts = np.concatenate([edges[:, 0], edges[:, 1]])
+        ends = np.concatenate([edges[:, 1], edges[:, 0]])
+
+        for _ in range(max_iterations):
+            bad = volumes(points) <= 0.0
+            if not np.any(bad):
+                break
+            for node in np.unique(connectivity[bad]):
+                neighbor_points = points[ends[starts == node]]
+                if len(neighbor_points):
+                    points[node] = neighbor_points.mean(axis=0)
+
+        still_bad = int(np.sum(volumes(points) <= 0.0))
+        if still_bad:
+            raise ValueError(
+                f"{still_bad} of {len(connectivity)} tetrahedra are still "
+                f"inverted or degenerate after {max_iterations} repair "
+                "passes; the fitted mesh needs a real re-fit, not just "
+                "smoothing."
+            )
+
+        self.log_warning(
+            "%d of %d tetrahedra were inverted or degenerate; repaired by "
+            "relaxing their nodes onto their neighbors' mean.",
+            n_inverted,
+            len(connectivity),
+        )
+        repaired = tetrahedra.copy()
+        repaired.points = points
+        return repaired
+
     def remesh_and_smooth_surface(
         self,
         surface: pv.PolyData,

--- a/src/monai_physio/contour_tools.py
+++ b/src/monai_physio/contour_tools.py
@@ -780,9 +780,15 @@ class ContourTools(MONAIPhysioBase):
             already clears zero volume.
 
         Raises:
-            ValueError: If elements are still inverted or degenerate after
-                *max_iterations* passes.
+            ValueError: If *tetrahedra* has no TETRA cells, or if elements
+                are still inverted or degenerate after *max_iterations*
+                passes.
         """
+        if np.uint8(pv.CellType.TETRA) not in tetrahedra.cells_dict:
+            raise ValueError(
+                "tetrahedra has no TETRA cells to repair; got cell types "
+                f"{sorted(tetrahedra.cells_dict)}."
+            )
         connectivity = tetrahedra.cells_dict[np.uint8(pv.CellType.TETRA)]
 
         def volumes(points: np.ndarray) -> np.ndarray:
@@ -803,13 +809,22 @@ class ContourTools(MONAIPhysioBase):
         )
         starts = np.concatenate([edges[:, 0], edges[:, 1]])
         ends = np.concatenate([edges[:, 1], edges[:, 0]])
+        order = np.argsort(starts, kind="stable")
+        sorted_starts = starts[order]
+        sorted_ends = ends[order]
+        split_points = np.searchsorted(sorted_starts, np.arange(len(points) + 1))
+        neighbors = {
+            node: np.unique(sorted_ends[split_points[node] : split_points[node + 1]])
+            for node in np.unique(connectivity)
+        }
 
         for _ in range(max_iterations):
             bad = volumes(points) <= 0.0
             if not np.any(bad):
                 break
+            snapshot = points.copy()
             for node in np.unique(connectivity[bad]):
-                neighbor_points = points[ends[starts == node]]
+                neighbor_points = snapshot[neighbors[node]]
                 if len(neighbor_points):
                     points[node] = neighbor_points.mean(axis=0)
 

--- a/src/monai_physio/train_physicsnemo_physics_informed_motion.py
+++ b/src/monai_physio/train_physicsnemo_physics_informed_motion.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 import numpy as np
 import pyvista as pv
 
+from .contour_tools import ContourTools
 from .physicsnemo_tools import DistributedContext, PhaseSampleDataset
 from .monai_physio_base import MONAIPhysioBase
 from .train_physicsnemo_mgn import TrainPhysicsNeMoMGN
@@ -637,14 +638,22 @@ class TrainPhysicsNeMoPhysicsInformedMotion(TrainPhysicsNeMoMGN):
         assert self._tets is not None
         self._reference_cache = {}
         device = context.device
+        contour_tools = ContourTools(log_level=self.log_level)
         for subject_id in sorted(set(self._sample_subjects)):
-            mesh = pv.read(str(self._reference_meshes[subject_id]))
-            points = np.asarray(mesh.points, dtype=np.float64)
-            if len(points) != n_points:
+            mesh = cast(
+                "pv.UnstructuredGrid", pv.read(str(self._reference_meshes[subject_id]))
+            )
+            if len(mesh.points) != n_points:
                 raise ValueError(
-                    f"{self._reference_meshes[subject_id]} has {len(points)} "
+                    f"{self._reference_meshes[subject_id]} has {len(mesh.points)} "
                     f"points, but the template has {n_points}."
                 )
+            # A per-subject fit carries no cell-quality constraint, so it can
+            # flip a handful of elements even though the template did not;
+            # repair here rather than only at fit time so meshes fitted before
+            # this check existed still load.
+            mesh = contour_tools.repair_inverted_tetrahedra(mesh)
+            points = np.asarray(mesh.points, dtype=np.float64)
             _, nodal = tet_volumes(points, self._tets)
             reference = torch.from_numpy(points).to(device=device, dtype=torch.float32)
             volumes = torch.from_numpy(nodal).to(device=device, dtype=torch.float32)

--- a/src/monai_physio/train_physicsnemo_physics_informed_motion.py
+++ b/src/monai_physio/train_physicsnemo_physics_informed_motion.py
@@ -651,9 +651,14 @@ class TrainPhysicsNeMoPhysicsInformedMotion(TrainPhysicsNeMoMGN):
             # A per-subject fit carries no cell-quality constraint, so it can
             # flip a handful of elements even though the template did not;
             # repair here rather than only at fit time so meshes fitted before
-            # this check existed still load.
-            mesh = contour_tools.repair_inverted_tetrahedra(mesh)
-            points = np.asarray(mesh.points, dtype=np.float64)
+            # this check existed still load. Repair against self._tets, the
+            # connectivity tet_volumes() below actually uses, rather than
+            # whatever cells the file happens to store -- a mismatch there
+            # would repair the wrong topology and still leave the physics
+            # elements inverted.
+            tet_grid = pv.UnstructuredGrid({pv.CellType.TETRA: self._tets}, mesh.points)
+            repaired = contour_tools.repair_inverted_tetrahedra(tet_grid)
+            points = np.asarray(repaired.points, dtype=np.float64)
             _, nodal = tet_volumes(points, self._tets)
             reference = torch.from_numpy(points).to(device=device, dtype=torch.float32)
             volumes = torch.from_numpy(nodal).to(device=device, dtype=torch.float32)

--- a/tests/test_contour_mesh_extraction.py
+++ b/tests/test_contour_mesh_extraction.py
@@ -407,5 +407,45 @@ class TestTrimTetrahedraToSurface:
         )
 
 
+class TestRepairInvertedTetrahedra:
+    """Node relaxation must fix a flippable mesh and give up on one that can't."""
+
+    @staticmethod
+    def _single_tetra(points: np.ndarray) -> pv.UnstructuredGrid:
+        """Build a one-cell tetrahedral mesh from four *points*."""
+        cells = np.array([4, 0, 1, 2, 3])
+        return pv.UnstructuredGrid(cells, [pv.CellType.TETRA], points)
+
+    def test_repairs_an_inverted_tetrahedron(self, contour_tools: ContourTools) -> None:
+        """Swapping two corners inverts the cell; relaxation must restore it."""
+        points = np.array(
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]
+        )
+        mesh = self._single_tetra(points)
+
+        repaired = contour_tools.repair_inverted_tetrahedra(mesh)
+
+        corners = repaired.points[repaired.cells_dict[np.uint8(pv.CellType.TETRA)]][0]
+        edges = corners[1:, :] - corners[0:1, :]
+        assert np.linalg.det(edges) / 6.0 > 0.0
+
+    def test_raises_when_unrecoverable(self, contour_tools: ContourTools) -> None:
+        """A degenerate cell with no neighbors to average toward can't be fixed."""
+        points = np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]
+        )
+        mesh = self._single_tetra(points)
+
+        with pytest.raises(ValueError, match="still inverted or degenerate"):
+            contour_tools.repair_inverted_tetrahedra(mesh, max_iterations=2)
+
+    def test_raises_when_no_tetra_cells(self, contour_tools: ContourTools) -> None:
+        """A mesh without TETRA cells fails with a clear message, not a KeyError."""
+        mesh = pv.UnstructuredGrid()
+
+        with pytest.raises(ValueError, match="no TETRA cells"):
+            contour_tools.repair_inverted_tetrahedra(mesh)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/test_physics_informed_motion.py
+++ b/tests/test_physics_informed_motion.py
@@ -498,3 +498,70 @@ def test_the_epoch_log_separates_the_two_loss_terms() -> None:
     assert "physics=0.000000" in messages[-1], (
         f"An epoch that accumulated nothing should report zero: {messages[-1]}"
     )
+
+
+def test_bind_reference_meshes_repairs_against_template_elements(tmp_path: Any) -> None:
+    """Repair must use ``self._tets``, not whatever cells the file stores.
+
+    A fitted reference file's own connectivity is never read back by
+    ``tet_volumes`` -- only ``self._tets`` is -- so repairing against the
+    file's cells instead would validate the wrong topology. Here the file
+    stores one degenerate, unrecoverable cell that touches only a single
+    node; repairing against it would raise, but ``self._tets`` names a
+    perfectly valid mesh, so binding must succeed unchanged.
+    """
+    import torch
+
+    from monai_physio.physicsnemo_tools import DistributedContext
+    from monai_physio.train_physicsnemo_physics_informed_motion import (
+        TrainPhysicsNeMoPhysicsInformedMotion,
+    )
+
+    points, tets = _grid_mesh(size=3)
+    mismatched = pv.UnstructuredGrid(
+        {pv.CellType.TETRA: np.array([[0, 0, 0, 0]])}, points
+    )
+    mesh_path = tmp_path / "reference.vtu"
+    mismatched.save(mesh_path)
+
+    method = TrainPhysicsNeMoPhysicsInformedMotion()
+    method._tets = tets
+    method._sample_subjects = ["subj0"]
+    method._reference_meshes = {"subj0": mesh_path}
+    context = DistributedContext(
+        device=torch.device("cpu"), rank=0, local_rank=0, world_size=1
+    )
+
+    method._bind_reference_meshes(context, n_points=len(points))
+
+    reference, volumes = method._reference_cache["subj0"]
+    assert np.allclose(reference.numpy(), points, atol=1e-5)
+    assert torch.all(volumes > 0)
+
+
+def test_bind_reference_meshes_tolerates_a_file_with_no_cells(tmp_path: Any) -> None:
+    """A reference file need not carry any cells at all; only its points do."""
+    import torch
+
+    from monai_physio.physicsnemo_tools import DistributedContext
+    from monai_physio.train_physicsnemo_physics_informed_motion import (
+        TrainPhysicsNeMoPhysicsInformedMotion,
+    )
+
+    points, tets = _grid_mesh(size=3)
+    mesh_path = tmp_path / "reference.vtp"
+    pv.PolyData(points).save(mesh_path)
+
+    method = TrainPhysicsNeMoPhysicsInformedMotion()
+    method._tets = tets
+    method._sample_subjects = ["subj0"]
+    method._reference_meshes = {"subj0": mesh_path}
+    context = DistributedContext(
+        device=torch.device("cpu"), rank=0, local_rank=0, world_size=1
+    )
+
+    method._bind_reference_meshes(context, n_points=len(points))
+
+    reference, volumes = method._reference_cache["subj0"]
+    assert np.allclose(reference.numpy(), points, atol=1e-5)
+    assert torch.all(volumes > 0)

--- a/tutorials/tutorial_16_duke_heart_physics_informed_motion_prep.py
+++ b/tutorials/tutorial_16_duke_heart_physics_informed_motion_prep.py
@@ -523,7 +523,15 @@ if __name__ == "__main__":
             # The model is volumetric here, so "fitted_reference_model" (the
             # tetrahedral mesh) and "fitted_reference_mesh" (its boundary) are
             # different geometries.  The volume is what the network predicts on.
-            fit_result["fitted_reference_model"].save(str(fitted_reference_model_file))
+            #
+            # The fit warps the template per subject with no cell-quality
+            # constraint, so it can flip a handful of elements even though the
+            # template itself was checked; repair before saving so Tutorial 17
+            # never has to.
+            fitted_reference_model = contour_tools.repair_inverted_tetrahedra(
+                cast(pv.UnstructuredGrid, fit_result["fitted_reference_model"])
+            )
+            fitted_reference_model.save(str(fitted_reference_model_file))
             fit_result["fitted_reference_mesh"].save(
                 str(case_output_dir / f"{case_id}_ssm_surface.vtp")
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of fitted heart meshes containing inverted tetrahedra.
  - Meshes are automatically repaired before nodal volume calculations and before being saved as reference models.
  - Valid meshes remain unchanged, while unsuccessful repairs report an error.
  - Point-count validation continues to be enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->