### PR TITLE
ENH: Fixed naming of transforms to standard to/from

### DIFF
--- a/.agents/agents/docs.md
+++ b/.agents/agents/docs.md
@@ -41,7 +41,8 @@ def register(self, moving_image: itk.Image) -> dict[str, Any]:
     -------
     dict
         Keys ``fixed_to_moving_transform`` and ``moving_to_fixed_transform``,
-        each a path to an ITK composite transform ``.hdf`` file.
+        each an ``itk.Transform`` (write with ``itk.transformwrite`` to
+        persist as an ``.hdf`` file).
     """
 ```
 

--- a/.agents/agents/docs.md
+++ b/.agents/agents/docs.md
@@ -40,8 +40,8 @@ def register(self, moving_image: itk.Image) -> dict[str, Any]:
     Returns
     -------
     dict
-        Keys ``forward_transform`` and ``inverse_transform``, each a path
-        to an ITK composite transform ``.hdf`` file.
+        Keys ``fixed_to_moving_transform`` and ``moving_to_fixed_transform``,
+        each a path to an ITK composite transform ``.hdf`` file.
     """
 ```
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,5 +2,5 @@
 # This overrides settings in pyproject.toml
 
 [lint]
-# Ignore UP007: Use Optional[X] instead of X | None for itk.Image compatibility
-ignore = ["UP007"]
+# Ignore UP007/UP045: Use Optional[X] instead of X | None for itk.Image compatibility
+ignore = ["UP007", "UP045"]

--- a/docs/api/registration/ants.rst
+++ b/docs/api/registration/ants.rst
@@ -36,8 +36,8 @@ Basic Registration
 
    result = registrar.register(moving)
 
-   forward_transform = result["forward_transform"]
-   inverse_transform = result["inverse_transform"]
+   fixed_to_moving_transform = result["fixed_to_moving_transform"]
+   moving_to_fixed_transform = result["moving_to_fixed_transform"]
    registered = registrar.get_registered_image()
 
 See Also

--- a/docs/api/registration/greedy.rst
+++ b/docs/api/registration/greedy.rst
@@ -34,8 +34,8 @@ Basic Registration
 
    result = registrar.register(moving)
 
-   forward_transform = result["forward_transform"]
-   inverse_transform = result["inverse_transform"]
+   fixed_to_moving_transform = result["fixed_to_moving_transform"]
+   moving_to_fixed_transform = result["moving_to_fixed_transform"]
    registered = registrar.get_registered_image()
 
 Installation Note

--- a/docs/api/registration/icon.rst
+++ b/docs/api/registration/icon.rst
@@ -35,8 +35,8 @@ Basic Registration
 
    result = registrar.register(moving)
 
-   forward_transform = result["forward_transform"]
-   inverse_transform = result["inverse_transform"]
+   fixed_to_moving_transform = result["fixed_to_moving_transform"]
+   moving_to_fixed_transform = result["moving_to_fixed_transform"]
    loss = result["loss"]
    registered = registrar.get_registered_image()
 
@@ -45,8 +45,10 @@ Result Dictionary
 
 ``register()`` returns:
 
-* ``forward_transform``: transform from moving image space to fixed image space
-* ``inverse_transform``: transform from fixed image space to moving image space
+* ``fixed_to_moving_transform``: warps the moving image onto the fixed grid
+  (or maps a fixed-space point to moving space)
+* ``moving_to_fixed_transform``: warps the fixed image onto the moving grid
+  (or maps a moving-space point to fixed space)
 * ``loss``: registration loss value reported by the backend
 
 Configuration

--- a/docs/api/registration/index.rst
+++ b/docs/api/registration/index.rst
@@ -22,8 +22,8 @@ Common Result Shape
 
 ``RegisterImagesANTS.register()`` and ``RegisterImagesICON.register()`` return:
 
-* ``forward_transform``
-* ``inverse_transform``
+* ``fixed_to_moving_transform``
+* ``moving_to_fixed_transform``
 * ``loss``
 
 Use :meth:`RegisterImagesBase.get_registered_image` after ``register()`` when a

--- a/docs/api/registration/time_series.rst
+++ b/docs/api/registration/time_series.rst
@@ -38,8 +38,8 @@ Basic Usage
        reference_frame=0,
        register_reference=False,
    )
-   forward_transforms = result["forward_transforms"]
-   inverse_transforms = result["inverse_transforms"]
+   fixed_to_moving_transforms = result["fixed_to_moving_transforms"]
+   moving_to_fixed_transforms = result["moving_to_fixed_transforms"]
 
 See Also
 ========

--- a/docs/cli_scripts/heart_gated_ct.rst
+++ b/docs/cli_scripts/heart_gated_ct.rst
@@ -171,7 +171,7 @@ Intermediate Files
    intermediate/
    ├── slice_*.mha                  # Individual 3D images per time point
    ├── slice_*.labelmap.mha         # Segmentation masks
-   ├── slice_*.reg_*.inverse_transform.hdf5  # Registration transforms
+   ├── slice_*.reg_*.moving_to_fixed_transform.hdf5  # Registration transforms
    └── slice_max.reg_*.mha          # Maximum intensity projections
    
    meshes/

--- a/docs/cookbook/add_a_registration_method.rst
+++ b/docs/cookbook/add_a_registration_method.rst
@@ -53,19 +53,19 @@ supply only the solve.
            forward, inverse, loss = solve(self.fixed_image_pre, moving_pre)
 
            return {
-               "forward_transform": forward,
-               "inverse_transform": inverse,
+               "fixed_to_moving_transform": forward,
+               "moving_to_fixed_transform": inverse,
                "loss": loss,
            }
 
 ``registration_method()`` is the one required override. It is internal -
 callers use ``register()``, which wraps it.
 
-**2. Honor the contract.** ``forward_transform`` warps the *moving image* onto
-the fixed grid. ``inverse_transform`` warps *moving points* into fixed space.
-Images and points take opposite transforms; getting this backwards is the
-classic silent failure here. Read :doc:`/developer/transform_conventions`
-before you return anything.
+**2. Honor the contract.** ``fixed_to_moving_transform`` warps the *moving
+image* onto the fixed grid. ``moving_to_fixed_transform`` warps *moving
+points* into fixed space. Images and points take opposite transforms; getting
+this backwards is the classic silent failure here. Read
+:doc:`/developer/transform_conventions` before you return anything.
 
 **3. Read the base's state, don't re-derive it.** Use
 ``self.fixed_image_pre`` and ``moving_image_pre`` rather than preprocessing

--- a/docs/developer/migration_next.md
+++ b/docs/developer/migration_next.md
@@ -106,7 +106,9 @@ produced the value: `RegisterImages*`/`RegisterModelsDistanceMaps`/
 
 ## `WorkflowCreateStatisticalModel.inverse_transforms` - removed
 
-**Change:** the attribute is gone. `forward_transforms` is unaffected.
+**Change:** the attribute is gone. `forward_transforms` (the surviving
+attribute) was itself later renamed to `fixed_to_moving_transforms` by the
+registration transform naming change above.
 
 **Why:** it was populated but never read - not by the workflow, nor by any
 tutorial, test or CLI in the repository. Each entry held a `CompositeTransform`
@@ -117,8 +119,9 @@ OOM killer partway through building a shape model. Removing it roughly halves
 the workflow's peak memory and costs nothing, because the value had no consumer.
 
 Callers that genuinely need the inverse of a correspondence can invert the
-matching `forward_transforms` entry with `itk.Transform.GetInverse`, which
-computes it on demand rather than holding one per sample for the whole run.
+matching `fixed_to_moving_transforms` entry with `itk.Transform.GetInverse`,
+which computes it on demand rather than holding one per sample for the whole
+run.
 
 **Before**
 
@@ -132,7 +135,7 @@ inverse = workflow.inverse_transforms[index]
 ```python
 workflow.process()
 inverse = itk.CompositeTransform[itk.D, 3].New()
-if not workflow.forward_transforms[index].GetInverse(inverse):
+if not workflow.fixed_to_moving_transforms[index].GetInverse(inverse):
     raise RuntimeError(f"Correspondence transform {index} is not invertible")
 ```
 

--- a/docs/developer/migration_next.md
+++ b/docs/developer/migration_next.md
@@ -12,6 +12,98 @@ break is recorded here in the commit that introduces it.
 At release time this file is renamed `migration_<version>.md` and a fresh
 `migration_next.md` is started for the next cycle.
 
+## Registration transform naming - `forward`/`inverse` renamed to `fixed_to_moving`/`moving_to_fixed`
+
+**Change:** every registration class now returns/exposes exactly two transform
+names, spelled out by direction instead of by "forward"/"inverse":
+
+- `fixed_to_moving_transform` - `TransformPoint()` maps a fixed-space
+  coordinate to the corresponding moving-space coordinate.
+- `moving_to_fixed_transform` - `TransformPoint()` maps a moving-space
+  coordinate to the corresponding fixed-space coordinate.
+
+This affects `RegisterImagesANTS`/`RegisterImagesICON`/`RegisterImagesGreedy`/
+`RegisterImagesGreedyICON`/`RegisterImagesChain`/`RegisterTimeSeriesImages`/
+`RegisterModelsDistanceMaps` (previously `forward_transform`/
+`inverse_transform`, or the plural `forward_transforms`/`inverse_transforms`
+for time series), and `RegisterModelsPCA`/`RegisterModelsICP`/
+`RegisterModelsICPITK` (previously `forward_point_transform`/
+`inverse_point_transform`). `WorkflowCreateStatisticalModel`,
+`WorkflowCreateMeanSurface`, and `WorkflowFitStatisticalModelToPatient`
+follow the same rename on their own `forward_transforms`/`l2l_forward_transform`/
+`l2i_forward_transform`/etc. attributes. `post_pca_transform` is unaffected.
+
+**Why:** "forward"/"inverse" did not name one fixed direction. Warping an
+image is a pull-back (needs a fixed-to-moving point map) while warping a
+point/mesh is a push-forward (needs the opposite map), so the same word meant
+opposite things depending on whether you were warping an image or a point -
+for the *same* registration result. Worse, image registration's
+`forward_transform` and PCA/ICP's `forward_point_transform` pointed in
+opposite real-world directions for the same "moving to fixed" concept. See
+`docs/developer/transform_conventions.rst` for the full explanation. Naming
+the transform by its literal source/target space removes both ambiguities:
+the correct transform for any operation is now just "the one whose name
+matches the space you have and the space you want."
+
+**The rename is not symmetric between the two families** - this is the
+detail most likely to be missed migrating by hand:
+
+| Old name | Class family | New name |
+|---|---|---|
+| `forward_transform(s)` | Image registration | `fixed_to_moving_transform(s)` |
+| `inverse_transform(s)` | Image registration | `moving_to_fixed_transform(s)` |
+| `forward_point_transform` | PCA / ICP | `moving_to_fixed_transform` |
+| `inverse_point_transform` | PCA / ICP | `fixed_to_moving_transform` |
+
+**Before**
+
+```python
+# Image registration
+result = RegisterImagesANTS().register(moving_image)
+warped = transform_tools.transform_image(
+    moving_image, result["forward_transform"], fixed_image
+)
+warped_points = transform_tools.transform_pvcontour(
+    points, result["inverse_transform"]
+)
+
+# PCA/ICP model registration
+result = registrar.compute_pca_transforms(reference_image)
+warped_template = transform_tools.transform_pvcontour(
+    template_points, result["forward_point_transform"]
+)
+```
+
+**After**
+
+```python
+# Image registration
+result = RegisterImagesANTS().register(moving_image)
+warped = transform_tools.transform_image(
+    moving_image, result["fixed_to_moving_transform"], fixed_image
+)
+warped_points = transform_tools.transform_pvcontour(
+    points, result["moving_to_fixed_transform"]
+)
+
+# PCA/ICP model registration
+result = registrar.compute_pca_transforms(reference_image)
+warped_template = transform_tools.transform_pvcontour(
+    template_points, result["moving_to_fixed_transform"]
+)
+```
+
+**Automated conversion:** none provided. A blind find-replace is unsafe here
+because the same old name maps to a *different* new name depending on which
+class produced the dict/attribute (see table above), and static analysis
+cannot always tell which family a bare `result["forward_transform"]` belongs
+to without tracing back to the registrar that built `result`. Search your
+code for `forward_transform`, `inverse_transform`, `forward_point_transform`,
+and `inverse_point_transform`, and at each hit, check which `Register*` class
+produced the value: `RegisterImages*`/`RegisterModelsDistanceMaps`/
+`RegisterTimeSeriesImages` use the top row of the table, `RegisterModelsPCA`/
+`RegisterModelsICP`/`RegisterModelsICPITK` use the bottom row.
+
 ## `WorkflowCreateStatisticalModel.inverse_transforms` - removed
 
 **Change:** the attribute is gone. `forward_transforms` is unaffected.

--- a/docs/developer/registration_images.rst
+++ b/docs/developer/registration_images.rst
@@ -24,12 +24,12 @@ Basic Pattern
    result = registrar.register(moving)
    registered = registrar.get_registered_image()
 
-The result dictionary contains ``forward_transform``, ``inverse_transform``,
-and ``loss``. Applying the right one is critical and direction-dependent:
-``forward_transform`` warps the moving image onto the fixed grid, while
-``inverse_transform`` warps moving points/landmarks into fixed space (image and
-point warps use opposite transforms). See
-:doc:`transform_conventions` for the full rules.
+The result dictionary contains ``fixed_to_moving_transform``,
+``moving_to_fixed_transform``, and ``loss``. Applying the right one is
+critical and direction-dependent: ``fixed_to_moving_transform`` warps the
+moving image onto the fixed grid, while ``moving_to_fixed_transform`` warps
+moving points/landmarks into fixed space (image and point warps use opposite
+transforms). See :doc:`transform_conventions` for the full rules.
 
 Time Series
 ===========
@@ -58,7 +58,7 @@ Workflows that accept a ``registration_method`` (e.g.
 any :class:`RegisterImagesBase` instance, including a composite chain that
 runs multiple backends in sequence. :class:`RegisterImagesChain` runs an
 ordered list of registrars, each stage refining the previous stage's
-``forward_transform`` through ``register_from()`` (see `Seeding a registration`_
+``fixed_to_moving_transform`` through ``register_from()`` (see `Seeding a registration`_
 below). :class:`RegisterImagesGreedyICON` is a named 2-stage convenience class
 for the common case of a fast Greedy registration followed by ICON refinement:
 
@@ -84,7 +84,7 @@ To start from an alignment you already have, call ``register_from()`` instead of
 
 .. code-block:: python
 
-   result = registrar.register_from(known_forward_transform, moving_image)
+   result = registrar.register_from(known_fixed_to_moving_transform, moving_image)
 
 It warps the moving image, mask and labelmap onto the fixed grid by that
 transform, registers the residual, and composes the two, so the returned

--- a/docs/developer/registration_models.rst
+++ b/docs/developer/registration_models.rst
@@ -45,9 +45,8 @@ Development Notes
 * Convert volumetric meshes to surfaces before surface registration when needed.
 * Treat ITK/PyVista coordinate transforms as high-risk and add focused tests.
 * Keep synthetic test meshes small and deterministic.
-* ``RegisterModelsPCA`` returns ``forward_point_transform`` /
-  ``inverse_point_transform``. These are **point** transforms whose orientation
-  is opposite to the image-registration transforms; see
+* ``RegisterModelsPCA`` returns ``moving_to_fixed_transform`` /
+  ``fixed_to_moving_transform``. These are **point** transforms; see
   :doc:`transform_conventions` before applying them to images or meshes.
 
 See Also

--- a/docs/developer/transform_conventions.rst
+++ b/docs/developer/transform_conventions.rst
@@ -22,9 +22,12 @@ Every registration class -- image (:class:`monai_physio.RegisterImagesANTS`,
 :class:`monai_physio.RegisterTimeSeriesImages` returns the list-valued
 ``fixed_to_moving_transforms`` / ``moving_to_fixed_transforms``.
 
-Because the name states the direction literally, you do not need to remember
-which member of the pair to use for a given class or operation -- just pick
-the transform whose name matches the source and target space you have.
+Because the name states the direction literally, mapping a *point* needs no
+lookup table -- just pick the transform whose name matches the source and
+target point space you have. Warping an *image* is different:
+:func:`TransformTools.transform_image` samples whichever grid you are
+building the output on, so the transform is picked by output grid, not by
+source/target space (see below).
 
 Read this page before applying any transform to an image, mask, contour, or
 landmark.

--- a/docs/developer/transform_conventions.rst
+++ b/docs/developer/transform_conventions.rst
@@ -2,32 +2,32 @@
 Transform Direction Conventions
 ===============================
 
-Registration in MONAI Physio produces a pair of transforms, and choosing the
-wrong one of the pair is the single most common registration mistake. The rules
-are simple but easy to get backwards, because **warping an image and warping a
-point require opposite transforms**, and because **model (PCA) registration
-returns its transforms in the opposite orientation from image registration**.
+Registration in MONAI Physio produces a pair of transforms, named for the
+literal spatial mapping they perform:
+
+``fixed_to_moving_transform``
+    ``TransformPoint()`` maps a **fixed**-space coordinate to the
+    corresponding **moving**-space coordinate.
+
+``moving_to_fixed_transform``
+    ``TransformPoint()`` maps a **moving**-space coordinate to the
+    corresponding **fixed**-space coordinate.
+
+Every registration class -- image (:class:`monai_physio.RegisterImagesANTS`,
+:class:`monai_physio.RegisterImagesICON`,
+:class:`monai_physio.RegisterImagesGreedy`,
+:class:`monai_physio.RegisterModelsDistanceMaps`) and model
+(:class:`monai_physio.RegisterModelsPCA`,
+:class:`monai_physio.RegisterModelsICP`) -- returns exactly these two names.
+:class:`monai_physio.RegisterTimeSeriesImages` returns the list-valued
+``fixed_to_moving_transforms`` / ``moving_to_fixed_transforms``.
+
+Because the name states the direction literally, you do not need to remember
+which member of the pair to use for a given class or operation -- just pick
+the transform whose name matches the source and target space you have.
 
 Read this page before applying any transform to an image, mask, contour, or
 landmark.
-
-The two transform families
-===========================
-
-Image registration
-    :class:`monai_physio.RegisterImagesANTS`,
-    :class:`monai_physio.RegisterImagesICON`, and
-    :class:`monai_physio.RegisterImagesGreedy` register a *moving* image to a
-    *fixed* image and return a dict with ``forward_transform`` and
-    ``inverse_transform``. :class:`monai_physio.RegisterTimeSeriesImages`
-    returns the list-valued ``forward_transforms`` / ``inverse_transforms``.
-
-Model (PCA) registration
-    :class:`monai_physio.RegisterModelsPCA` deforms a *template* model toward
-    a *target* (patient) and, via ``compute_pca_transforms()``, returns
-    ``forward_point_transform`` and ``inverse_point_transform``. These are
-    **point transforms**, oriented opposite to the image-registration transforms
-    (see `PCA point transforms`_ below).
 
 Image warping vs. point warping use opposite transforms
 ========================================================
@@ -36,18 +36,17 @@ ITK resampling is a *pull-back* operation. To build the warped image on the
 fixed grid, :func:`TransformTools.transform_image` (an ``itk.ResampleImageFilter``)
 visits every fixed-grid sample ``q`` and looks up the moving image at
 ``transform.TransformPoint(q)``. The transform it needs therefore maps
-**fixed-space coordinates to moving-space coordinates**.
+**fixed-space coordinates to moving-space coordinates** --
+``fixed_to_moving_transform``.
 
 Warping a *point* (landmark, contour vertex, mesh node) is a *push-forward*
 operation: :func:`TransformTools.transform_pvcontour` /
 :func:`TransformTools.transform_dataset` apply ``transform.TransformPoint(p)``
-directly to each input point. To move a moving-space landmark to its location in
-the fixed image, the transform must map **moving-space coordinates to
-fixed-space coordinates** -- the inverse of the image-warp transform.
+directly to each input point. To move a moving-space landmark to its location
+in the fixed image, the transform must map **moving-space coordinates to
+fixed-space coordinates** -- ``moving_to_fixed_transform``.
 
-So for the **same** moving-to-fixed registration result:
-
-.. list-table:: Image registration: which transform to apply
+.. list-table:: Which transform to apply
    :header-rows: 1
    :widths: 50 25 25
 
@@ -55,79 +54,51 @@ So for the **same** moving-to-fixed registration result:
      - Transform
      - Helper
    * - Warp the **moving image** into fixed space (onto the fixed grid)
-     - ``forward_transform``
+     - ``fixed_to_moving_transform``
      - :func:`TransformTools.transform_image`
    * - Warp **moving points / contours / landmarks** into fixed space
-     - ``inverse_transform``
+     - ``moving_to_fixed_transform``
      - :func:`TransformTools.transform_pvcontour`
    * - Warp the **fixed image** into moving space (e.g. time-series reconstruction)
-     - ``inverse_transform``
+     - ``moving_to_fixed_transform``
      - :func:`TransformTools.transform_image`
    * - Warp **fixed points / contours / landmarks** into moving space
-     - ``forward_transform``
+     - ``fixed_to_moving_transform``
      - :func:`TransformTools.transform_pvcontour`
-
-The first two rows are the everyday case (warping the registered moving data
-into the fixed/reference frame): the **image uses** ``forward_transform``, the
-**points use** ``inverse_transform``. The last two rows are the mirror image;
-:meth:`monai_physio.RegisterTimeSeriesImages.reconstruct_time_series` is the
-canonical consumer of ``inverse_transform`` for image warping (it resamples the
-fixed image back onto each moving frame's grid).
 
 .. note::
 
-   All three image-registration backends (ANTS, ICON, Greedy) follow this same
-   convention. ``transform_image(moving, forward_transform, fixed)`` is the
-   correct call to warp the moving image onto the fixed grid for every backend.
+   All registration classes (image and model alike) follow this same
+   convention. ``transform_image(moving, fixed_to_moving_transform, fixed)``
+   is the correct call to warp the moving image onto the fixed grid for every
+   backend, and ``transform_pvcontour(points, moving_to_fixed_transform)`` is
+   the correct call to warp moving points/mesh nodes into fixed space for
+   every backend -- image or model.
 
-PCA point transforms
-====================
+PCA / ICP point transforms
+===========================
 
-:class:`monai_physio.RegisterModelsPCA` builds ``forward_point_transform``
+:class:`monai_physio.RegisterModelsPCA` builds ``moving_to_fixed_transform``
 directly from the template-to-target point displacement, so
-``forward_point_transform.TransformPoint(template_point)`` returns the
-corresponding *target* point. As a **point** map it goes template (moving) to
-target (fixed) -- which is the same orientation as image registration's
-``inverse_transform``, and therefore the **opposite** orientation of image
-registration's ``forward_transform``.
-
-Concretely, treating the template as the moving object and the patient/target as
-the fixed object:
-
-.. list-table:: Same goal, opposite transform names across the two families
-   :header-rows: 1
-   :widths: 50 25 25
-
-   * - Goal
-     - Image registration
-     - PCA model registration
-   * - Warp the **image** (moving/template space -> fixed/target grid)
-     - ``forward_transform``
-     - ``inverse_point_transform``
-   * - Warp **points / meshes** (moving/template -> fixed/target)
-     - ``inverse_transform``
-     - ``forward_point_transform``
-
-In other words, ``forward_point_transform`` plays the role that
-``inverse_transform`` plays for image registration, and
-``inverse_point_transform`` plays the role of ``forward_transform``. Deforming
-the template mesh onto the patient (the usual PCA use, performed internally by
+``moving_to_fixed_transform.TransformPoint(template_point)`` returns the
+corresponding *target* point -- treating the template as the moving object
+and the patient/target as the fixed object. Deforming the template mesh onto
+the patient (the usual PCA use, performed internally by
 ``transform_template_model()`` and ``transform_point()``) uses
-``forward_point_transform``; resampling an image with the PCA result uses
-``inverse_point_transform``.
+``moving_to_fixed_transform``; resampling an image with the PCA result uses
+``fixed_to_moving_transform``. :class:`monai_physio.RegisterModelsICP`
+follows the same convention.
 
 Rule of thumb
 =============
 
 * **Images pull back; points push forward.** For one registration result, the
-  image and the points always use the two *different* members of the transform
-  pair.
-* **Image into the reference frame** -> ``forward_transform`` (image
-  registration) / ``inverse_point_transform`` (PCA).
-* **Points into the reference frame** -> ``inverse_transform`` (image
-  registration) / ``forward_point_transform`` (PCA).
-* When in doubt, warp a known landmark and a small image patch and confirm they
-  land in the same place before trusting a pipeline.
+  image and the points always use the two *different* members of the
+  transform pair.
+* **Image into the reference frame** -> ``fixed_to_moving_transform``.
+* **Points into the reference frame** -> ``moving_to_fixed_transform``.
+* When in doubt, warp a known landmark and a small image patch and confirm
+  they land in the same place before trusting a pipeline.
 
 See Also
 ========

--- a/docs/developer/utilities.rst
+++ b/docs/developer/utilities.rst
@@ -16,7 +16,7 @@ Transform Tools
    from monai_physio import TransformTools
 
    tools = TransformTools()
-   transform = itk.transformread("forward_transform.hdf")
+   transform = itk.transformread("fixed_to_moving_transform.hdf")
    moving = itk.imread("moving.mha")
    reference = itk.imread("reference.mha")
 
@@ -32,7 +32,7 @@ For PyVista contours:
    from monai_physio import TransformTools
 
    mesh = pv.read("heart_t0.vtp")
-   transform = itk.transformread("forward_transform.hdf")
+   transform = itk.transformread("fixed_to_moving_transform.hdf")
 
    transformed = TransformTools().transform_pvcontour(mesh, transform)
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -263,8 +263,12 @@ For standalone registration:
    results = registerer.register(moving_image)
 
    # Get transformation fields
-   inverse_transform = results["inverse_transform"]  # Fixed to moving space
-   forward_transform = results["forward_transform"]  # Moving to fixed space
+   # Warps the moving image onto the fixed grid (or maps a fixed-space
+   # point to moving space)
+   fixed_to_moving_transform = results["fixed_to_moving_transform"]
+   # Warps the fixed image onto the moving grid (or maps a moving-space
+   # point to fixed space)
+   moving_to_fixed_transform = results["moving_to_fixed_transform"]
 
 VTK to USD Conversion
 ---------------------

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -439,8 +439,8 @@ Run
       python tutorials/tutorial_03_lung_reconstruct_highres_4d_ct.py
 
 Outputs
-   ``reconstructed_frame_<i>.mha`` plus forward and inverse transforms for
-   every phase, and two screenshots, under
+   ``reconstructed_frame_<i>.mha`` plus fixed_to_moving and moving_to_fixed
+   transforms for every phase, and two screenshots, under
    ``tutorials/output/tutorial_03_{heart,lung}/``.
 
 Adapt to your data
@@ -813,8 +813,8 @@ Run
 Outputs
    Per case, under ``tutorials/output/tutorial_08_lung/<case>/``: the fitted
    reference surface, its PCA coefficients, and one warped surface plus
-   forward/inverse transform per phase. Those per-phase surfaces are exactly
-   the training set Tutorial 9 consumes.
+   fixed_to_moving/moving_to_fixed transform per phase. Those per-phase
+   surfaces are exactly the training set Tutorial 9 consumes.
 
 Adapt to your data
    Point ``data_dir`` at a directory of per-case 4D series and set

--- a/experiments/Heart-Create_Statistical_Model/2-input_surfaces_to_surfaces_aligned.py
+++ b/experiments/Heart-Create_Statistical_Model/2-input_surfaces_to_surfaces_aligned.py
@@ -71,8 +71,8 @@ output_dir.mkdir(exist_ok=True)
 
 # Store results
 aligned_meshes = {}
-transforms_point_forward = {}  # Moving to Fixed point transforms (forward_point_transform)
-transforms_point_inverse = {}  # Fixed to Moving point transforms (inverse_point_transform)
+transforms_point_forward = {}  # Moving to Fixed point transforms (moving_to_fixed_transform)
+transforms_point_inverse = {}  # Fixed to Moving point transforms (fixed_to_moving_transform)
 
 contour_tools = ContourTools()
 
@@ -102,19 +102,19 @@ for mesh_file in mesh_files:
     # Store results
     mesh_id = mesh_file.stem
     aligned_meshes[mesh_id] = result["registered_model"]
-    transforms_point_forward[mesh_id] = result["forward_point_transform"]
-    transforms_point_inverse[mesh_id] = result["inverse_point_transform"]
+    transforms_point_forward[mesh_id] = result["moving_to_fixed_transform"]
+    transforms_point_inverse[mesh_id] = result["fixed_to_moving_transform"]
 
     # Save aligned mesh
     output_path = output_dir / f"{mesh_id}.vtp"
     result["registered_model"].save(output_path)
     itk.transformwrite(
-        result["forward_point_transform"],
-        output_dir / f"{mesh_id}_forward_point_transform.hdf",
+        result["moving_to_fixed_transform"],
+        output_dir / f"{mesh_id}_moving_to_fixed_transform.hdf",
     )
     itk.transformwrite(
-        result["inverse_point_transform"],
-        output_dir / f"{mesh_id}_inverse_point_transform.hdf",
+        result["fixed_to_moving_transform"],
+        output_dir / f"{mesh_id}_fixed_to_moving_transform.hdf",
     )
     print(f"\n  Saved aligned mesh: {output_path}")
 

--- a/experiments/Heart-Create_Statistical_Model/3-registration_based_correspondence.py
+++ b/experiments/Heart-Create_Statistical_Model/3-registration_based_correspondence.py
@@ -113,8 +113,8 @@ for vtk_file in vtk_files:
         transform_type="Deformable",
     )
 
-    forward_transform = result["forward_transform"]
-    inverse_transform = result["inverse_transform"]
+    fixed_to_moving_transform = result["fixed_to_moving_transform"]
+    moving_to_fixed_transform = result["moving_to_fixed_transform"]
 
     # Get registered model
     registered_model = result["registered_model"]
@@ -125,10 +125,12 @@ for vtk_file in vtk_files:
     print(f"Saved: {output_file.name}")
 
     itk.transformwrite(
-        forward_transform, output_dir / f"{case_id}.forward_transform.hdf"
+        fixed_to_moving_transform,
+        output_dir / f"{case_id}.fixed_to_moving_transform.hdf",
     )
     itk.transformwrite(
-        inverse_transform, output_dir / f"{case_id}.inverse_transform.hdf"
+        moving_to_fixed_transform,
+        output_dir / f"{case_id}.moving_to_fixed_transform.hdf",
     )
 
     # Calculate registration statistics

--- a/experiments/Heart-Create_Statistical_Model/4-surfaces_aligned_correspond_to_pca_inputs.py
+++ b/experiments/Heart-Create_Statistical_Model/4-surfaces_aligned_correspond_to_pca_inputs.py
@@ -23,7 +23,7 @@ contour_tools = ContourTools()
 template_mesh = pv.read(_HERE / "kcl-heart-model/average_surface.vtp")
 
 # Find all VTK/VTP files in correspondence directory
-tfm_filenames = sorted(correspond_dir.glob("??.forward_transform.hdf"))
+tfm_filenames = sorted(correspond_dir.glob("??.fixed_to_moving_transform.hdf"))
 # Since we are transforming points, we use the forward transform to effect an inverse transform
 
 print(f"Found {len(tfm_filenames)} files in {correspond_dir}/")

--- a/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/1-initial_registration.py
+++ b/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/1-initial_registration.py
@@ -109,12 +109,12 @@ def per_label_dice(
 
 
 def warp_landmarks(
-    inverse_transform: itk.Transform,
+    moving_to_fixed_transform: itk.Transform,
     moving_landmarks: dict[str, tuple[float, float, float]],
 ) -> dict[str, tuple[float, float, float]]:
     """Warp every moving landmark into reference space.
 
-    Point/landmark warping uses ``inverse_transform`` -- the moving-space ->
+    Point/landmark warping uses ``moving_to_fixed_transform`` -- the moving-space ->
     fixed-space point map -- which is the opposite of the transform used to
     warp the moving image onto the fixed grid (images pull back; points push
     forward). Returns a ``{label: (x, y, z)}`` dict in LPS. See
@@ -122,7 +122,7 @@ def warp_landmarks(
     """
     new_landmarks = {}
     for name, point in moving_landmarks.items():
-        new_point = inverse_transform.TransformPoint(np.array(point))
+        new_point = moving_to_fixed_transform.TransformPoint(np.array(point))
         new_landmarks[name] = tuple(np.array(new_point).tolist())
     return new_landmarks
 
@@ -492,26 +492,26 @@ for subject_index, subject_id in enumerate(cohort):
                 time_elapsed = time.perf_counter() - time_start
                 print(f"   ...finished registration in {time_elapsed:.1f}s")
 
-                forward_transform = reg_result["forward_transform"]
-                inverse_transform = reg_result["inverse_transform"]
+                fixed_to_moving_transform = reg_result["fixed_to_moving_transform"]
+                moving_to_fixed_transform = reg_result["moving_to_fixed_transform"]
                 loss = float(reg_result["loss"])
 
                 print(f"Writing results to {method_dir / f'{stem}_init_*.*'}")
 
                 itk.transformwrite(
-                    forward_transform,
+                    fixed_to_moving_transform,
                     str(method_dir / f"{stem}_init_fwd.hdf"),
                     compression=True,
                 )
                 itk.transformwrite(
-                    inverse_transform,
+                    moving_to_fixed_transform,
                     str(method_dir / f"{stem}_init_inv.hdf"),
                     compression=True,
                 )
 
                 warped_image = transform_tools.transform_image(
                     moving_image,
-                    forward_transform,
+                    fixed_to_moving_transform,
                     fixed_image,
                     interpolation_method="linear",
                 )
@@ -525,7 +525,7 @@ for subject_index, subject_id in enumerate(cohort):
                 if fixed_labelmap is not None and moving_labelmap is not None:
                     warped_labelmap = transform_tools.transform_image(
                         moving_labelmap,
-                        forward_transform,
+                        fixed_to_moving_transform,
                         fixed_labelmap,
                         interpolation_method="nearest",
                     )
@@ -557,7 +557,7 @@ for subject_index, subject_id in enumerate(cohort):
                 if fixed_mask is not None and moving_mask is not None:
                     warped_mask = transform_tools.transform_image(
                         moving_mask,
-                        forward_transform,
+                        fixed_to_moving_transform,
                         fixed_mask,
                         interpolation_method="nearest",
                     )
@@ -572,7 +572,7 @@ for subject_index, subject_id in enumerate(cohort):
                     # Landmarks live in LPS world space, unaffected by cropping, so
                     # the uncropped moving_landmarks are warped here.
                     warped_landmarks = warp_landmarks(
-                        inverse_transform, moving_landmarks
+                        moving_to_fixed_transform, moving_landmarks
                     )
                     landmark_tools.write_landmarks_3dslicer(
                         warped_landmarks,

--- a/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/3-eval_icon.py
+++ b/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/3-eval_icon.py
@@ -283,17 +283,17 @@ for subject_id in test_subjects:
 
         for index in range(len(image_files)):
             timepoint = timepoints[index]
-            forward_transform = result["forward_transforms"][index]
-            inverse_transform = result["inverse_transforms"][index]
+            fixed_to_moving_transform = result["fixed_to_moving_transforms"][index]
+            moving_to_fixed_transform = result["moving_to_fixed_transforms"][index]
             loss = float(result["losses"][index])
 
             itk.transformwrite(
-                forward_transform,
+                fixed_to_moving_transform,
                 str(method_dir / f"{subject_id}_g{timepoint}_forward_tfm.hdf"),
                 compression=True,
             )
             itk.transformwrite(
-                inverse_transform,
+                moving_to_fixed_transform,
                 str(method_dir / f"{subject_id}_g{timepoint}_inverse_tfm.hdf"),
                 compression=True,
             )
@@ -303,7 +303,9 @@ for subject_id in test_subjects:
             shared = sorted(timepoint_landmarks.keys() & fixed_landmarks.keys())
             errors = []
             for name in shared:
-                warped = inverse_transform.TransformPoint(timepoint_landmarks[name])
+                warped = moving_to_fixed_transform.TransformPoint(
+                    timepoint_landmarks[name]
+                )
                 err = float(
                     np.linalg.norm(
                         np.asarray(warped, dtype=np.float64)
@@ -341,7 +343,7 @@ for subject_id in test_subjects:
             # precomputed landmarks.
             warped_ref = transform_tools.transform_image(
                 fixed_image,
-                inverse_transform,
+                moving_to_fixed_transform,
                 moving_images[index],
                 interpolation_method="linear",
             )
@@ -452,7 +454,7 @@ print("=" * len(header))
 # ## 7. Per-method aggregate table: warped-reference landmark errors
 #
 # Compares landmarks extracted from the reference image warped back to each
-# time-point's grid (via ``inverse_transform``) against that time-point's own
+# time-point's grid (via ``moving_to_fixed_transform``) against that time-point's own
 # precomputed landmarks.  Both sets are in the moving (time-point) image space,
 # so errors are Euclidean distances without any additional transform.
 

--- a/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/registration_test.py
+++ b/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/registration_test.py
@@ -84,16 +84,16 @@ t_start = time.perf_counter()
 reg_result = reg.register(moving_image=moving_image)
 elapsed = time.perf_counter() - t_start
 
-forward_transform = reg_result["forward_transform"]
+fixed_to_moving_transform = reg_result["fixed_to_moving_transform"]
 loss = float(reg_result["loss"])
 print(f"{method} registration done in {elapsed:.1f} s, loss={loss:.4f}")
 
 # %% [markdown]
 # ## 5. Warp time point 20 into time point 60's space and save
 #
-# ``forward_transform`` is the transform consumed by ``transform_image`` to
+# ``fixed_to_moving_transform`` is the transform consumed by ``transform_image`` to
 # resample the moving image onto the fixed grid (it supplies the fixed->moving
-# sampling map the ITK resampler needs). ``inverse_transform`` is the opposite
+# sampling map the ITK resampler needs). ``moving_to_fixed_transform`` is the opposite
 # direction, used to warp the fixed image onto the moving grid (e.g. in
 # ``RegisterTimeSeriesImages.reconstruct_time_series``). This holds for all
 # three backends (ANTS, ICON, Greedy).
@@ -103,7 +103,7 @@ transform_tools = TransformTools()
 warp_t_start = time.perf_counter()
 warped_image = transform_tools.transform_image(
     moving_image,
-    forward_transform,
+    fixed_to_moving_transform,
     fixed_image,
     interpolation_method="linear",
 )

--- a/experiments/Heart-GatedCT_To_USD/1-register_images.py
+++ b/experiments/Heart-GatedCT_To_USD/1-register_images.py
@@ -101,10 +101,10 @@ if __name__ == "__main__":
         reg.set_fixed_mask(None)
         results = reg.register(moving_image)
         print(f"  Done registering whole image for slice {i:03d}.")
-        inverse_transform = results["inverse_transform"]
-        forward_transform = results["forward_transform"]
+        moving_to_fixed_transform = results["moving_to_fixed_transform"]
+        fixed_to_moving_transform = results["fixed_to_moving_transform"]
         moving_image_reg = TransformTools().transform_image(
-            moving_image, forward_transform, fixed_image, "sinc"
+            moving_image, fixed_to_moving_transform, fixed_image, "sinc"
         )  # Final resampling with sinc
         itk.imwrite(
             moving_image_reg,
@@ -112,12 +112,12 @@ if __name__ == "__main__":
             compression=True,
         )
         itk.transformwrite(
-            [forward_transform],
+            [fixed_to_moving_transform],
             str(output_dir / f"slice_{i:03d}.reg_all.forward.hdf"),
             compression=True,
         )
         itk.transformwrite(
-            [inverse_transform],
+            [moving_to_fixed_transform],
             str(output_dir / f"slice_{i:03d}.reg_all.inverse.hdf"),
             compression=True,
         )
@@ -134,10 +134,10 @@ if __name__ == "__main__":
         reg.set_fixed_mask(fixed_image_dynamic_anatomy_mask)
         results = reg.register(moving_image, moving_image_dynamic_anatomy_mask)
         print(f"  Done registering dynamic anatomy mask for slice {i:03d}.")
-        inverse_transform = results["inverse_transform"]
-        forward_transform = results["forward_transform"]
+        moving_to_fixed_transform = results["moving_to_fixed_transform"]
+        fixed_to_moving_transform = results["fixed_to_moving_transform"]
         moving_image_reg_dynamic_anatomy = TransformTools().transform_image(
-            moving_image, forward_transform, fixed_image, "sinc"
+            moving_image, fixed_to_moving_transform, fixed_image, "sinc"
         )  # Final resampling with sinc
         itk.imwrite(
             moving_image_dynamic_anatomy_mask,
@@ -150,12 +150,12 @@ if __name__ == "__main__":
             compression=True,
         )
         itk.transformwrite(
-            [forward_transform],
+            [fixed_to_moving_transform],
             str(output_dir / f"slice_{i:03d}.reg_dynamic_anatomy.forward.hdf"),
             compression=True,
         )
         itk.transformwrite(
-            [inverse_transform],
+            [moving_to_fixed_transform],
             str(output_dir / f"slice_{i:03d}.reg_dynamic_anatomy.inverse.hdf"),
             compression=True,
         )
@@ -173,10 +173,10 @@ if __name__ == "__main__":
         reg.set_fixed_mask(fixed_image_static_mask)
         results = reg.register(moving_image, moving_image_static_mask)
         print(f"  Done registering static anatomy mask for slice {i:03d}.")
-        inverse_transform = results["inverse_transform"]
-        forward_transform = results["forward_transform"]
+        moving_to_fixed_transform = results["moving_to_fixed_transform"]
+        fixed_to_moving_transform = results["fixed_to_moving_transform"]
         moving_image_reg_static = TransformTools().transform_image(
-            moving_image, forward_transform, fixed_image, "sinc"
+            moving_image, fixed_to_moving_transform, fixed_image, "sinc"
         )  # Final resampling with sinc
         itk.imwrite(
             moving_image_static_mask,
@@ -189,12 +189,12 @@ if __name__ == "__main__":
             compression=True,
         )
         itk.transformwrite(
-            [forward_transform],
+            [fixed_to_moving_transform],
             str(output_dir / f"slice_{i:03d}.reg_static_anatomy.forward.hdf"),
             compression=True,
         )
         itk.transformwrite(
-            [inverse_transform],
+            [moving_to_fixed_transform],
             str(output_dir / f"slice_{i:03d}.reg_static_anatomy.inverse.hdf"),
             compression=True,
         )

--- a/experiments/Heart-GatedCT_To_USD/3-transform_dynamic_and_static_contours.py
+++ b/experiments/Heart-GatedCT_To_USD/3-transform_dynamic_and_static_contours.py
@@ -36,11 +36,11 @@ if __name__ == "__main__":
     ):
         con = ContourTools()
         for i, transform_filename in zip(frame_indices, transform_filenames):
-            forward_transform = itk.transformread(transform_filename)[0]
+            fixed_to_moving_transform = itk.transformread(transform_filename)[0]
             print(f"Applying transform {transform_filename} to {base_name}")
 
             new_contours = con.transform_contours(
-                contours, forward_transform, with_deformation_magnitude=True
+                contours, fixed_to_moving_transform, with_deformation_magnitude=True
             )
             new_contours.save(
                 os.path.join(

--- a/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_model_icp_itk.py
+++ b/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_model_icp_itk.py
@@ -158,17 +158,17 @@ icp_result = icp_registrar.register(
 
 # Get the aligned mesh and transform
 icp_registered_model_surface = icp_result["registered_model"]
-icp_forward_point_transform = icp_result["forward_point_transform"]
+icp_moving_to_fixed_transform = icp_result["moving_to_fixed_transform"]
 
 print("\nICP affine registration complete")
-print("   Transform =", icp_result["forward_point_transform"])
+print("   Transform =", icp_result["moving_to_fixed_transform"])
 
 # Save aligned model
 icp_registered_model_surface.save(str(output_dir / "icp_registered_model_surface.vtp"))
 print("  Saved ICP-aligned model surface")
 
 itk.transformwrite(
-    [icp_result["forward_point_transform"]],
+    [icp_result["moving_to_fixed_transform"]],
     str(output_dir / "icp_transform.hdf"),
     compression=True,
 )
@@ -179,7 +179,7 @@ print("  Saved ICP transform")
 # This gets the volumetric mesh into patient space for PCA registration
 transform_tools = TransformTools()
 icp_registered_model = transform_tools.transform_pvcontour(
-    template_model, icp_forward_point_transform
+    template_model, icp_moving_to_fixed_transform
 )
 icp_registered_model.save(str(output_dir / "icp_registered_model.vtk"))
 print("\nApplied ICP transform to full model mesh")

--- a/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_model_registration_pca.py
+++ b/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_model_registration_pca.py
@@ -168,17 +168,17 @@ icp_result = icp_registrar.register(
 
 # Get the aligned mesh and transform
 icp_registered_model_surface = icp_result["registered_model"]
-icp_forward_point_transform = icp_result["forward_point_transform"]
+icp_moving_to_fixed_transform = icp_result["moving_to_fixed_transform"]
 
 print("\nICP affine registration complete")
-print("   Transform =", icp_result["forward_point_transform"])
+print("   Transform =", icp_result["moving_to_fixed_transform"])
 
 # Save aligned model
 icp_registered_model_surface.save(str(output_dir / "icp_registered_model_surface.vtp"))
 print("  Saved ICP-aligned model surface")
 
 itk.transformwrite(
-    [icp_result["forward_point_transform"]],
+    [icp_result["moving_to_fixed_transform"]],
     str(output_dir / "icp_transform.hdf"),
     compression=True,
 )
@@ -189,7 +189,7 @@ print("  Saved ICP transform")
 # This gets the volumetric mesh into patient space for PCA registration
 transform_tools = TransformTools()
 icp_registered_model = transform_tools.transform_pvcontour(
-    template_model, icp_forward_point_transform
+    template_model, icp_moving_to_fixed_transform
 )
 icp_registered_model.save(str(output_dir / "icp_registered_model.vtk"))
 print("\nApplied ICP transform to full model mesh")
@@ -208,7 +208,7 @@ pca_registrar = RegisterModelsPCA.from_pca_model(
     pca_template_model=template_model_surface,
     pca_model=pca_model,
     pca_number_of_modes=10,
-    post_pca_transform=icp_forward_point_transform,
+    post_pca_transform=icp_moving_to_fixed_transform,
     fixed_model=patient_surface,
     reference_image=patient_image,
 )

--- a/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_patient.py
+++ b/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_patient.py
@@ -159,8 +159,8 @@ if __name__ == "__main__":
     # %%
     # Rough alignment using ICP
     icp_results = registrar.register_model_to_model_icp()
-    icp_inverse_point_transform = icp_results["inverse_point_transform"]
-    icp_forward_point_transform = icp_results["forward_point_transform"]
+    icp_fixed_to_moving_transform = icp_results["fixed_to_moving_transform"]
+    icp_moving_to_fixed_transform = icp_results["moving_to_fixed_transform"]
     icp_model_surface = icp_results["fitted_reference_mesh"]
     icp_labelmap = icp_results["registered_template_labelmap"]
 
@@ -184,8 +184,8 @@ if __name__ == "__main__":
     print("Starting deformable labelmap-to-labelmap registration...")
 
     l2l_results = registrar.register_labelmap_to_labelmap()
-    l2l_inverse_transform = l2l_results["inverse_transform"]
-    l2l_forward_transform = l2l_results["forward_transform"]
+    l2l_moving_to_fixed_transform = l2l_results["moving_to_fixed_transform"]
+    l2l_fixed_to_moving_transform = l2l_results["fixed_to_moving_transform"]
     l2l_model_surface = l2l_results["fitted_reference_mesh"]
     l2l_labelmap = l2l_results["registered_template_labelmap"]
 
@@ -199,8 +199,8 @@ if __name__ == "__main__":
     print("This may take several minutes depending on GPU availability.")
 
     l2i_results = registrar.register_labelmap_to_image()
-    l2i_inverse_transform = l2i_results["inverse_transform"]
-    l2i_forward_transform = l2i_results["forward_transform"]
+    l2i_moving_to_fixed_transform = l2i_results["moving_to_fixed_transform"]
+    l2i_fixed_to_moving_transform = l2i_results["fixed_to_moving_transform"]
     l2i_surface = l2i_results["fitted_reference_mesh"]
     l2i_labelmap = l2i_results["registered_template_labelmap"]
     print("\nRegistration complete!")
@@ -218,7 +218,7 @@ if __name__ == "__main__":
 
     start_time = time.time()
     # Timing only; the workflow stores the ICP-aligned model before PCA registration.
-    icp_p = registrar.icp_registrar.forward_point_transform.TransformPoint(tmp_p)
+    icp_p = registrar.icp_registrar.moving_to_fixed_transform.TransformPoint(tmp_p)
     print(
         f"--- ICP forward transform time: {time.time() - start_time} seconds",
         flush=True,
@@ -234,11 +234,11 @@ if __name__ == "__main__":
     print(f"PCA transform time: {time.time() - start_time} seconds", flush=True)
 
     start_time = time.time()
-    tmp_p = registrar.l2l_inverse_transform.TransformPoint(tmp_p)
+    tmp_p = registrar.l2l_moving_to_fixed_transform.TransformPoint(tmp_p)
     print(f"L2L inverse transform time: {time.time() - start_time} seconds", flush=True)
 
     start_time = time.time()
-    tmp_p = registrar.l2i_inverse_transform.TransformPoint(tmp_p)
+    tmp_p = registrar.l2i_moving_to_fixed_transform.TransformPoint(tmp_p)
     print(f"L2I inverse transform time: {time.time() - start_time} seconds", flush=True)
 
     # %%

--- a/experiments/Heart_and_Lungs_Motion/1-heart_and_lungs_combined.py
+++ b/experiments/Heart_and_Lungs_Motion/1-heart_and_lungs_combined.py
@@ -146,14 +146,16 @@ if __name__ == "__main__":
         stale_frame.unlink()
 
     cardiac_field_files = sorted(beating_heart_dir.glob("deformation_field_s*.mha"))
-    forward_transform_files = sorted(respiratory_dir.glob("slice_*_all_forward.hdf"))
+    fixed_to_moving_transform_files = sorted(
+        respiratory_dir.glob("slice_*_all_forward.hdf")
+    )
 
     if not cardiac_field_files:
         raise FileNotFoundError(
             f"No cardiac deformation fields found in {beating_heart_dir}. "
             "Run temp_heart_and_lungs_beating_heart.py first."
         )
-    if not forward_transform_files:
+    if not fixed_to_moving_transform_files:
         raise FileNotFoundError(
             f"No respiratory forward transforms found in {respiratory_dir}. "
             "Run tutorial_01_lung_gated_ct_to_usd.py first."
@@ -164,7 +166,7 @@ if __name__ == "__main__":
             "Run tutorial_04_lung_ct_to_vtk.py first."
         )
 
-    n_phases = len(forward_transform_files)
+    n_phases = len(fixed_to_moving_transform_files)
     n_stages = len(cardiac_field_files)
     logger.info(
         "Respiratory phases: %d, cardiac stages: %d (1 cardiac cycle/phase)",
@@ -205,13 +207,13 @@ if __name__ == "__main__":
     # Respiratory-warped vertex positions for every (phase, stage):
     # resp_points[phase][stage] = forward_phase(cardiac_surface[stage]).points.
     resp_points: list[list[np.ndarray]] = []
-    for phase_idx, forward_file in enumerate(forward_transform_files):
-        forward_transform = itk.transformread(str(forward_file))
+    for phase_idx, forward_file in enumerate(fixed_to_moving_transform_files):
+        fixed_to_moving_transform = itk.transformread(str(forward_file))
         resp_points.append(
             [
                 np.asarray(
                     _transform_tools.transform_pvcontour(
-                        cardiac_surface, forward_transform
+                        cardiac_surface, fixed_to_moving_transform
                     ).points,
                     dtype=np.float32,
                 )

--- a/experiments/Lung-GatedCT_To_USD/0-register_dirlab_4dct.py
+++ b/experiments/Lung-GatedCT_To_USD/0-register_dirlab_4dct.py
@@ -68,11 +68,11 @@ if __name__ == "__main__":
             moving_mask_d = dilate_mask(moving_mask, heart_mask_dilation)
             reg_images.set_fixed_mask(fixed_mask_d)
         results = reg_images.register(moving_image, moving_mask_d)
-        inverse_transform = results["inverse_transform"]
-        forward_transform = results["forward_transform"]
+        moving_to_fixed_transform = results["moving_to_fixed_transform"]
+        fixed_to_moving_transform = results["fixed_to_moving_transform"]
         print("Registering image...Done!")
         moving_image_reg = TransformTools().transform_image(
-            moving_image, forward_transform, fixed_image, "sinc"
+            moving_image, fixed_to_moving_transform, fixed_image, "sinc"
         )  # Final resampling with sinc
         itk.imwrite(
             moving_image_reg,
@@ -81,13 +81,13 @@ if __name__ == "__main__":
         )
 
         itk.transformwrite(
-            [forward_transform],
+            [fixed_to_moving_transform],
             f"{output_dir}/{case_name}_T{image_num * 10:02d}_{mask_name}_forward.hdf",
             compression=True,
         )
 
         itk.transformwrite(
-            [inverse_transform],
+            [moving_to_fixed_transform],
             f"{output_dir}/{case_name}_T{image_num * 10:02d}_{mask_name}_inverse.hdf",
             compression=True,
         )

--- a/experiments/Lung-GatedCT_To_USD/1-make_dirlab_models.py
+++ b/experiments/Lung-GatedCT_To_USD/1-make_dirlab_models.py
@@ -32,13 +32,13 @@ if __name__ == "__main__":
         con_tools = ContourTools()
         new_contours = []
         for i in range(10):
-            inverse_transform = itk.transformread(
+            moving_to_fixed_transform = itk.transformread(
                 f"{output_dir}/{case_name}_T{i * 10:02d}_{mask_name}_inverse.hdf"
             )[0]
 
             print(f"Transforming {case_name} - {mask_name} - T{i * 10:02d}")
             new_contours.append(
-                con_tools.transform_contours(contours, inverse_transform)
+                con_tools.transform_contours(contours, moving_to_fixed_transform)
             )
 
         return new_contours

--- a/experiments/Lung-GatedCT_To_USD_NV/0-register_dirlab_4dct.py
+++ b/experiments/Lung-GatedCT_To_USD_NV/0-register_dirlab_4dct.py
@@ -69,11 +69,11 @@ if __name__ == "__main__":
             moving_mask_d = dilate_mask(moving_mask, heart_mask_dilation)
             reg_images.set_fixed_mask(fixed_mask_d)
         results = reg_images.register(moving_image, moving_mask_d)
-        inverse_transform = results["inverse_transform"]
-        forward_transform = results["forward_transform"]
+        moving_to_fixed_transform = results["moving_to_fixed_transform"]
+        fixed_to_moving_transform = results["fixed_to_moving_transform"]
         print("Registering image...Done!")
         moving_image_reg = TransformTools().transform_image(
-            moving_image, forward_transform, fixed_image, "sinc"
+            moving_image, fixed_to_moving_transform, fixed_image, "sinc"
         )  # Final resampling with sinc
         itk.imwrite(
             moving_image_reg,
@@ -82,13 +82,13 @@ if __name__ == "__main__":
         )
 
         itk.transformwrite(
-            [forward_transform],
+            [fixed_to_moving_transform],
             f"{output_dir}/{case_name}_T{image_num * 10:02d}_{mask_name}_forward.hdf",
             compression=True,
         )
 
         itk.transformwrite(
-            [inverse_transform],
+            [moving_to_fixed_transform],
             f"{output_dir}/{case_name}_T{image_num * 10:02d}_{mask_name}_inverse.hdf",
             compression=True,
         )

--- a/experiments/Lung-GatedCT_To_USD_NV/1-make_dirlab_models.py
+++ b/experiments/Lung-GatedCT_To_USD_NV/1-make_dirlab_models.py
@@ -32,13 +32,13 @@ if __name__ == "__main__":
         con_tools = ContourTools()
         new_contours = []
         for i in range(10):
-            inverse_transform = itk.transformread(
+            moving_to_fixed_transform = itk.transformread(
                 f"{output_dir}/{case_name}_T{i * 10:02d}_{mask_name}_inverse.hdf"
             )[0]
 
             print(f"Transforming {case_name} - {mask_name} - T{i * 10:02d}")
             new_contours.append(
-                con_tools.transform_contours(contours, inverse_transform)
+                con_tools.transform_contours(contours, moving_to_fixed_transform)
             )
 
         return new_contours

--- a/experiments/Reconstruct4DCT/reconstruct_4d_ct.py
+++ b/experiments/Reconstruct4DCT/reconstruct_4d_ct.py
@@ -55,11 +55,11 @@ def register_slices(
     tfm_tools = TransformTools()
 
     img = images[reference_image_num]
-    forward_transform = None
-    inverse_transform = None
+    fixed_to_moving_transform = None
+    moving_to_fixed_transform = None
     results = None
     reg_image = None
-    prior_forward_transform = None
+    prior_fixed_to_moving_transform = None
 
     reference_image = images[reference_image_num]
     reference_image_indx = files_indx[reference_image_num]
@@ -73,37 +73,47 @@ def register_slices(
         print(
             f"Registering reference slice {reference_image_indx} using identify transform"
         )
-        forward_transform = identity_tfm
-        inverse_transform = identity_tfm
+        fixed_to_moving_transform = identity_tfm
+        moving_to_fixed_transform = identity_tfm
         if portion_of_prior_to_use > 0.0:
-            prior_forward_transform = identity_tfm
+            prior_fixed_to_moving_transform = identity_tfm
         reg_image = img
         reg_image_inv = fixed_image
     else:
         print(f"Registering reference slice {reference_image_indx} to reference image.")
         results = reg_tool.register(img)
-        forward_transform = results["forward_transform"]
-        inverse_transform = results["inverse_transform"]
+        fixed_to_moving_transform = results["fixed_to_moving_transform"]
+        moving_to_fixed_transform = results["moving_to_fixed_transform"]
         if portion_of_prior_to_use > 0.0:
-            prior_forward_transform = tfm_tools.combine_displacement_field_transforms(
-                identity_tfm,
-                forward_transform,
-                reference_image,
-                tfm1_weight=1.0,
-                tfm2_weight=portion_of_prior_to_use,
-                tfm1_blur_sigma=0.0,
-                tfm2_blur_sigma=0.5,
-                mode="add",
+            prior_fixed_to_moving_transform = (
+                tfm_tools.combine_displacement_field_transforms(
+                    identity_tfm,
+                    fixed_to_moving_transform,
+                    reference_image,
+                    tfm1_weight=1.0,
+                    tfm2_weight=portion_of_prior_to_use,
+                    tfm1_blur_sigma=0.0,
+                    tfm2_blur_sigma=0.5,
+                    mode="add",
+                )
             )
-        reg_image = tfm_tools.transform_image(img, forward_transform, fixed_image)
-        reg_image_inv = tfm_tools.transform_image(fixed_image, inverse_transform, img)
+        reg_image = tfm_tools.transform_image(
+            img, fixed_to_moving_transform, fixed_image
+        )
+        reg_image_inv = tfm_tools.transform_image(
+            fixed_image, moving_to_fixed_transform, img
+        )
 
     num_images = len(images)
 
-    forward_transform_arr = [itk.Transform[itk.D, 3].New() for _ in range(num_images)]
-    inverse_transform_arr = [itk.Transform[itk.D, 3].New() for _ in range(num_images)]
-    forward_transform_arr[reference_image_num] = forward_transform
-    inverse_transform_arr[reference_image_num] = inverse_transform
+    fixed_to_moving_transform_arr = [
+        itk.Transform[itk.D, 3].New() for _ in range(num_images)
+    ]
+    moving_to_fixed_transform_arr = [
+        itk.Transform[itk.D, 3].New() for _ in range(num_images)
+    ]
+    fixed_to_moving_transform_arr[reference_image_num] = fixed_to_moving_transform
+    moving_to_fixed_transform_arr[reference_image_num] = moving_to_fixed_transform
 
     debug_mode = True
 
@@ -121,7 +131,7 @@ def register_slices(
         itk.imwrite(reg_image_inv, out_file, compression=True)
 
         itk.transformwrite(
-            forward_transform,
+            fixed_to_moving_transform,
             os.path.join(
                 _RESULTS_DIR,
                 f"slice_{reg_tool_name}_forward_{reference_image_indx:03d}.hdf",
@@ -129,7 +139,7 @@ def register_slices(
             compression=True,
         )
         itk.transformwrite(
-            inverse_transform,
+            moving_to_fixed_transform,
             os.path.join(
                 _RESULTS_DIR,
                 f"slice_{reg_tool_name}_inverse_{reference_image_indx:03d}.hdf",
@@ -137,7 +147,7 @@ def register_slices(
             compression=True,
         )
 
-    prior_forward_transform_ref = prior_forward_transform
+    prior_fixed_to_moving_transform_ref = prior_fixed_to_moving_transform
 
     for step_i in [1, -1]:
         start_i = 0
@@ -149,7 +159,7 @@ def register_slices(
             start_i = reference_image_num + 1
             end_i = num_files
 
-        prior_forward_transform = prior_forward_transform_ref
+        prior_fixed_to_moving_transform = prior_fixed_to_moving_transform_ref
 
         if start_i != end_i:
             print(
@@ -163,8 +173,12 @@ def register_slices(
             # Try identity as initial transform
             print("     Trying init with identity.")
             results_init_identity = reg_tool.register(img)
-            inverse_tranform_init_identity = results_init_identity["inverse_transform"]
-            forward_transform_init_identity = results_init_identity["forward_transform"]
+            inverse_tranform_init_identity = results_init_identity[
+                "moving_to_fixed_transform"
+            ]
+            fixed_to_moving_transform_init_identity = results_init_identity[
+                "fixed_to_moving_transform"
+            ]
             loss_init_identity = results_init_identity["loss"]
             print("        Final loss:", results_init_identity["loss"])
 
@@ -172,27 +186,31 @@ def register_slices(
                 # Try with prior transform
                 print("     Trying with init prior.")
                 results_init_prior = reg_tool.register_from(
-                    prior_forward_transform, img
+                    prior_fixed_to_moving_transform, img
                 )
-                inverse_transform_init_prior = results_init_prior["inverse_transform"]
-                forward_transform_init_prior = results_init_prior["forward_transform"]
+                moving_to_fixed_transform_init_prior = results_init_prior[
+                    "moving_to_fixed_transform"
+                ]
+                fixed_to_moving_transform_init_prior = results_init_prior[
+                    "fixed_to_moving_transform"
+                ]
                 loss_init_prior = results_init_prior["loss"]
                 print("        Final loss:", results_init_prior["loss"])
 
                 if loss_init_identity < loss_init_prior:
                     print("     Using identity.")
-                    prior_forward_transform = identity_tfm
-                    inverse_transform = inverse_tranform_init_identity
-                    forward_transform = forward_transform_init_identity
+                    prior_fixed_to_moving_transform = identity_tfm
+                    moving_to_fixed_transform = inverse_tranform_init_identity
+                    fixed_to_moving_transform = fixed_to_moving_transform_init_identity
                 else:
                     print("     Using prior.")
-                    inverse_transform = inverse_transform_init_prior
-                    forward_transform = forward_transform_init_prior
+                    moving_to_fixed_transform = moving_to_fixed_transform_init_prior
+                    fixed_to_moving_transform = fixed_to_moving_transform_init_prior
 
-                prior_forward_transform = (
+                prior_fixed_to_moving_transform = (
                     tfm_tools.combine_displacement_field_transforms(
                         identity_tfm,
-                        forward_transform,
+                        fixed_to_moving_transform,
                         reference_image,
                         tfm1_weight=1.0,
                         tfm2_weight=portion_of_prior_to_use,
@@ -202,15 +220,15 @@ def register_slices(
                     )
                 )
             else:
-                inverse_transform = inverse_tranform_init_identity
-                forward_transform = forward_transform_init_identity
+                moving_to_fixed_transform = inverse_tranform_init_identity
+                fixed_to_moving_transform = fixed_to_moving_transform_init_identity
 
-            forward_transform_arr[img_indx] = forward_transform
-            inverse_transform_arr[img_indx] = inverse_transform
+            fixed_to_moving_transform_arr[img_indx] = fixed_to_moving_transform
+            moving_to_fixed_transform_arr[img_indx] = moving_to_fixed_transform
 
             if debug_mode:
                 reg_image = tfm_tools.transform_image(
-                    img, forward_transform, fixed_image
+                    img, fixed_to_moving_transform, fixed_image
                 )
                 out_file = os.path.join(
                     _RESULTS_DIR,
@@ -219,7 +237,7 @@ def register_slices(
                 itk.imwrite(reg_image, out_file, compression=True)
 
                 reg_image = tfm_tools.transform_image(
-                    fixed_image, inverse_transform, img
+                    fixed_image, moving_to_fixed_transform, img
                 )
                 out_file = os.path.join(
                     _RESULTS_DIR,
@@ -228,7 +246,7 @@ def register_slices(
                 itk.imwrite(reg_image, out_file, compression=True)
 
                 itk.transformwrite(
-                    forward_transform,
+                    fixed_to_moving_transform,
                     os.path.join(
                         _RESULTS_DIR,
                         f"slice_{reg_tool_name}_forward_{img_file_indx:03d}.hdf",
@@ -236,7 +254,7 @@ def register_slices(
                     compression=True,
                 )
                 itk.transformwrite(
-                    inverse_transform,
+                    moving_to_fixed_transform,
                     os.path.join(
                         _RESULTS_DIR,
                         f"slice_{reg_tool_name}_inverse_{img_file_indx:03d}.hdf",
@@ -245,14 +263,14 @@ def register_slices(
                 )
 
     return {
-        "forward_transforms": forward_transform_arr,
-        "inverse_transforms": inverse_transform_arr,
+        "fixed_to_moving_transforms": fixed_to_moving_transform_arr,
+        "moving_to_fixed_transforms": moving_to_fixed_transform_arr,
     }
 
 
 # %%
-forward_transform_arr = None
-inverse_transform_arr = None
+fixed_to_moving_transform_arr = None
+moving_to_fixed_transform_arr = None
 for reg_tool_name, reg_tool, num_iterations in reg_method_data:
     reg_tool.set_fixed_image(fixed_image)
     reg_tool.set_number_of_iterations(num_iterations)
@@ -266,8 +284,8 @@ for reg_tool_name, reg_tool, num_iterations in reg_method_data:
         reference_image_reg_use_identity,
         portion_of_prior_to_use=0.0,
     )
-    forward_transform_arr = results["forward_transforms"]
-    inverse_transform_arr = results["inverse_transforms"]
+    fixed_to_moving_transform_arr = results["fixed_to_moving_transforms"]
+    moving_to_fixed_transform_arr = results["moving_to_fixed_transforms"]
 
 # %%
 tfm_tool = TransformTools()
@@ -292,12 +310,12 @@ grid_image = tfm_tool.generate_grid_image(fixed_image, 30, 1)
 
 for i in range(num_files):
     print(files_indx[i])
-    inverse_transform = itk.transformread(
+    moving_to_fixed_transform = itk.transformread(
         os.path.join(_RESULTS_DIR, f"slice_ANTS_inverse_{files_indx[i]:03d}.hdf")
     )[0]
 
     inverse_image = tfm_tool.convert_transform_to_displacement_field(
-        inverse_transform,
+        moving_to_fixed_transform,
         fixed_image,
         np_component_type=np.float32,
     )
@@ -309,7 +327,7 @@ for i in range(num_files):
 
     inverse_grid_image = tfm_tool.transform_image(
         grid_image,
-        inverse_transform,
+        moving_to_fixed_transform,
         fixed_image,
     )
     itk.imwrite(

--- a/experiments/Reconstruct4DCT/reconstruct_4d_ct_class.py
+++ b/experiments/Reconstruct4DCT/reconstruct_4d_ct_class.py
@@ -161,8 +161,8 @@ for method_idx, registration_method_name in enumerate(registration_method_names)
         prior_weight=portion_of_prior_transform_to_init_next_transform,
     )
 
-    forward_transforms = result["forward_transforms"]
-    inverse_transforms = result["inverse_transforms"]
+    fixed_to_moving_transforms = result["fixed_to_moving_transforms"]
+    moving_to_fixed_transforms = result["moving_to_fixed_transforms"]
     losses = result["losses"]
 
     print(f"\n{registration_method_name.upper()} registration complete!")
@@ -175,7 +175,7 @@ for method_idx, registration_method_name in enumerate(registration_method_names)
     print("  Reconstructing time series in fixed image space...")
     reconstructed_images = registrar.reconstruct_time_series(
         moving_images=images,
-        inverse_transforms=inverse_transforms,
+        moving_to_fixed_transforms=moving_to_fixed_transforms,
         upsample_to_fixed_resolution=True,
     )
 
@@ -193,7 +193,7 @@ for method_idx, registration_method_name in enumerate(registration_method_names)
         # Also save forward-transformed images (moving to fixed using forward transform)
         # This shows the moving image aligned to fixed space
         reg_image = tfm_tools.transform_image(
-            images[i], forward_transforms[i], fixed_image
+            images[i], fixed_to_moving_transforms[i], fixed_image
         )
         out_file = os.path.join(
             _RESULTS_DIR,
@@ -203,7 +203,7 @@ for method_idx, registration_method_name in enumerate(registration_method_names)
 
         # Save transforms
         itk.transformwrite(
-            forward_transforms[i],
+            fixed_to_moving_transforms[i],
             os.path.join(
                 _RESULTS_DIR,
                 f"slice_{registration_method_name}_forward_{img_indx:03d}.hdf",
@@ -211,7 +211,7 @@ for method_idx, registration_method_name in enumerate(registration_method_names)
             compression=True,
         )
         itk.transformwrite(
-            inverse_transforms[i],
+            moving_to_fixed_transforms[i],
             os.path.join(
                 _RESULTS_DIR,
                 f"slice_{registration_method_name}_inverse_{img_indx:03d}.hdf",
@@ -238,7 +238,7 @@ for method_idx, registration_method_name in enumerate(registration_method_names)
         # Transform grid with inverse transform (FM)
         inverse_grid_image = tfm_tools.transform_image(
             grid_image,
-            inverse_transforms[i],
+            moving_to_fixed_transforms[i],
             fixed_image,
         )
         itk.imwrite(
@@ -251,13 +251,15 @@ for method_idx, registration_method_name in enumerate(registration_method_names)
         )
 
         # Save displacement field as image
-        inverse_transform_image = tfm_tools.convert_transform_to_displacement_field(
-            inverse_transforms[i],
-            fixed_image,
-            np_component_type=np.float32,
+        moving_to_fixed_transform_image = (
+            tfm_tools.convert_transform_to_displacement_field(
+                moving_to_fixed_transforms[i],
+                fixed_image,
+                np_component_type=np.float32,
+            )
         )
         itk.imwrite(
-            inverse_transform_image,
+            moving_to_fixed_transform_image,
             os.path.join(
                 _RESULTS_DIR,
                 f"slice_{registration_method_name}_inverse_{img_indx:03d}_field.mha",

--- a/src/monai_physio/cli/reconstruct_highres_4d_ct.py
+++ b/src/monai_physio/cli/reconstruct_highres_4d_ct.py
@@ -345,11 +345,11 @@ Examples:
         # Save transforms if requested
         if args.save_transforms:
             print("  Saving transforms...")
-            forward_transforms = result["forward_transforms"]
-            inverse_transforms = result["inverse_transforms"]
+            fixed_to_moving_transforms = result["fixed_to_moving_transforms"]
+            moving_to_fixed_transforms = result["moving_to_fixed_transforms"]
 
             for i, (fwd_tfm, inv_tfm) in enumerate(
-                zip(forward_transforms, inverse_transforms)
+                zip(fixed_to_moving_transforms, moving_to_fixed_transforms)
             ):
                 fwd_file = os.path.join(
                     args.output_dir, f"{args.output_prefix}_forward_{i:03d}.hdf5"
@@ -363,7 +363,7 @@ Examples:
                 if i == 0:
                     print(f"    {fwd_file}")
                     print(f"    {inv_file}")
-                elif i == len(forward_transforms) - 1:
+                elif i == len(fixed_to_moving_transforms) - 1:
                     print(f"    ... {fwd_file}")
                     print(f"    ... {inv_file}")
 
@@ -394,7 +394,7 @@ Examples:
         print(f"\nAll output files saved to: {args.output_dir}")
         print(f"  - {len(reconstructed_images)} reconstructed images")
         if args.save_transforms:
-            print(f"  - {len(forward_transforms) * 2} transform files")
+            print(f"  - {len(fixed_to_moving_transforms) * 2} transform files")
         if args.save_losses:
             print("  - 1 loss statistics file")
 

--- a/src/monai_physio/register_images_ants.py
+++ b/src/monai_physio/register_images_ants.py
@@ -75,7 +75,7 @@ class RegisterImagesANTS(RegisterImagesBase):
         >>> registrar.set_transform_type('Affine')
         >>> registrar.set_metric('Mattes')
         >>> result = registrar.register(moving_image)
-        >>> inverse_transform = result['inverse_transform']
+        >>> moving_to_fixed_transform = result['moving_to_fixed_transform']
     """
 
     def __init__(self, log_level: int | str = logging.INFO):
@@ -536,12 +536,12 @@ class RegisterImagesANTS(RegisterImagesBase):
 
         Returns:
             dict: Dictionary containing:
-                - "forward_transform": Warps the moving image onto the fixed
+                - "fixed_to_moving_transform": Warps the moving image onto the fixed
                   grid (warping moving points/landmarks into fixed space uses
-                  "inverse_transform" instead -- image and point warps use
+                  "moving_to_fixed_transform" instead -- image and point warps use
                   opposite transforms; see
                   docs/developer/transform_conventions)
-                - "inverse_transform": Warps the fixed image onto the moving grid
+                - "moving_to_fixed_transform": Warps the fixed image onto the moving grid
                 - "loss": Loss value from the registration
 
         Note:
@@ -562,8 +562,8 @@ class RegisterImagesANTS(RegisterImagesBase):
         Example:
             >>> # Basic registration
             >>> result = registrar.register(moving_image)
-            >>> inverse_transform = result['inverse_transform']
-            >>> forward_transform = result['forward_transform']
+            >>> moving_to_fixed_transform = result['moving_to_fixed_transform']
+            >>> fixed_to_moving_transform = result['fixed_to_moving_transform']
             >>>
             >>> # Masked registration for cardiac structures
             >>> registrar.set_fixed_mask(heart_mask_fixed)
@@ -686,8 +686,8 @@ class RegisterImagesANTS(RegisterImagesBase):
             reference_image=self.moving_image,
         )
 
-        forward_transform = forward_reg
-        inverse_transform = inverse_reg
+        fixed_to_moving_transform = forward_reg
+        moving_to_fixed_transform = inverse_reg
         moving_image_reg = registration_result["warpedmovout"]
         loss = ants.image_similarity(
             self._itk_to_ants_image(self.fixed_image),
@@ -695,7 +695,7 @@ class RegisterImagesANTS(RegisterImagesBase):
         )
 
         return {
-            "forward_transform": forward_transform,
-            "inverse_transform": inverse_transform,
+            "fixed_to_moving_transform": fixed_to_moving_transform,
+            "moving_to_fixed_transform": moving_to_fixed_transform,
             "loss": loss,
         }

--- a/src/monai_physio/register_images_base.py
+++ b/src/monai_physio/register_images_base.py
@@ -62,8 +62,8 @@ class RegisterImagesBase(MONAIPhysioBase):
         ...     def registration_method(self, moving_image, **kwargs):
         ...         # Implement specific registration algorithm
         ...         return {
-        ...             'forward_transform': tfm_forward,  # warps moving image -> fixed grid
-        ...             'inverse_transform': tfm_inverse,  # warps fixed image -> moving grid
+        ...             'fixed_to_moving_transform': tfm_f2m,  # warps moving image -> fixed grid
+        ...             'moving_to_fixed_transform': tfm_m2f,  # warps fixed image -> moving grid
         ...             'loss': 0.0,
         ...         }
         >>>
@@ -71,8 +71,8 @@ class RegisterImagesBase(MONAIPhysioBase):
         >>> registrar.set_modality('ct')
         >>> registrar.set_fixed_image(reference_image)
         >>> result = registrar.register(moving_image)
-        >>> forward_tfm = result['forward_transform']  # warps moving image -> fixed grid
-        >>> inverse_tfm = result['inverse_transform']  # warps fixed image -> moving grid
+        >>> f2m_tfm = result['fixed_to_moving_transform']  # warps moving image -> fixed grid
+        >>> m2f_tfm = result['moving_to_fixed_transform']  # warps fixed image -> moving grid
 
     See :class:`RegisterImagesChain` to combine multiple registrars into a
     multi-stage pipeline (e.g. a fast coarse registrar followed by a
@@ -113,8 +113,8 @@ class RegisterImagesBase(MONAIPhysioBase):
 
         self.fast_mode: bool = False
 
-        self.forward_transform: Optional[itk.Transform] = None
-        self.inverse_transform: Optional[itk.Transform] = None
+        self.fixed_to_moving_transform: Optional[itk.Transform] = None
+        self.moving_to_fixed_transform: Optional[itk.Transform] = None
         self.loss: Optional[float] = None
         self.moving_image_registered: Optional[itk.Image] = None
 
@@ -183,8 +183,8 @@ class RegisterImagesBase(MONAIPhysioBase):
         """
         self.fixed_image = fixed_image
         self.fixed_image_pre = None
-        self.forward_transform = None
-        self.inverse_transform = None
+        self.fixed_to_moving_transform = None
+        self.moving_to_fixed_transform = None
         self.loss = None
         self.moving_image_registered = None
 
@@ -214,8 +214,8 @@ class RegisterImagesBase(MONAIPhysioBase):
             >>> registrar.set_fixed_mask(heart_mask)
         """
         self.fixed_image_pre = None
-        self.forward_transform = None
-        self.inverse_transform = None
+        self.fixed_to_moving_transform = None
+        self.moving_to_fixed_transform = None
         self.loss = None
         self.moving_image_registered = None
 
@@ -239,8 +239,8 @@ class RegisterImagesBase(MONAIPhysioBase):
                 co-registered with the fixed image, or None to clear.
         """
         self.fixed_labelmap = fixed_labelmap
-        self.forward_transform = None
-        self.inverse_transform = None
+        self.fixed_to_moving_transform = None
+        self.moving_to_fixed_transform = None
         self.loss = None
         self.moving_image_registered = None
 
@@ -289,11 +289,12 @@ class RegisterImagesBase(MONAIPhysioBase):
 
         Returns:
             dict: Dictionary containing:
-                - "forward_transform": Warps the moving image onto the fixed
-                  grid. Warping moving points/landmarks into fixed space uses
-                  "inverse_transform" instead (see register() and
+                - "fixed_to_moving_transform": Warps the moving image onto the
+                  fixed grid. Warping moving points/landmarks into fixed space
+                  uses "moving_to_fixed_transform" instead (see register() and
                   docs/developer/transform_conventions).
-                - "inverse_transform": Warps the fixed image onto the moving grid
+                - "moving_to_fixed_transform": Warps the fixed image onto the
+                  moving grid
                 - "loss": Registration loss/metric value
 
         Raises:
@@ -325,10 +326,12 @@ class RegisterImagesBase(MONAIPhysioBase):
 
         Returns:
             dict: Dictionary containing transformation results:
-                - "forward_transform": Warps the moving IMAGE onto the fixed
-                  grid, i.e. transform_image(moving, forward_transform, fixed).
-                - "inverse_transform": Warps the fixed IMAGE onto the moving
-                  grid, i.e. transform_image(fixed, inverse_transform, moving).
+                - "fixed_to_moving_transform": Warps the moving IMAGE onto the
+                  fixed grid, i.e.
+                  transform_image(moving, fixed_to_moving_transform, fixed).
+                - "moving_to_fixed_transform": Warps the fixed IMAGE onto the
+                  moving grid, i.e.
+                  transform_image(fixed, moving_to_fixed_transform, moving).
                 - "loss": Registration loss/metric value
 
         Note:
@@ -337,10 +340,10 @@ class RegisterImagesBase(MONAIPhysioBase):
             fixed-grid sample to the moving image) while point transforms push
             forward (they map a point to its corresponding location):
 
-            - Warp the moving image into fixed space  -> forward_transform
-            - Warp moving points/landmarks into fixed  -> inverse_transform
-            - Warp the fixed image into moving space   -> inverse_transform
-            - Warp fixed points/landmarks into moving   -> forward_transform
+            - Warp the moving image into fixed space  -> fixed_to_moving_transform
+            - Warp moving points/landmarks into fixed  -> moving_to_fixed_transform
+            - Warp the fixed image into moving space   -> moving_to_fixed_transform
+            - Warp fixed points/landmarks into moving   -> fixed_to_moving_transform
 
             See docs/developer/transform_conventions for the full discussion.
 
@@ -348,8 +351,8 @@ class RegisterImagesBase(MONAIPhysioBase):
             NotImplementedError: This method must be implemented by subclasses
         """
         self.moving_image_registered = None
-        self.forward_transform = None
-        self.inverse_transform = None
+        self.fixed_to_moving_transform = None
+        self.moving_to_fixed_transform = None
         self.loss = None
 
         if self.fixed_image_pre is None:
@@ -383,19 +386,19 @@ class RegisterImagesBase(MONAIPhysioBase):
             moving_image_pre=moving_image_pre,
         )
 
-        self.forward_transform = result["forward_transform"]
-        self.inverse_transform = result["inverse_transform"]
+        self.fixed_to_moving_transform = result["fixed_to_moving_transform"]
+        self.moving_to_fixed_transform = result["moving_to_fixed_transform"]
         self.loss = result["loss"]
 
         return {
-            "forward_transform": self.forward_transform,
-            "inverse_transform": self.inverse_transform,
+            "fixed_to_moving_transform": self.fixed_to_moving_transform,
+            "moving_to_fixed_transform": self.moving_to_fixed_transform,
             "loss": self.loss,
         }
 
     def register_from(
         self,
-        initial_forward_transform: itk.Transform,
+        initial_fixed_to_moving_transform: itk.Transform,
         moving_image: itk.Image,
         moving_mask: Optional[itk.Image] = None,
         moving_labelmap: Optional[itk.Image] = None,
@@ -403,20 +406,20 @@ class RegisterImagesBase(MONAIPhysioBase):
         """Register starting from a known alignment.
 
         The moving data is warped onto the fixed grid by
-        ``initial_forward_transform`` first, :meth:`register` then measures only
-        the residual misalignment, and the two are composed. This is the single
-        supported way to seed a registration: doing it here rather than inside
-        each backend keeps the pre-warp, the composition and the inversion
-        identical for every algorithm.
+        ``initial_fixed_to_moving_transform`` first, :meth:`register` then
+        measures only the residual misalignment, and the two are composed.
+        This is the single supported way to seed a registration: doing it
+        here rather than inside each backend keeps the pre-warp, the
+        composition and the inversion identical for every algorithm.
 
         The image, the mask and the labelmap are all pre-warped, so they stay in
         the same frame as each other; the mask and labelmap use nearest-neighbor
         interpolation to preserve their discrete values.
 
         Args:
-            initial_forward_transform: Starting alignment, in the same
-                convention as the returned ``forward_transform`` -- it warps the
-                moving image onto the fixed grid.
+            initial_fixed_to_moving_transform: Starting alignment, in the same
+                convention as the returned ``fixed_to_moving_transform`` -- it
+                warps the moving image onto the fixed grid.
             moving_image: The 3D image to be registered to the fixed image.
             moving_mask: Binary mask for the moving image ROI.
             moving_labelmap: Multi-label segmentation for the moving image.
@@ -429,7 +432,10 @@ class RegisterImagesBase(MONAIPhysioBase):
             ValueError: If the fixed image has not been set.
         """
         warped_image, warped_mask, warped_labelmap = self._prewarp_moving(
-            initial_forward_transform, moving_image, moving_mask, moving_labelmap
+            initial_fixed_to_moving_transform,
+            moving_image,
+            moving_mask,
+            moving_labelmap,
         )
         result = self.register(
             warped_image,
@@ -437,7 +443,7 @@ class RegisterImagesBase(MONAIPhysioBase):
             moving_labelmap=warped_labelmap,
         )
         composed = self._compose_with_initial(
-            initial_forward_transform, result, moving_image
+            initial_fixed_to_moving_transform, result, moving_image
         )
 
         # register() left the pre-warped image on self; the composed transforms
@@ -446,14 +452,14 @@ class RegisterImagesBase(MONAIPhysioBase):
         self.moving_image = moving_image
         self.moving_image_registered = None
 
-        self.forward_transform = composed["forward_transform"]
-        self.inverse_transform = composed["inverse_transform"]
+        self.fixed_to_moving_transform = composed["fixed_to_moving_transform"]
+        self.moving_to_fixed_transform = composed["moving_to_fixed_transform"]
         self.loss = composed["loss"]
         return composed
 
     def _prewarp_moving(
         self,
-        initial_forward_transform: itk.Transform,
+        initial_fixed_to_moving_transform: itk.Transform,
         moving_image: itk.Image,
         moving_mask: Optional[itk.Image],
         moving_labelmap: Optional[itk.Image],
@@ -461,8 +467,8 @@ class RegisterImagesBase(MONAIPhysioBase):
         """Warp the moving image, mask and labelmap onto the fixed grid.
 
         Args:
-            initial_forward_transform: Alignment to apply, in the image-warp
-                convention.
+            initial_fixed_to_moving_transform: Alignment to apply, in the
+                image-warp convention.
             moving_image: Raw moving image.
             moving_mask: Moving mask, or None.
             moving_labelmap: Moving labelmap, or None.
@@ -493,7 +499,7 @@ class RegisterImagesBase(MONAIPhysioBase):
                 return None
             return transform_tools.transform_image(
                 image,
-                initial_forward_transform,
+                initial_fixed_to_moving_transform,
                 self.fixed_image,
                 interpolation_method="nearest" if nearest else "linear",
                 background_value=0.0 if nearest else background_value,
@@ -507,15 +513,15 @@ class RegisterImagesBase(MONAIPhysioBase):
 
     def _compose_with_initial(
         self,
-        initial_forward_transform: itk.Transform,
+        initial_fixed_to_moving_transform: itk.Transform,
         result: dict[str, Union[itk.Transform, float]],
         moving_image: itk.Image,
     ) -> dict[str, Union[itk.Transform, float]]:
         """Compose a residual registration result onto its initial transform.
 
         Args:
-            initial_forward_transform: The alignment the moving data was
-                pre-warped by.
+            initial_fixed_to_moving_transform: The alignment the moving data
+                was pre-warped by.
             result: Result of registering the pre-warped data.
             moving_image: Raw moving image, whose grid defines the domain the
                 initial transform is inverted over.
@@ -536,10 +542,13 @@ class RegisterImagesBase(MONAIPhysioBase):
         # which is what the image-warp direction needs: a fixed-grid sample is
         # mapped by the residual, then by the initial transform, to land in the
         # original moving image.
-        forward_transform = itk.CompositeTransform[itk.D, 3].New()
-        self._add_transform_flattened(forward_transform, initial_forward_transform)
+        fixed_to_moving_transform = itk.CompositeTransform[itk.D, 3].New()
         self._add_transform_flattened(
-            forward_transform, cast(itk.Transform, result["forward_transform"])
+            fixed_to_moving_transform, initial_fixed_to_moving_transform
+        )
+        self._add_transform_flattened(
+            fixed_to_moving_transform,
+            cast(itk.Transform, result["fixed_to_moving_transform"]),
         )
 
         # The inverse runs the other way -- a moving-grid sample is mapped by the
@@ -547,17 +556,18 @@ class RegisterImagesBase(MONAIPhysioBase):
         # residual's inverse into the fixed image -- so the additions are
         # reversed too.
         initial_inverse = transform_tools.invert_transform(
-            initial_forward_transform, moving_image
+            initial_fixed_to_moving_transform, moving_image
         )
-        inverse_transform = itk.CompositeTransform[itk.D, 3].New()
+        moving_to_fixed_transform = itk.CompositeTransform[itk.D, 3].New()
         self._add_transform_flattened(
-            inverse_transform, cast(itk.Transform, result["inverse_transform"])
+            moving_to_fixed_transform,
+            cast(itk.Transform, result["moving_to_fixed_transform"]),
         )
-        self._add_transform_flattened(inverse_transform, initial_inverse)
+        self._add_transform_flattened(moving_to_fixed_transform, initial_inverse)
 
         return {
-            "forward_transform": forward_transform,
-            "inverse_transform": inverse_transform,
+            "fixed_to_moving_transform": fixed_to_moving_transform,
+            "moving_to_fixed_transform": moving_to_fixed_transform,
             "loss": result["loss"],
         }
 
@@ -659,8 +669,12 @@ class RegisterImagesBase(MONAIPhysioBase):
                 ``result``.
             result: The dict returned by ``other.registration_method(...)``.
         """
-        other.forward_transform = cast(itk.Transform, result["forward_transform"])
-        other.inverse_transform = cast(itk.Transform, result["inverse_transform"])
+        other.fixed_to_moving_transform = cast(
+            itk.Transform, result["fixed_to_moving_transform"]
+        )
+        other.moving_to_fixed_transform = cast(
+            itk.Transform, result["moving_to_fixed_transform"]
+        )
         other.loss = cast(float, result["loss"])
         other.moving_image_registered = None
 
@@ -678,7 +692,7 @@ class RegisterImagesBase(MONAIPhysioBase):
             TfmTools = TransformTools()
             self.moving_image_registered = TfmTools.transform_image(
                 self.moving_image,
-                self.forward_transform,
+                self.fixed_to_moving_transform,
                 self.fixed_image,
                 background_value=self._prewarp_background_value(self.moving_image),
             )

--- a/src/monai_physio/register_images_chain.py
+++ b/src/monai_physio/register_images_chain.py
@@ -15,7 +15,7 @@ from .register_images_base import RegisterImagesBase
 
 class RegisterImagesChain(RegisterImagesBase):
     """Run an ordered list of registrars in sequence, each stage refining the
-    previous stage's forward_transform via
+    previous stage's fixed_to_moving_transform via
     :meth:`RegisterImagesBase.register_from`.
 
     Use this to combine independent registration backends into a multi-stage
@@ -135,6 +135,6 @@ class RegisterImagesChain(RegisterImagesBase):
                     current_forward, stage_result, moving_image
                 )
             )
-            current_forward = cast(itk.Transform, result["forward_transform"])
+            current_forward = cast(itk.Transform, result["fixed_to_moving_transform"])
 
         return result

--- a/src/monai_physio/register_images_greedy.py
+++ b/src/monai_physio/register_images_greedy.py
@@ -433,10 +433,10 @@ class RegisterImagesGreedy(RegisterImagesBase):
         Converts ITK images to SimpleITK, runs Greedy (affine and/or deformable),
         then converts outputs back to ITK transforms.
 
-        Returns a dict with "forward_transform", "inverse_transform", and
+        Returns a dict with "fixed_to_moving_transform", "moving_to_fixed_transform", and
         "loss". As with the other image-registration backends,
-        forward_transform warps the moving image onto the fixed grid and
-        inverse_transform warps the fixed image onto the moving grid; point and
+        fixed_to_moving_transform warps the moving image onto the fixed grid and
+        moving_to_fixed_transform warps the fixed image onto the moving grid; point and
         landmark warps use the opposite transform from image warps (see
         docs/developer/transform_conventions).
         """
@@ -497,8 +497,8 @@ class RegisterImagesGreedy(RegisterImagesBase):
         iterations_str = self._greedy_iterations_str()
         metric_str = self._greedy_metric()
 
-        forward_transform: itk.Transform
-        inverse_transform: itk.Transform
+        fixed_to_moving_transform: itk.Transform
+        moving_to_fixed_transform: itk.Transform
         loss_val: float
 
         if self.transform_type == "Rigid":
@@ -513,10 +513,10 @@ class RegisterImagesGreedy(RegisterImagesBase):
                 metric_str=metric_str,
                 dof=6,
             )
-            forward_transform = self._matrix_to_itk_affine(mat)
+            fixed_to_moving_transform = self._matrix_to_itk_affine(mat)
             inverse_affine = itk.AffineTransform[itk.D, 3].New()
-            forward_transform.GetInverse(inverse_affine)
-            inverse_transform = inverse_affine
+            fixed_to_moving_transform.GetInverse(inverse_affine)
+            moving_to_fixed_transform = inverse_affine
         elif self.transform_type == "Affine":
             mat, loss_val = self._registration_method_affine_or_rigid(
                 fixed_sitk,
@@ -529,10 +529,10 @@ class RegisterImagesGreedy(RegisterImagesBase):
                 metric_str=metric_str,
                 dof=12,
             )
-            forward_transform = self._matrix_to_itk_affine(mat)
+            fixed_to_moving_transform = self._matrix_to_itk_affine(mat)
             inverse_affine = itk.AffineTransform[itk.D, 3].New()
-            forward_transform.GetInverse(inverse_affine)
-            inverse_transform = inverse_affine
+            fixed_to_moving_transform.GetInverse(inverse_affine)
+            moving_to_fixed_transform = inverse_affine
         else:
             # Deformable: affine + warp
             aff_mat, warp_sitk, loss_val = self._registration_method_deformable(
@@ -565,17 +565,17 @@ class RegisterImagesGreedy(RegisterImagesBase):
                 )
                 disp_tfm = itk.DisplacementFieldTransform[itk.D, 3].New()
                 disp_tfm.SetDisplacementField(disp_itk)
-            # forward_transform is consumed by transform_image(moving, ...,
+            # fixed_to_moving_transform is consumed by transform_image(moving, ...,
             # fixed) to warp the moving image onto the fixed grid, so it holds
             # Greedy's raw affine+warp (Greedy applies the affine first, then
-            # the warp). inverse_transform is the numerically inverted field,
+            # the warp). moving_to_fixed_transform is the numerically inverted field,
             # used to warp the fixed image onto the moving grid. This matches
             # RegisterImagesANTS/ICON and RegisterTimeSeriesImages.
             forward_composite = itk.CompositeTransform[itk.D, 3].New()
             if aff_tfm is not None:
                 forward_composite.AddTransform(aff_tfm)
             forward_composite.AddTransform(disp_tfm)
-            forward_transform = forward_composite
+            fixed_to_moving_transform = forward_composite
             inv_disp = TransformTools().invert_displacement_field_transform(disp_tfm)
             inv_aff = itk.AffineTransform[itk.D, 3].New()
             if aff_tfm is not None:
@@ -584,10 +584,10 @@ class RegisterImagesGreedy(RegisterImagesBase):
             inverse_composite.AddTransform(inv_disp)
             if aff_tfm is not None:
                 inverse_composite.AddTransform(inv_aff)
-            inverse_transform = inverse_composite
+            moving_to_fixed_transform = inverse_composite
 
         return {
-            "forward_transform": forward_transform,
-            "inverse_transform": inverse_transform,
+            "fixed_to_moving_transform": fixed_to_moving_transform,
+            "moving_to_fixed_transform": moving_to_fixed_transform,
             "loss": loss_val,
         }

--- a/src/monai_physio/register_images_greedy_icon.py
+++ b/src/monai_physio/register_images_greedy_icon.py
@@ -13,7 +13,7 @@ from .register_images_icon import RegisterImagesICON
 
 class RegisterImagesGreedyICON(RegisterImagesChain):
     """Greedy registration followed by ICON refinement, using Greedy's
-    forward_transform to initialize ICON.
+    fixed_to_moving_transform to initialize ICON.
 
     Access the two stages by name via ``.greedy``/``.icon`` (e.g.
     ``RegisterImagesGreedyICON().greedy.set_number_of_iterations([30, 15, 7, 3])``)

--- a/src/monai_physio/register_images_icon.py
+++ b/src/monai_physio/register_images_icon.py
@@ -77,7 +77,7 @@ class RegisterImagesICON(RegisterImagesBase):
         >>> registrar.set_modality('ct')
         >>> registrar.set_fixed_image(reference_image)
         >>> result = registrar.register(moving_image)
-        >>> forward_transform = result['forward_transform']
+        >>> fixed_to_moving_transform = result['fixed_to_moving_transform']
     """
 
     # Networks already built in this process, keyed by everything that changes
@@ -231,19 +231,19 @@ class RegisterImagesICON(RegisterImagesBase):
 
         Returns:
             dict: Dictionary containing:
-                - "forward_transform": Warps the moving image onto the fixed
+                - "fixed_to_moving_transform": Warps the moving image onto the fixed
                   grid (warping moving points/landmarks into fixed space uses
-                  "inverse_transform" instead -- image and point warps use
+                  "moving_to_fixed_transform" instead -- image and point warps use
                   opposite transforms; see
                   docs/developer/transform_conventions)
-                - "inverse_transform": Warps the fixed image onto the moving grid
+                - "moving_to_fixed_transform": Warps the fixed image onto the moving grid
                 - "loss": Loss value from the registration
 
         Note:
             The transformations are inverse consistent, meaning
-            forward_transform is approximately inverse(inverse_transform).
-            Use forward_transform to warp the moving image onto the fixed grid,
-            and inverse_transform to warp the fixed image onto the moving grid.
+            fixed_to_moving_transform is approximately inverse(moving_to_fixed_transform).
+            Use fixed_to_moving_transform to warp the moving image onto the fixed grid,
+            and moving_to_fixed_transform to warp the fixed image onto the moving grid.
             Point/landmark warps use the opposite transform from image warps
             (see docs/developer/transform_conventions).
 
@@ -257,8 +257,8 @@ class RegisterImagesICON(RegisterImagesBase):
         Example:
             >>> # Basic registration
             >>> result = registrar.register(moving_image)
-            >>> forward_transform = result['forward_transform']
-            >>> inverse_transform = result['inverse_transform']
+            >>> fixed_to_moving_transform = result['fixed_to_moving_transform']
+            >>> moving_to_fixed_transform = result['moving_to_fixed_transform']
             >>>
             >>> # Masked registration for cardiac structures
             >>> registrar.set_fixed_mask(heart_mask_fixed)
@@ -277,12 +277,12 @@ class RegisterImagesICON(RegisterImagesBase):
 
         self._ensure_net()
 
-        inverse_transform = None
-        forward_transform = None
+        moving_to_fixed_transform = None
+        fixed_to_moving_transform = None
         loss_artifacts = None
         _, icon_itk_wrapper, _, _, _, _, _ = _load_icon()
         if fixed_effective_mask is not None and moving_effective_mask is not None:
-            inverse_transform, forward_transform, loss_artifacts = (
+            moving_to_fixed_transform, fixed_to_moving_transform, loss_artifacts = (
                 icon_itk_wrapper.register_pair_with_mask(
                     self.net,
                     self.fixed_image_pre,
@@ -294,7 +294,7 @@ class RegisterImagesICON(RegisterImagesBase):
                 )
             )
         else:
-            inverse_transform, forward_transform, loss_artifacts = (
+            moving_to_fixed_transform, fixed_to_moving_transform, loss_artifacts = (
                 icon_itk_wrapper.register_pair(
                     self.net,
                     self.fixed_image_pre,
@@ -307,8 +307,8 @@ class RegisterImagesICON(RegisterImagesBase):
         loss = loss_artifacts[0]
 
         return {
-            "forward_transform": forward_transform,
-            "inverse_transform": inverse_transform,
+            "fixed_to_moving_transform": fixed_to_moving_transform,
+            "moving_to_fixed_transform": moving_to_fixed_transform,
             "loss": loss,
         }
 

--- a/src/monai_physio/register_models_distance_maps.py
+++ b/src/monai_physio/register_models_distance_maps.py
@@ -91,8 +91,8 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         contour_tools (ContourTools): Model utility instance
         registrar_Greedy (RegisterImagesGreedy): Greedy registration instance
         registrar_ICON (RegisterImagesICON): ICON registration instance
-        fixed_to_moving_transform (itk.CompositeTransform): Optimized moving→fixed transform
-        moving_to_fixed_transform (itk.CompositeTransform): Optimized fixed→moving transform
+        fixed_to_moving_transform (itk.CompositeTransform): Optimized fixed-to-moving transform
+        moving_to_fixed_transform (itk.CompositeTransform): Optimized moving-to-fixed transform
         registered_model (pv.PolyData): Aligned moving model
 
     Example:
@@ -173,10 +173,10 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
 
         # Registration results
         self.fixed_to_moving_transform: Optional[itk.CompositeTransform] = (
-            None  # Moving→fixed
+            None  # Fixed-to-moving
         )
         self.moving_to_fixed_transform: Optional[itk.CompositeTransform] = (
-            None  # Fixed→moving
+            None  # Moving-to-fixed
         )
         self.registered_model: Optional[pv.PolyData] = None
 
@@ -359,8 +359,8 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         Returns:
             Dictionary containing:
                 - 'registered_model': Aligned moving model (PyVista PolyData)
-                - 'fixed_to_moving_transform': Moving→fixed transform (ITK CompositeTransform)
-                - 'moving_to_fixed_transform': Fixed→moving transform (ITK CompositeTransform)
+                - 'fixed_to_moving_transform': Fixed-to-moving transform (ITK CompositeTransform)
+                - 'moving_to_fixed_transform': Moving-to-fixed transform (ITK CompositeTransform)
 
         Raises:
             ValueError: If transform_type is not 'None', 'Rigid', 'Affine', or 'Deformable'
@@ -462,10 +462,10 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
             # Compose Greedy affine + ICON deformable.
             # ICON runs on images already resampled to the patient (fixed) grid,
             # so its transforms are deformations within patient space.
-            # Forward (fixed→moving for image pull-back): apply ICON first
-            # (patient-space δ), then Greedy (patient→ICP-template).
-            # Inverse (moving→fixed for point push-forward): apply Greedy first
-            # (ICP-template→patient), then ICON (patient-space refinement).
+            # fixed_to_moving_transform (image pull-back): apply ICON first
+            # (patient-space delta), then Greedy (patient-to-ICP-template).
+            # moving_to_fixed_transform (point push-forward): apply Greedy first
+            # (ICP-template-to-patient), then ICON (patient-space refinement).
             # combine_displacement_field_transforms(a, b) evaluates b then a, so
             # the stage that runs first is the second argument.
             self.fixed_to_moving_transform = (

--- a/src/monai_physio/register_models_distance_maps.py
+++ b/src/monai_physio/register_models_distance_maps.py
@@ -39,7 +39,7 @@ Example:
     >>>
     >>> # Access results
     >>> aligned_model = result['registered_model']
-    >>> forward_transform = result['forward_transform']  # warps moving image -> fixed grid
+    >>> fixed_to_moving_transform = result['fixed_to_moving_transform']  # warps moving image -> fixed grid
 """
 
 import logging
@@ -75,11 +75,11 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         they follow the image convention (see
         docs/developer/transform_conventions):
 
-        - forward_transform: warps the moving image/mask onto the fixed grid.
+        - fixed_to_moving_transform: warps the moving image/mask onto the fixed grid.
           Warping the moving MODEL points/landmarks onto the fixed model uses
-          inverse_transform instead (image and point warps use opposite
+          moving_to_fixed_transform instead (image and point warps use opposite
           transforms).
-        - inverse_transform: warps the fixed image/mask onto the moving grid.
+        - moving_to_fixed_transform: warps the fixed image/mask onto the moving grid.
 
     Attributes:
         moving_model (pv.PolyData): Surface model to be aligned
@@ -91,8 +91,8 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         contour_tools (ContourTools): Model utility instance
         registrar_Greedy (RegisterImagesGreedy): Greedy registration instance
         registrar_ICON (RegisterImagesICON): ICON registration instance
-        forward_transform (itk.CompositeTransform): Optimized moving→fixed transform
-        inverse_transform (itk.CompositeTransform): Optimized fixed→moving transform
+        fixed_to_moving_transform (itk.CompositeTransform): Optimized moving→fixed transform
+        moving_to_fixed_transform (itk.CompositeTransform): Optimized fixed→moving transform
         registered_model (pv.PolyData): Aligned moving model
 
     Example:
@@ -115,7 +115,7 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         >>>
         >>> # Get aligned model and transforms
         >>> aligned_model = result['registered_model']
-        >>> forward_transform = result['forward_transform']
+        >>> fixed_to_moving_transform = result['fixed_to_moving_transform']
     """
 
     def __init__(
@@ -172,8 +172,12 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         self.moving_mask_image: Optional[itk.Image] = None
 
         # Registration results
-        self.forward_transform: Optional[itk.CompositeTransform] = None  # Moving→fixed
-        self.inverse_transform: Optional[itk.CompositeTransform] = None  # Fixed→moving
+        self.fixed_to_moving_transform: Optional[itk.CompositeTransform] = (
+            None  # Moving→fixed
+        )
+        self.moving_to_fixed_transform: Optional[itk.CompositeTransform] = (
+            None  # Fixed→moving
+        )
         self.registered_model: Optional[pv.PolyData] = None
 
     def set_icon_weights_path(self, weights_path: str) -> None:
@@ -355,8 +359,8 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         Returns:
             Dictionary containing:
                 - 'registered_model': Aligned moving model (PyVista PolyData)
-                - 'forward_transform': Moving→fixed transform (ITK CompositeTransform)
-                - 'inverse_transform': Fixed→moving transform (ITK CompositeTransform)
+                - 'fixed_to_moving_transform': Moving→fixed transform (ITK CompositeTransform)
+                - 'moving_to_fixed_transform': Fixed→moving transform (ITK CompositeTransform)
 
         Raises:
             ValueError: If transform_type is not 'None', 'Rigid', 'Affine', or 'Deformable'
@@ -384,8 +388,8 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         # Step 2: Greedy rigid or affine stage (skipped for None/Deformable uses Affine)
         greedy_type = "Affine" if transform_type == "Deformable" else transform_type
 
-        forward_transform_Greedy = None
-        inverse_transform_Greedy = None
+        fixed_to_moving_transform_Greedy = None
+        moving_to_fixed_transform_Greedy = None
         greedy_loss: Optional[float] = None
         if greedy_type != "None":
             self.log_info("Performing Greedy %s registration...", greedy_type)
@@ -398,17 +402,21 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
                 moving_image=self.moving_distance_map_image,
                 moving_mask=self.moving_mask_image,
             )
-            forward_transform_Greedy = result_Greedy["forward_transform"]
-            inverse_transform_Greedy = result_Greedy["inverse_transform"]
+            fixed_to_moving_transform_Greedy = result_Greedy[
+                "fixed_to_moving_transform"
+            ]
+            moving_to_fixed_transform_Greedy = result_Greedy[
+                "moving_to_fixed_transform"
+            ]
             greedy_loss = result_Greedy.get("loss")
         else:
             identity_transform = itk.AffineTransform[itk.D, 3].New()
             identity_transform.SetIdentity()
-            forward_transform_Greedy = identity_transform
-            inverse_transform_Greedy = identity_transform
+            fixed_to_moving_transform_Greedy = identity_transform
+            moving_to_fixed_transform_Greedy = identity_transform
 
-        self.forward_transform = forward_transform_Greedy
-        self.inverse_transform = inverse_transform_Greedy
+        self.fixed_to_moving_transform = fixed_to_moving_transform_Greedy
+        self.moving_to_fixed_transform = moving_to_fixed_transform_Greedy
 
         # Step 3: ICON deformable stage (only for Deformable mode)
         if transform_type == "Deformable":
@@ -418,7 +426,7 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
             moving_distance_map_affine_transformed = (
                 self.transform_tools.transform_image(
                     self.moving_distance_map_image,
-                    forward_transform_Greedy,
+                    fixed_to_moving_transform_Greedy,
                     self.reference_image,
                     interpolation_method="linear",
                 )
@@ -434,7 +442,7 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
             )
             # moving_mask_affine_transformed = self.transform_tools.transform_image(
             # self.moving_mask_image,
-            # forward_transform_Greedy,
+            # fixed_to_moving_transform_Greedy,
             # self.reference_image,
             # interpolation_method="nearest",
             # )
@@ -448,8 +456,8 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
                 moving_image=moving_distance_map_affine_transformed,
                 # moving_mask=moving_mask_affine_transformed,
             )
-            forward_transform_ICON = result_ICON["forward_transform"]
-            inverse_transform_ICON = result_ICON["inverse_transform"]
+            fixed_to_moving_transform_ICON = result_ICON["fixed_to_moving_transform"]
+            moving_to_fixed_transform_ICON = result_ICON["moving_to_fixed_transform"]
 
             # Compose Greedy affine + ICON deformable.
             # ICON runs on images already resampled to the patient (fixed) grid,
@@ -460,18 +468,18 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
             # (ICP-template→patient), then ICON (patient-space refinement).
             # combine_displacement_field_transforms(a, b) evaluates b then a, so
             # the stage that runs first is the second argument.
-            self.forward_transform = (
+            self.fixed_to_moving_transform = (
                 self.transform_tools.combine_displacement_field_transforms(
-                    forward_transform_Greedy,
-                    forward_transform_ICON,
+                    fixed_to_moving_transform_Greedy,
+                    fixed_to_moving_transform_ICON,
                     reference_image=self.reference_image,
                     mode="compose",
                 )
             )
-            self.inverse_transform = (
+            self.moving_to_fixed_transform = (
                 self.transform_tools.combine_displacement_field_transforms(
-                    inverse_transform_ICON,
-                    inverse_transform_Greedy,
+                    moving_to_fixed_transform_ICON,
+                    moving_to_fixed_transform_Greedy,
                     reference_image=self.reference_image,
                     mode="compose",
                 )
@@ -481,7 +489,7 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         self.log_info("Transforming moving model...")
         self.registered_model = self.transform_tools.transform_pvcontour(
             self.moving_model,
-            self.inverse_transform,
+            self.moving_to_fixed_transform,
             with_deformation_magnitude=True,
         )
 
@@ -493,8 +501,8 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
 
         # Return results as dictionary
         return {
-            "forward_transform": self.forward_transform,
-            "inverse_transform": self.inverse_transform,
+            "fixed_to_moving_transform": self.fixed_to_moving_transform,
+            "moving_to_fixed_transform": self.moving_to_fixed_transform,
             "registered_model": self.registered_model,
         }
 
@@ -508,7 +516,7 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         of any size the peak is set by how much is still reachable rather than by
         how much any one registration needs.
 
-        Only the working set goes.  ``forward_transform``, ``inverse_transform``
+        Only the working set goes.  ``fixed_to_moving_transform``, ``moving_to_fixed_transform``
         and ``registered_model`` are the result and are left alone.
         """
         self.fixed_distance_map_image = None
@@ -527,5 +535,5 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
             registrar.moving_image_registered = None
             # The composed result above no longer refers to these, and each is a
             # dense field on the reference grid.
-            registrar.forward_transform = None
-            registrar.inverse_transform = None
+            registrar.fixed_to_moving_transform = None
+            registrar.moving_to_fixed_transform = None

--- a/src/monai_physio/register_models_icp.py
+++ b/src/monai_physio/register_models_icp.py
@@ -82,8 +82,8 @@ class RegisterModelsICP(MONAIPhysioBase):
         moving_model (pv.PolyData): Surface model to be aligned
         fixed_model (pv.PolyData): Target surface model
         transform_tools (TransformTools): Transform utility instance
-        moving_to_fixed_transform (itk.AffineTransform): Optimized moving→fixed transform
-        fixed_to_moving_transform (itk.AffineTransform): Optimized fixed→moving transform
+        moving_to_fixed_transform (itk.AffineTransform): Optimized moving-to-fixed transform
+        fixed_to_moving_transform (itk.AffineTransform): Optimized fixed-to-moving transform
         registered_model (pv.PolyData): Aligned moving model
 
     Example:
@@ -158,8 +158,8 @@ class RegisterModelsICP(MONAIPhysioBase):
             max_iterations: Maximum ICP iterations for this stage.
 
         Returns:
-            Tuple of the transformed model and this stage's moving→fixed point
-            transform.
+            Tuple of the transformed model and this stage's moving-to-fixed
+            point transform.
         """
         icp = vtk.vtkIterativeClosestPointTransform()
         icp.SetSource(model)
@@ -289,9 +289,9 @@ class RegisterModelsICP(MONAIPhysioBase):
         Returns:
             Dictionary containing:
                 - 'registered_model': Aligned moving model (PyVista PolyData)
-                - 'moving_to_fixed_transform': Moving→fixed transform
+                - 'moving_to_fixed_transform': Moving-to-fixed transform
                     (ITK AffineTransform)
-                - 'fixed_to_moving_transform': Fixed→moving transform
+                - 'fixed_to_moving_transform': Fixed-to-moving transform
                     (ITK AffineTransform)
 
         Raises:

--- a/src/monai_physio/register_models_icp.py
+++ b/src/monai_physio/register_models_icp.py
@@ -35,7 +35,7 @@ Example:
     >>>
     >>> # Access results
     >>> aligned_model = result['registered_model']
-    >>> forward_point_transform = result['forward_point_transform']  # Moving to fixed
+    >>> moving_to_fixed_transform = result['moving_to_fixed_transform']  # Moving to fixed
         # transform
 """
 
@@ -70,23 +70,20 @@ class RegisterModelsICP(MONAIPhysioBase):
         whose transform has no scale degree of freedom.
 
     **Transform Convention:**
-        These are POINT transforms (applied with TransformPoint, e.g. via
-        TransformTools.transform_pvcontour), so their orientation is opposite to
-        the image-registration transforms (see
-        docs/developer/transform_conventions):
+        These are POINT transforms, applied with TransformPoint (e.g. via
+        TransformTools.transform_pvcontour); see
+        docs/developer/transform_conventions:
 
-        - forward_point_transform: maps moving points -> fixed points; use it to
-          warp the moving model/landmarks onto the fixed model. This is the
-          inverse of the transform that would warp the moving IMAGE onto the
-          fixed grid.
-        - inverse_point_transform: maps fixed points -> moving points.
+        - moving_to_fixed_transform: maps moving points -> fixed points; use it to
+          warp the moving model/landmarks onto the fixed model.
+        - fixed_to_moving_transform: maps fixed points -> moving points.
 
     Attributes:
         moving_model (pv.PolyData): Surface model to be aligned
         fixed_model (pv.PolyData): Target surface model
         transform_tools (TransformTools): Transform utility instance
-        forward_point_transform (itk.AffineTransform): Optimized moving→fixed transform
-        inverse_point_transform (itk.AffineTransform): Optimized fixed→moving transform
+        moving_to_fixed_transform (itk.AffineTransform): Optimized moving→fixed transform
+        fixed_to_moving_transform (itk.AffineTransform): Optimized fixed→moving transform
         registered_model (pv.PolyData): Aligned moving model
 
     Example:
@@ -109,7 +106,7 @@ class RegisterModelsICP(MONAIPhysioBase):
         >>>
         >>> # Get aligned model and transforms
         >>> aligned_model = result['registered_model']
-        >>> forward_point_transform = result['forward_point_transform']
+        >>> moving_to_fixed_transform = result['moving_to_fixed_transform']
     """
 
     def __init__(
@@ -138,8 +135,8 @@ class RegisterModelsICP(MONAIPhysioBase):
         self.transform_tools = TransformTools()
 
         # Registration results
-        self.forward_point_transform: Optional[itk.AffineTransform] = None
-        self.inverse_point_transform: Optional[itk.AffineTransform] = None
+        self.moving_to_fixed_transform: Optional[itk.AffineTransform] = None
+        self.fixed_to_moving_transform: Optional[itk.AffineTransform] = None
         self.registered_model: Optional[pv.PolyData] = None
 
     # ICP stages run for each transform type, in order.
@@ -292,9 +289,9 @@ class RegisterModelsICP(MONAIPhysioBase):
         Returns:
             Dictionary containing:
                 - 'registered_model': Aligned moving model (PyVista PolyData)
-                - 'forward_point_transform': Moving→fixed transform
+                - 'moving_to_fixed_transform': Moving→fixed transform
                     (ITK AffineTransform)
-                - 'inverse_point_transform': Fixed→moving transform
+                - 'fixed_to_moving_transform': Fixed→moving transform
                     (ITK AffineTransform)
 
         Raises:
@@ -344,14 +341,14 @@ class RegisterModelsICP(MONAIPhysioBase):
         self.log_info("Translating by %s to align centroids...", translation)
 
         # Create ITK affine transform with translation
-        forward_point_transform = itk.AffineTransform[itk.D, 3].New()
-        forward_point_transform.SetIdentity()
-        forward_point_transform.SetOffset(translation)
+        moving_to_fixed_transform = itk.AffineTransform[itk.D, 3].New()
+        moving_to_fixed_transform.SetIdentity()
+        moving_to_fixed_transform.SetOffset(translation)
 
         # Apply centroid alignment to model
         registered_model = self.transform_tools.transform_pvcontour(
             registered_model,
-            forward_point_transform,
+            moving_to_fixed_transform,
             with_deformation_magnitude=False,
         )
 
@@ -371,7 +368,7 @@ class RegisterModelsICP(MONAIPhysioBase):
                 scale,
             )
             scale_transform = self._scale_transform(scale, fixed_centroid)
-            forward_point_transform.Compose(scale_transform)
+            moving_to_fixed_transform.Compose(scale_transform)
             registered_model = self.transform_tools.transform_pvcontour(
                 registered_model,
                 scale_transform,
@@ -391,21 +388,21 @@ class RegisterModelsICP(MONAIPhysioBase):
             registered_model, stage_transform = self._icp_stage(
                 registered_model, stage, max_iterations
             )
-            forward_point_transform.Compose(stage_transform)
+            moving_to_fixed_transform.Compose(stage_transform)
             self.log_debug("Center after %s ICP: %s", stage, registered_model.center)
 
         # Compute inverse transform
         # Ths forward transform for ICP is consistent with the transform convention
         # used with images-to-images registration.
         self.registered_model = registered_model
-        self.forward_point_transform = forward_point_transform
-        self.inverse_point_transform = forward_point_transform.GetInverseTransform()
+        self.moving_to_fixed_transform = moving_to_fixed_transform
+        self.fixed_to_moving_transform = moving_to_fixed_transform.GetInverseTransform()
 
         self.log_info("%s ICP registration complete!", transform_type.upper())
 
         # Return results as dictionary
         return {
             "registered_model": self.registered_model,
-            "forward_point_transform": self.forward_point_transform,
-            "inverse_point_transform": self.inverse_point_transform,
+            "moving_to_fixed_transform": self.moving_to_fixed_transform,
+            "fixed_to_moving_transform": self.fixed_to_moving_transform,
         }

--- a/src/monai_physio/register_models_icp_itk.py
+++ b/src/monai_physio/register_models_icp_itk.py
@@ -25,9 +25,9 @@ class RegisterModelsICPITK(MONAIPhysioBase):
         reference_image (itk.Image): Patient image providing coordinate frame and
             distance data
         transform_type: Rigid or Affine
-        forward_point_transform (itk.ComposeScaleSkewVersor3DTransform): Optimized
+        moving_to_fixed_transform (itk.ComposeScaleSkewVersor3DTransform): Optimized
             transformation
-        inverse_point_transform (itk.ComposeScaleSkewVersor3DTransform): Optimized
+        fixed_to_moving_transform (itk.ComposeScaleSkewVersor3DTransform): Optimized
             transformation
         registered_model (pv.PolyData): Final registered model
 
@@ -71,10 +71,10 @@ class RegisterModelsICPITK(MONAIPhysioBase):
         self.transform_type: str = "Affine"
 
         # outputs
-        self.forward_point_transform: Optional[
+        self.moving_to_fixed_transform: Optional[
             itk.ComposeScaleSkewVersor3DTransform
         ] = None
-        self.inverse_point_transform: Optional[
+        self.fixed_to_moving_transform: Optional[
             itk.ComposeScaleSkewVersor3DTransform
         ] = None
         self.registered_model: Optional[pv.PolyData] = None
@@ -382,7 +382,7 @@ class RegisterModelsICPITK(MONAIPhysioBase):
         )
 
         # Create optimized transform
-        self.forward_point_transform = itk.ComposeScaleSkewVersor3DTransform[
+        self.moving_to_fixed_transform = itk.ComposeScaleSkewVersor3DTransform[
             itk.D
         ].New()
         opt_itk_params = itk.OptimizerParameters[itk.D](12)
@@ -396,17 +396,17 @@ class RegisterModelsICPITK(MONAIPhysioBase):
         elif self.transform_type == "Affine":
             for i in range(12):
                 opt_itk_params[i] = result_affine.x[i]
-        self.forward_point_transform.SetParameters(opt_itk_params)
+        self.moving_to_fixed_transform.SetParameters(opt_itk_params)
 
-        self.inverse_point_transform = (
-            self.forward_point_transform.GetInverseTransform()
+        self.fixed_to_moving_transform = (
+            self.moving_to_fixed_transform.GetInverseTransform()
         )
 
         self.final_mean_distance = result_affine.fun
 
         self.registered_model = self._transform_tools.transform_pvcontour(
             self.moving_model,
-            self.forward_point_transform,
+            self.moving_to_fixed_transform,
             with_deformation_magnitude=False,
         )
 
@@ -416,7 +416,7 @@ class RegisterModelsICPITK(MONAIPhysioBase):
 
         return {
             "registered_model": self.registered_model,
-            "forward_point_transform": self.forward_point_transform,
-            "inverse_point_transform": self.inverse_point_transform,
+            "moving_to_fixed_transform": self.moving_to_fixed_transform,
+            "fixed_to_moving_transform": self.fixed_to_moving_transform,
             "mean_distance": self.final_mean_distance,
         }

--- a/src/monai_physio/register_models_pca.py
+++ b/src/monai_physio/register_models_pca.py
@@ -59,13 +59,12 @@ class RegisterModelsPCA(MONAIPhysioBase):
         registered_model_pca_coefficients (np.ndarray): Optimized PCA coefficients
         registered_model (pv.DataSet): Final registered and deformed model
         post_pca_transform (itk.Transform): Transform to apply after PCA registration
-        forward_point_transform (itk.DisplacementFieldTransform): POINT transform
+        moving_to_fixed_transform (itk.DisplacementFieldTransform): POINT transform
             mapping template points -> registered/target points; use it to warp
-            the template model/landmarks onto the target. Its orientation is
-            opposite to an image-registration forward_transform (see
+            the template model/landmarks onto the target (see
             docs/developer/transform_conventions). Does not include the post-PCA
             transform.
-        inverse_point_transform (itk.DisplacementFieldTransform): POINT transform
+        fixed_to_moving_transform (itk.DisplacementFieldTransform): POINT transform
             mapping target points -> template points. Does not include the
             post-PCA transform.
 
@@ -228,8 +227,8 @@ class RegisterModelsPCA(MONAIPhysioBase):
         self.registered_model: Optional[pv.DataSet] = None
         self.registered_model_mean_distance: float = 0.0
         self.registered_model_pca_deformation: Optional[np.ndarray] = None
-        self.forward_point_transform: Optional[itk.DisplacementFieldTransform] = None
-        self.inverse_point_transform: Optional[itk.DisplacementFieldTransform] = None
+        self.moving_to_fixed_transform: Optional[itk.DisplacementFieldTransform] = None
+        self.fixed_to_moving_transform: Optional[itk.DisplacementFieldTransform] = None
 
         # Sampling caches, built lazily by _prepare_sampling()
         self._sampling_ready: bool = False
@@ -945,12 +944,12 @@ class RegisterModelsPCA(MONAIPhysioBase):
             >>> p[0], p[1], p[2] = 10.0, 20.0, 30.0
             >>> transformed_p = registrar.transform_point(p)
         """
-        if self.forward_point_transform is None:
+        if self.moving_to_fixed_transform is None:
             self.log_error("Forward point transform is not set.")
             raise ValueError(
                 "compute_pca_transforms() must be called before transform_point()"
             )
-        transformed_point = self.forward_point_transform.TransformPoint(point)
+        transformed_point = self.moving_to_fixed_transform.TransformPoint(point)
 
         if include_post_pca_transform and self.post_pca_transform is not None:
             transformed_point = self.post_pca_transform.TransformPoint(
@@ -976,15 +975,15 @@ class RegisterModelsPCA(MONAIPhysioBase):
 
         Returns:
             Dictionary containing:
-                - 'forward_point_transform': POINT transform mapping template
+                - 'moving_to_fixed_transform': POINT transform mapping template
                   points -> target points (warps the template onto the target)
-                - 'inverse_point_transform': POINT transform mapping target
+                - 'fixed_to_moving_transform': POINT transform mapping target
                   points -> template points
 
         Note:
-            These are point transforms, oriented opposite to image-registration
-            transforms; see docs/developer/transform_conventions. Neither
-            includes post_pca_transform.
+            These are point transforms (see docs/developer/transform_conventions
+            for image-warp vs. point-warp direction). Neither includes
+            post_pca_transform.
         """
         assert self.registered_model_pca_deformation is not None, (
             "PCA deformation must be computed"
@@ -1000,29 +999,33 @@ class RegisterModelsPCA(MONAIPhysioBase):
             )
         )
 
-        self.forward_point_transform = itk.DisplacementFieldTransform[itk.D, 3].New()
-        self.forward_point_transform.SetDisplacementField(
+        self.moving_to_fixed_transform = itk.DisplacementFieldTransform[itk.D, 3].New()
+        self.moving_to_fixed_transform.SetDisplacementField(
             template_model_pca_deformation_field_image
         )
 
         transform_tools = TransformTools()
-        self.inverse_point_transform = (
+        self.fixed_to_moving_transform = (
             transform_tools.invert_displacement_field_transform(
-                self.forward_point_transform
+                self.moving_to_fixed_transform
             )
         )
 
         self._log_transform_fidelity(template_points)
 
         return {
-            "forward_point_transform": self.forward_point_transform,
-            "inverse_point_transform": self.inverse_point_transform,
+            "moving_to_fixed_transform": self.moving_to_fixed_transform,
+            "fixed_to_moving_transform": self.fixed_to_moving_transform,
         }
 
     def _log_transform_fidelity(self, template_points: np.ndarray) -> None:
         """Report how well the field reproduces the deformation and inverts."""
-        assert self.forward_point_transform is not None, "forward transform must be set"
-        assert self.inverse_point_transform is not None, "inverse transform must be set"
+        assert self.moving_to_fixed_transform is not None, (
+            "forward transform must be set"
+        )
+        assert self.fixed_to_moving_transform is not None, (
+            "inverse transform must be set"
+        )
         assert self.registered_model_pca_deformation is not None, (
             "PCA deformation must be computed"
         )
@@ -1038,9 +1041,9 @@ class RegisterModelsPCA(MONAIPhysioBase):
         round_trip = np.empty_like(sampled)
         for i, source in enumerate(sampled):
             point[0], point[1], point[2] = (float(v) for v in source)
-            mapped = self.forward_point_transform.TransformPoint(point)
+            mapped = self.moving_to_fixed_transform.TransformPoint(point)
             forward[i] = (mapped[0], mapped[1], mapped[2])
-            back = self.inverse_point_transform.TransformPoint(mapped)
+            back = self.fixed_to_moving_transform.TransformPoint(mapped)
             round_trip[i] = (back[0], back[1], back[2])
 
         expected = sampled + deformation

--- a/src/monai_physio/register_time_series_images.py
+++ b/src/monai_physio/register_time_series_images.py
@@ -53,14 +53,14 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         ...     register_reference=True,
         ... )
         >>>
-        >>> forward_tfms = result['forward_transforms']  # warp moving images -> fixed grid
-        >>> inverse_tfms = result['inverse_transforms']  # warp fixed image -> moving grids
+        >>> forward_tfms = result['fixed_to_moving_transforms']  # warp moving images -> fixed grid
+        >>> inverse_tfms = result['moving_to_fixed_transforms']  # warp fixed image -> moving grids
         >>> losses = result['losses']
         >>>
         >>> # Reconstruct time series with optional upsampling
         >>> reconstructed = registrar.reconstruct_time_series(
         ...     moving_images=time_series_images,
-        ...     inverse_transforms=inverse_tfms,
+        ...     moving_to_fixed_transforms=inverse_tfms,
         ...     upsample_to_fixed_resolution=True,
         ... )
     """
@@ -174,12 +174,12 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         Returns:
             dict: Dictionary containing results:
-                - "forward_transforms" (list[itk.Transform]): one per image;
+                - "fixed_to_moving_transforms" (list[itk.Transform]): one per image;
                   each warps its moving image onto the fixed grid (warping
                   moving points/landmarks into fixed space uses the matching
                   inverse transform instead -- see
                   docs/developer/transform_conventions)
-                - "inverse_transforms" (list[itk.Transform]): one per image;
+                - "moving_to_fixed_transforms" (list[itk.Transform]): one per image;
                   each warps the fixed image onto that moving image's grid
                   (used by reconstruct_time_series)
                 - "losses" (list[float]): Registration loss value for each image
@@ -212,7 +212,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             >>>
             >>> # Access results using new intuitive names
             >>> for i, (forward_tfm, loss) in enumerate(
-            ...     zip(result['forward_transforms'], result['losses'])
+            ...     zip(result['fixed_to_moving_transforms'], result['losses'])
             ... ):
             ...     # Apply forward transform to align moving image i to fixed
             ...     registered = transform_tools.transform_image(
@@ -248,8 +248,8 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             )
 
         # Initialize result lists
-        forward_transforms: list[Optional[itk.Transform]] = [None] * num_images
-        inverse_transforms: list[Optional[itk.Transform]] = [None] * num_images
+        fixed_to_moving_transforms: list[Optional[itk.Transform]] = [None] * num_images
+        moving_to_fixed_transforms: list[Optional[itk.Transform]] = [None] * num_images
         losses = [0.0] * num_images
 
         # Create identity transform for fixed image
@@ -275,17 +275,17 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 moving_mask=reference_mask,
                 moving_labelmap=reference_labelmap,
             )
-            forward_transform = result["forward_transform"]
-            inverse_transform = result["inverse_transform"]
+            fixed_to_moving_transform = result["fixed_to_moving_transform"]
+            moving_to_fixed_transform = result["moving_to_fixed_transform"]
             loss = result["loss"]
         else:
             # Use identity transform for reference frame
-            forward_transform = identity_tfm
-            inverse_transform = identity_tfm
+            fixed_to_moving_transform = identity_tfm
+            moving_to_fixed_transform = identity_tfm
             loss = 0.0
 
-        forward_transforms[reference_frame] = forward_transform
-        inverse_transforms[reference_frame] = inverse_transform
+        fixed_to_moving_transforms[reference_frame] = fixed_to_moving_transform
+        moving_to_fixed_transforms[reference_frame] = moving_to_fixed_transform
         losses[reference_frame] = loss
 
         # Register every remaining frame; each is independent of the others.
@@ -304,24 +304,28 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 moving_labelmap=moving_labelmap,
             )
 
-            forward_transforms[img_idx] = result["forward_transform"]
-            inverse_transforms[img_idx] = result["inverse_transform"]
+            fixed_to_moving_transforms[img_idx] = result["fixed_to_moving_transform"]
+            moving_to_fixed_transforms[img_idx] = result["moving_to_fixed_transform"]
             losses[img_idx] = cast(float, result["loss"])
 
-        assert all(t is not None for t in forward_transforms)
-        assert all(t is not None for t in inverse_transforms)
+        assert all(t is not None for t in fixed_to_moving_transforms)
+        assert all(t is not None for t in moving_to_fixed_transforms)
         return {
-            "forward_transforms": [t for t in forward_transforms if t is not None],
-            "inverse_transforms": [t for t in inverse_transforms if t is not None],
+            "fixed_to_moving_transforms": [
+                t for t in fixed_to_moving_transforms if t is not None
+            ],
+            "moving_to_fixed_transforms": [
+                t for t in moving_to_fixed_transforms if t is not None
+            ],
             "losses": losses,
         }
 
     def reconstruct_time_series(
         self,
         moving_images: list[itk.Image],
-        inverse_transforms: list[itk.Transform],
+        moving_to_fixed_transforms: list[itk.Transform],
         upsample_to_fixed_resolution: bool = False,
-        forward_transforms: Optional[list[itk.Transform]] = None,
+        fixed_to_moving_transforms: Optional[list[itk.Transform]] = None,
         composite_mode: Literal["reference", "mean", "max"] = "reference",
     ) -> list[itk.Image]:
         """Reconstruct time series images using inverse transforms.
@@ -335,20 +339,20 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         warped back to each time point. When composite_mode is "mean" or
         "max", a single composite image is built first -- the pixel-by-pixel
         mean or max across the fixed image and every moving image warped onto
-        the fixed grid via forward_transforms -- and that composite is warped
+        the fixed grid via fixed_to_moving_transforms -- and that composite is warped
         back to each time point instead. This lets anatomy or contrast only
         visible in some frames propagate into every reconstructed time point.
 
         Args:
             moving_images (list[itk.Image]): List of moving images to reconstruct
-            inverse_transforms (list[itk.Transform]): List of inverse transforms
+            moving_to_fixed_transforms (list[itk.Transform]): List of inverse transforms
                 (one per moving image), each used to warp the fixed image onto
                 that moving image's grid
             upsample_to_fixed_resolution (bool, optional): If True, reconstructed
                 images will be upsampled to isotropic resolution (mean of fixed image's
                 X and Y spacing) while maintaining their original origin and direction.
                 Default: False
-            forward_transforms (list[itk.Transform], optional): List of forward
+            fixed_to_moving_transforms (list[itk.Transform], optional): List of forward
                 transforms (one per moving image), each used to warp that moving
                 image onto the fixed grid. Required when composite_mode is
                 "mean" or "max". Default: None
@@ -362,8 +366,8 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         Raises:
             ValueError: If fixed_image is not set
-            ValueError: If lengths of moving_images and inverse_transforms don't match
-            ValueError: If composite_mode is "mean"/"max" and forward_transforms
+            ValueError: If lengths of moving_images and moving_to_fixed_transforms don't match
+            ValueError: If composite_mode is "mean"/"max" and fixed_to_moving_transforms
                 is not provided or its length doesn't match moving_images
 
         Example:
@@ -378,7 +382,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             >>>
             >>> reconstructed_images = registrar.reconstruct_time_series(
             ...     moving_images=time_series_images,
-            ...     inverse_transforms=result['inverse_transforms'],
+            ...     moving_to_fixed_transforms=result['moving_to_fixed_transforms'],
             ...     upsample_to_fixed_resolution=True,
             ... )
         """
@@ -387,25 +391,25 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 "Fixed image must be set before reconstructing time series"
             )
 
-        if len(moving_images) != len(inverse_transforms):
+        if len(moving_images) != len(moving_to_fixed_transforms):
             raise ValueError(
                 f"Number of moving images ({len(moving_images)}) must match "
-                f"number of inverse transforms ({len(inverse_transforms)})"
+                f"number of inverse transforms ({len(moving_to_fixed_transforms)})"
             )
 
         if composite_mode == "reference":
             source_image = self.fixed_image
         elif composite_mode in ("mean", "max"):
-            if forward_transforms is None or len(forward_transforms) != len(
-                moving_images
-            ):
+            if fixed_to_moving_transforms is None or len(
+                fixed_to_moving_transforms
+            ) != len(moving_images):
                 raise ValueError(
-                    "forward_transforms must be provided and match "
+                    "fixed_to_moving_transforms must be provided and match "
                     "moving_images length when composite_mode is "
                     f"{composite_mode!r}"
                 )
             source_image = self._compute_composite_reference(
-                moving_images, forward_transforms, composite_mode
+                moving_images, fixed_to_moving_transforms, composite_mode
             )
         else:
             raise ValueError(
@@ -415,7 +419,9 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         reconstructed_images: list[itk.Image] = []
 
-        for moving_image, inverse_transform in zip(moving_images, inverse_transforms):
+        for moving_image, moving_to_fixed_transform in zip(
+            moving_images, moving_to_fixed_transforms
+        ):
             if upsample_to_fixed_resolution:
                 # Create a reference image with isotropic spacing (mean of fixed image's
                 # X and Y spacing) and moving image's origin and direction
@@ -431,7 +437,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             # modality's "no tissue" value, not 0.
             reconstructed = self.transform_tools.transform_image(
                 source_image,
-                inverse_transform,
+                moving_to_fixed_transform,
                 reference_image,
                 background_value=self._prewarp_background_value(source_image),
             )
@@ -442,13 +448,13 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
     def _compute_composite_reference(
         self,
         moving_images: list[itk.Image],
-        forward_transforms: list[itk.Transform],
+        fixed_to_moving_transforms: list[itk.Transform],
         mode: Literal["mean", "max"],
     ) -> itk.Image:
         """Build a composite reference image from the fixed image and moving images.
 
         Warps every moving image onto the fixed grid using its
-        forward_transform, then combines those registered images with the
+        fixed_to_moving_transform, then combines those registered images with the
         fixed image pixel-by-pixel using the given reduction. Moving images
         whose extent does not fully cover the fixed grid contribute only
         where they actually have data -- voxels resampled from outside a
@@ -458,7 +464,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         Args:
             moving_images (list[itk.Image]): Moving images to warp and combine
-            forward_transforms (list[itk.Transform]): One forward transform per
+            fixed_to_moving_transforms (list[itk.Transform]): One forward transform per
                 moving image, warping it onto the fixed grid
             mode (Literal["mean", "max"]): Pixel-wise reduction to apply
 
@@ -479,10 +485,12 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         if mode == "mean":
             valid_count = np.ones_like(accumulator)
 
-        for moving_image, forward_transform in zip(moving_images, forward_transforms):
+        for moving_image, fixed_to_moving_transform in zip(
+            moving_images, fixed_to_moving_transforms
+        ):
             registered = self.transform_tools.transform_image(
                 moving_image,
-                forward_transform,
+                fixed_to_moving_transform,
                 self.fixed_image,
                 background_value=self._prewarp_background_value(moving_image),
             )
@@ -493,7 +501,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             coverage_image.CopyInformation(moving_image)
             registered_coverage = self.transform_tools.transform_image(
                 coverage_image,
-                forward_transform,
+                fixed_to_moving_transform,
                 self.fixed_image,
                 interpolation_method="nearest",
                 background_value=0,
@@ -592,7 +600,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 computes its own preprocessing from the raw moving_image
 
         Returns:
-            dict: Registration result with forward_transform, inverse_transform, and loss
+            dict: Registration result with fixed_to_moving_transform, moving_to_fixed_transform, and loss
         """
         self._delegate_to(self.registrar, moving_image, moving_mask, moving_labelmap)
         result = self.registrar.registration_method(
@@ -603,7 +611,11 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         )
         self._capture_delegate_result(self.registrar, result)
         return {
-            "forward_transform": cast(itk.Transform, result["forward_transform"]),
-            "inverse_transform": cast(itk.Transform, result["inverse_transform"]),
+            "fixed_to_moving_transform": cast(
+                itk.Transform, result["fixed_to_moving_transform"]
+            ),
+            "moving_to_fixed_transform": cast(
+                itk.Transform, result["moving_to_fixed_transform"]
+            ),
             "loss": float(cast(float, result["loss"])),
         }

--- a/src/monai_physio/register_time_series_images.py
+++ b/src/monai_physio/register_time_series_images.py
@@ -53,14 +53,16 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         ...     register_reference=True,
         ... )
         >>>
-        >>> forward_tfms = result['fixed_to_moving_transforms']  # warp moving images -> fixed grid
-        >>> inverse_tfms = result['moving_to_fixed_transforms']  # warp fixed image -> moving grids
+        >>> # warp moving images -> fixed grid
+        >>> f2m_tfms = result['fixed_to_moving_transforms']
+        >>> # warp fixed image -> moving grids
+        >>> m2f_tfms = result['moving_to_fixed_transforms']
         >>> losses = result['losses']
         >>>
         >>> # Reconstruct time series with optional upsampling
         >>> reconstructed = registrar.reconstruct_time_series(
         ...     moving_images=time_series_images,
-        ...     moving_to_fixed_transforms=inverse_tfms,
+        ...     moving_to_fixed_transforms=m2f_tfms,
         ...     upsample_to_fixed_resolution=True,
         ... )
     """
@@ -177,7 +179,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 - "fixed_to_moving_transforms" (list[itk.Transform]): one per image;
                   each warps its moving image onto the fixed grid (warping
                   moving points/landmarks into fixed space uses the matching
-                  inverse transform instead -- see
+                  moving_to_fixed_transforms entry instead -- see
                   docs/developer/transform_conventions)
                 - "moving_to_fixed_transforms" (list[itk.Transform]): one per image;
                   each warps the fixed image onto that moving image's grid
@@ -211,12 +213,13 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
             ... )
             >>>
             >>> # Access results using new intuitive names
-            >>> for i, (forward_tfm, loss) in enumerate(
+            >>> for i, (f2m_tfm, loss) in enumerate(
             ...     zip(result['fixed_to_moving_transforms'], result['losses'])
             ... ):
-            ...     # Apply forward transform to align moving image i to fixed
+            ...     # Apply fixed_to_moving_transform to align moving image i
+            ...     # to fixed
             ...     registered = transform_tools.transform_image(
-            ...         moving_images[i], forward_tfm, fixed_image
+            ...         moving_images[i], f2m_tfm, fixed_image
             ...     )
         """
         if self.fixed_image is None:
@@ -328,12 +331,13 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         fixed_to_moving_transforms: Optional[list[itk.Transform]] = None,
         composite_mode: Literal["reference", "mean", "max"] = "reference",
     ) -> list[itk.Image]:
-        """Reconstruct time series images using inverse transforms.
+        """Reconstruct time series images using moving_to_fixed_transforms.
 
-        This method applies the inverse transforms to reconstruct each moving image
-        in the fixed image space. If upsample_to_fixed_resolution is enabled,
-        the reconstructed images will use isotropic spacing (mean of fixed image's
-        X and Y spacing) while maintaining each moving image's original origin and direction.
+        This method applies the moving_to_fixed_transforms to reconstruct each
+        moving image in the fixed image space. If upsample_to_fixed_resolution
+        is enabled, the reconstructed images will use isotropic spacing (mean
+        of fixed image's X and Y spacing) while maintaining each moving
+        image's original origin and direction.
 
         By default (composite_mode="reference"), the fixed/reference image is
         warped back to each time point. When composite_mode is "mean" or
@@ -345,17 +349,17 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         Args:
             moving_images (list[itk.Image]): List of moving images to reconstruct
-            moving_to_fixed_transforms (list[itk.Transform]): List of inverse transforms
-                (one per moving image), each used to warp the fixed image onto
-                that moving image's grid
+            moving_to_fixed_transforms (list[itk.Transform]): List of
+                moving-to-fixed transforms (one per moving image), each used
+                to warp the fixed image onto that moving image's grid
             upsample_to_fixed_resolution (bool, optional): If True, reconstructed
                 images will be upsampled to isotropic resolution (mean of fixed image's
                 X and Y spacing) while maintaining their original origin and direction.
                 Default: False
-            fixed_to_moving_transforms (list[itk.Transform], optional): List of forward
-                transforms (one per moving image), each used to warp that moving
-                image onto the fixed grid. Required when composite_mode is
-                "mean" or "max". Default: None
+            fixed_to_moving_transforms (list[itk.Transform], optional): List of
+                fixed-to-moving transforms (one per moving image), each used to
+                warp that moving image onto the fixed grid. Required when
+                composite_mode is "mean" or "max". Default: None
             composite_mode (Literal["reference", "mean", "max"], optional):
                 Which image to warp back to each time point. "reference" uses
                 the fixed image as-is (default). "mean"/"max" build a composite
@@ -366,9 +370,11 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         Raises:
             ValueError: If fixed_image is not set
-            ValueError: If lengths of moving_images and moving_to_fixed_transforms don't match
-            ValueError: If composite_mode is "mean"/"max" and fixed_to_moving_transforms
-                is not provided or its length doesn't match moving_images
+            ValueError: If lengths of moving_images and
+                moving_to_fixed_transforms don't match
+            ValueError: If composite_mode is "mean"/"max" and
+                fixed_to_moving_transforms is not provided or its length
+                doesn't match moving_images
 
         Example:
             >>> greedy = RegisterImagesGreedy()
@@ -394,7 +400,8 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
         if len(moving_images) != len(moving_to_fixed_transforms):
             raise ValueError(
                 f"Number of moving images ({len(moving_images)}) must match "
-                f"number of inverse transforms ({len(moving_to_fixed_transforms)})"
+                f"number of moving_to_fixed_transforms "
+                f"({len(moving_to_fixed_transforms)})"
             )
 
         if composite_mode == "reference":
@@ -464,8 +471,9 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         Args:
             moving_images (list[itk.Image]): Moving images to warp and combine
-            fixed_to_moving_transforms (list[itk.Transform]): One forward transform per
-                moving image, warping it onto the fixed grid
+            fixed_to_moving_transforms (list[itk.Transform]): One
+                fixed_to_moving transform per moving image, warping it onto
+                the fixed grid
             mode (Literal["mean", "max"]): Pixel-wise reduction to apply
 
         Returns:
@@ -600,7 +608,8 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
                 computes its own preprocessing from the raw moving_image
 
         Returns:
-            dict: Registration result with fixed_to_moving_transform, moving_to_fixed_transform, and loss
+            dict: Registration result with fixed_to_moving_transform,
+                moving_to_fixed_transform, and loss
         """
         self._delegate_to(self.registrar, moving_image, moving_mask, moving_labelmap)
         result = self.registrar.registration_method(

--- a/src/monai_physio/workflow_convert_image_to_usd.py
+++ b/src/monai_physio/workflow_convert_image_to_usd.py
@@ -207,12 +207,12 @@ class WorkflowConvertImageToUSD(MONAIPhysioBase):
                 compression=True,
             )
             itk.transformwrite(
-                reg_results["inverse_transform"],
+                reg_results["moving_to_fixed_transform"],
                 os.path.join(self.output_directory, f"{filename_prefix}_inverse.hdf"),
                 compression=True,
             )
             itk.transformwrite(
-                reg_results["forward_transform"],
+                reg_results["fixed_to_moving_transform"],
                 os.path.join(self.output_directory, f"{filename_prefix}_forward.hdf"),
                 compression=True,
             )
@@ -412,14 +412,14 @@ class WorkflowConvertImageToUSD(MONAIPhysioBase):
 
             for anatomy_type in anatomy_types:
                 # Get the forward transform for this anatomy type and frame
-                forward_transform = self.registration_results[i][anatomy_type][
-                    "forward_transform"
+                fixed_to_moving_transform = self.registration_results[i][anatomy_type][
+                    "fixed_to_moving_transform"
                 ]
 
                 # Transform the reference contours
                 transformed_anatomy_contours = self.contour_tools.transform_contours(
                     self.reference_contours[anatomy_type],
-                    forward_transform,
+                    fixed_to_moving_transform,
                     with_deformation_magnitude=True,
                 )
 

--- a/src/monai_physio/workflow_create_mean_surface.py
+++ b/src/monai_physio/workflow_create_mean_surface.py
@@ -8,7 +8,7 @@ template through each sample and averaging the *template's* points:
    default, so size differences remain part of the averaged shape).
 2. Register each aligned sample to the template with
    :class:`RegisterModelsDistanceMaps` (Greedy affine + ICON on distance maps).
-3. Warp the template by each sample's forward transform, giving one surface per
+3. Warp the template by each sample's fixed_to_moving transform, giving one surface per
    sample that carries the sample's shape on the template's topology.
 4. Average those point sets.
 
@@ -107,7 +107,7 @@ class WorkflowCreateMeanSurface(MONAIPhysioBase):
         # Results (populated by process()).
         self.mean_surface: Optional[pv.PolyData] = None
         self.corresponded_surfaces: list[pv.PolyData] = []
-        self.forward_transforms: list[Any] = []
+        self.fixed_to_moving_transforms: list[Any] = []
         self.iteration_rms_mm: list[float] = []
 
     # ─────────────────────────── Tuning setters ────────────────────────────
@@ -197,7 +197,7 @@ class WorkflowCreateMeanSurface(MONAIPhysioBase):
 
         Returns:
             Dict with ``mean_surface`` (template topology, mean shape),
-            ``corresponded_surfaces`` and ``forward_transforms`` from the final
+            ``corresponded_surfaces`` and ``fixed_to_moving_transforms`` from the final
             iteration, the per-iteration ``iteration_rms_mm``, and
             ``number_of_iterations_run``.
         """
@@ -219,7 +219,9 @@ class WorkflowCreateMeanSurface(MONAIPhysioBase):
             self.log_info(
                 "Atlas iteration %d/%d", iteration + 1, self.number_of_iterations
             )
-            corresponded, forward_transforms, aligned = self._correspond(template)
+            corresponded, fixed_to_moving_transforms, aligned = self._correspond(
+                template
+            )
 
             mean_points = np.mean(
                 [np.asarray(surface.points) for surface in corresponded], axis=0
@@ -240,7 +242,7 @@ class WorkflowCreateMeanSurface(MONAIPhysioBase):
             template = new_template
 
             self.corresponded_surfaces = corresponded
-            self.forward_transforms = forward_transforms
+            self.fixed_to_moving_transforms = fixed_to_moving_transforms
             self.log_info("  mean moved %.4f mm (RMS) from the previous template", rms)
 
             if rms < self.convergence_tolerance:
@@ -254,7 +256,7 @@ class WorkflowCreateMeanSurface(MONAIPhysioBase):
         return {
             "mean_surface": self.mean_surface,
             "corresponded_surfaces": self.corresponded_surfaces,
-            "forward_transforms": self.forward_transforms,
+            "fixed_to_moving_transforms": self.fixed_to_moving_transforms,
             "iteration_rms_mm": self.iteration_rms_mm,
             "number_of_iterations_run": iterations_run,
         }
@@ -301,7 +303,7 @@ class WorkflowCreateMeanSurface(MONAIPhysioBase):
         """Warp ``template`` onto every input surface.
 
         Returns one surface per input, each carrying that input's shape on the
-        template's topology, the forward transform that produced it, and the
+        template's topology, the fixed_to_moving transform that produced it, and the
         ICP-aligned inputs those transforms were computed against.
         """
         aligned: list[pv.PolyData] = []
@@ -333,7 +335,7 @@ class WorkflowCreateMeanSurface(MONAIPhysioBase):
         )
 
         corresponded: list[pv.PolyData] = []
-        forward_transforms: list[Any] = []
+        fixed_to_moving_transforms: list[Any] = []
         for index, aligned_surface in enumerate(aligned):
             self.log_info("  registering surface %d/%d", index + 1, len(aligned))
 
@@ -349,16 +351,16 @@ class WorkflowCreateMeanSurface(MONAIPhysioBase):
                 registrar.set_icon_weights_path(self.icon_weights_path)
             result = registrar.register(transform_type=self.registration_transform_type)
 
-            # The forward (image-convention) transform maps template points into
-            # the sample's shape, so warping the template by it yields template
-            # topology with sample shape.
+            # fixed_to_moving_transform maps template points into the sample's
+            # shape, so warping the template by it yields template topology
+            # with sample shape.
             corresponded.append(
                 self.contour_tools.transform_contours(
                     template,
-                    tfm=result["forward_transform"],
+                    tfm=result["fixed_to_moving_transform"],
                     with_deformation_magnitude=False,
                 )
             )
-            forward_transforms.append(result["forward_transform"])
+            fixed_to_moving_transforms.append(result["fixed_to_moving_transform"])
 
-        return corresponded, forward_transforms, aligned
+        return corresponded, fixed_to_moving_transforms, aligned

--- a/src/monai_physio/workflow_create_statistical_model.py
+++ b/src/monai_physio/workflow_create_statistical_model.py
@@ -133,7 +133,7 @@ class WorkflowCreateStatisticalModel(MONAIPhysioBase):
         self.sample_models: list[pv.DataSet] = []
         self.sample_ids: list[str] = []
         self.aligned_models: list[pv.DataSet] = []
-        self.forward_transforms: list = []
+        self.fixed_to_moving_transforms: list = []
         self.pca_input_models: list[pv.DataSet] = []
         self.pca_input_residual_rms: list[float] = []
         self.pca_fitted: Optional[PCA] = None
@@ -210,7 +210,7 @@ class WorkflowCreateStatisticalModel(MONAIPhysioBase):
         self.log_section("Step 2: ICP alignment to reference surface", width=70)
         assert self.reference_model is not None and self.sample_models
         self.aligned_models = []
-        self.forward_transforms = []
+        self.fixed_to_moving_transforms = []
 
         reference_surface = self.contour_tools.extract_surface(self.reference_model)
         for i, (sid, moving) in enumerate(zip(self.sample_ids, self.sample_models)):
@@ -230,11 +230,11 @@ class WorkflowCreateStatisticalModel(MONAIPhysioBase):
             else:
                 aligned_model = self.contour_tools.transform_contours(
                     cast(pv.PolyData, moving),
-                    tfm=result["forward_point_transform"],
+                    tfm=result["moving_to_fixed_transform"],
                     with_deformation_magnitude=False,
                 )
             self.aligned_models.append(aligned_model)
-            self.forward_transforms.append(result["forward_point_transform"])
+            self.fixed_to_moving_transforms.append(result["moving_to_fixed_transform"])
         self.log_info("ICP alignment complete for %d samples", len(self.aligned_models))
 
     def _step3_deformable_correspondence(self) -> None:
@@ -256,7 +256,7 @@ class WorkflowCreateStatisticalModel(MONAIPhysioBase):
             buffer_factor=self.reference_buffer_factor,
             ptype=itk.UC,
         )
-        self.forward_transforms = []
+        self.fixed_to_moving_transforms = []
 
         for i, (sid, moving) in enumerate(zip(self.sample_ids, self.aligned_models)):
             self.log_info(
@@ -278,25 +278,25 @@ class WorkflowCreateStatisticalModel(MONAIPhysioBase):
                 transform_type="Deformable",
             )
 
-            # Only the forward transform is kept.  Each one owns dense
-            # full-grid displacement fields, and holding the inverse as well
-            # doubled the cost of a population for a value nothing read.
-            self.forward_transforms.append(result["forward_transform"])
+            # Only the fixed_to_moving transform is kept.  Each one owns dense
+            # full-grid displacement fields, and holding the moving_to_fixed
+            # one as well doubled the cost of a population for a value
+            # nothing read.
+            self.fixed_to_moving_transforms.append(result["fixed_to_moving_transform"])
 
         # aligned_models stays the ICP-aligned input: step 4 measures the
         # corresponded shapes against it.
         self.log_info(
             "Deformable registration complete for %d samples",
-            len(self.forward_transforms),
+            len(self.fixed_to_moving_transforms),
         )
 
     def _step4_build_pca_inputs(self) -> None:
         """Build corresponded shapes in reference space (notebook 4).
 
-        For each case, reference_model is warped by forward (image) deformation
-        (= inverse point) transform from step 3, so that we get reference topology
-        in ICP-aligned space with residual deformation per subject to be used as PCA
-        input.
+        For each case, reference_model is warped by the fixed_to_moving_transform
+        from step 3, so that we get reference topology in ICP-aligned space with
+        residual deformation per subject to be used as PCA input.
 
         The warped template only approximates its subject: the deformable
         registration always stops short of it, and because that shortfall is
@@ -310,7 +310,7 @@ class WorkflowCreateStatisticalModel(MONAIPhysioBase):
         well the registration landed.
         """
         self.log_section("Step 4: Build PCA inputs (corresponded shapes)", width=70)
-        assert self.reference_model is not None and self.forward_transforms
+        assert self.reference_model is not None and self.fixed_to_moving_transforms
         project = self.project_to_measured_surfaces
         if project and not self.solve_for_surface_pca:
             # The PCA inputs are volume meshes here, so snapping their interior
@@ -324,7 +324,7 @@ class WorkflowCreateStatisticalModel(MONAIPhysioBase):
         self.pca_input_models = []
         self.pca_input_residual_rms = []
         for sid, fwd_tfm, aligned in zip(
-            self.sample_ids, self.forward_transforms, self.aligned_models
+            self.sample_ids, self.fixed_to_moving_transforms, self.aligned_models
         ):
             pca_input_model = self.contour_tools.transform_contours(
                 cast(pv.PolyData, self.reference_model),

--- a/src/monai_physio/workflow_fit_statistical_model_to_patient.py
+++ b/src/monai_physio/workflow_fit_statistical_model_to_patient.py
@@ -95,8 +95,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         number_of_pca_components (int): Number of PCA components when PCA enabled
         labelmap_interior_object_ids (list): List of labelmap IDs corresponding to interior objects that should
             not be used when computing a distance map.
-        icp_forward_point_transform : ICP transforms
-        icp_inverse_point_transform : ICP inverse transforms
+        icp_moving_to_fixed_transform : ICP transforms
+        icp_fixed_to_moving_transform : ICP inverse transforms
         icp_template_model_surface: template model surface after ICP alignment
         icp_template_model: template model (UnstructuredGrid) after ICP alignment
         pca_coefficients: PCA shape coefficients (if PCA used)
@@ -104,12 +104,12 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
             (if PCA used)
         pca_template_model_surface: template model surface after PCA registration (if
             PCA used)
-        l2l_forward_transform: Labelmap-to-labelmap forward transform
-        l2l_inverse_transform: Labelmap-to-labelmap inverse transform
+        l2l_fixed_to_moving_transform: Labelmap-to-labelmap fixed-to-moving transform
+        l2l_moving_to_fixed_transform: Labelmap-to-labelmap moving-to-fixed transform
         l2l_template_model_surface: template model surface after labelmap-to-labelmap
             registration
-        l2i_forward_transform: Labelmap-to-image forward transform
-        l2i_inverse_transform: Labelmap-to-image inverse transform
+        l2i_fixed_to_moving_transform: Labelmap-to-image fixed-to-moving transform
+        l2i_moving_to_fixed_transform: Labelmap-to-image moving-to-fixed transform
         l2i_template_model_surface: template model surface after labelmap-to-image
             registration
         l2i_template_labelmap: template labelmap after labelmap-to-image registration
@@ -263,8 +263,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
 
         # Stage 1: ICP alignment results
         self.icp_registrar: Optional[RegisterModelsICP] = None
-        self.icp_inverse_point_transform: Optional[itk.Transform] = None
-        self.icp_forward_point_transform: Optional[itk.Transform] = None
+        self.icp_fixed_to_moving_transform: Optional[itk.Transform] = None
+        self.icp_moving_to_fixed_transform: Optional[itk.Transform] = None
         self.icp_template_model: Optional[pv.DataSet] = None
         self.icp_template_model_surface: Optional[pv.PolyData] = None
         self.icp_template_labelmap: Optional[itk.Image] = None
@@ -272,8 +272,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         # Stage 1.5: PCA registration results (optional; enable via set_use_pca_registration(True, pca_model, number_of_pca_components))
         self.use_pca_registration = False
         self.pca_registrar: Optional[RegisterModelsPCA] = None
-        self.pca_forward_point_transform: Optional[itk.Transform] = None
-        self.pca_inverse_point_transform: Optional[itk.Transform] = None
+        self.pca_moving_to_fixed_transform: Optional[itk.Transform] = None
+        self.pca_fixed_to_moving_transform: Optional[itk.Transform] = None
         self.pca_model: Optional[dict[str, Any]] = None
         self.number_of_pca_components: int = 0
         self.pca_coefficients: Optional[np.ndarray] = None
@@ -284,15 +284,15 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
 
         # Stage 2: Labelmap-to-labelmap registration results
         self.use_l2l_registration = True
-        self.l2l_inverse_transform: Optional[itk.Transform] = None
-        self.l2l_forward_transform: Optional[itk.Transform] = None
+        self.l2l_moving_to_fixed_transform: Optional[itk.Transform] = None
+        self.l2l_fixed_to_moving_transform: Optional[itk.Transform] = None
         self.l2l_template_model_surface: Optional[pv.PolyData] = None
         self.l2l_template_labelmap: Optional[itk.Image] = None
 
         # Stage 3: Labelmap-to-image registration results (disabled by default; enable via set_use_labelmap_to_image_registration(True, template_labelmap, ...))
         self.use_l2i_registration = False
-        self.l2i_inverse_transform: Optional[itk.Transform] = None
-        self.l2i_forward_transform: Optional[itk.Transform] = None
+        self.l2i_moving_to_fixed_transform: Optional[itk.Transform] = None
+        self.l2i_fixed_to_moving_transform: Optional[itk.Transform] = None
         self.l2i_template_model_surface: Optional[pv.PolyData] = None
         self.l2i_template_labelmap: Optional[itk.Image] = None
 
@@ -521,8 +521,10 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
 
         Returns:
             dict: Dictionary containing:
-                - 'forward_transform': used to warp an image from model to patient space
-                - 'inverse_transform': used to warp an image from patient to model space
+                - 'fixed_to_moving_transform': used to warp an image from
+                  model to patient space
+                - 'moving_to_fixed_transform': used to warp an image from
+                  patient to model space
                 - 'fitted_reference_mesh': Transformed model model surface
         """
         self.log_section("Stage 1: ICP Alignment (RegisterModelsICP)", width=70)
@@ -539,19 +541,19 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
 
         # Store results
         # Note: Point transforms are in opposite direction from image transforms
-        self.icp_forward_point_transform = icp_result["forward_point_transform"]
-        self.icp_inverse_point_transform = icp_result["inverse_point_transform"]
+        self.icp_moving_to_fixed_transform = icp_result["moving_to_fixed_transform"]
+        self.icp_fixed_to_moving_transform = icp_result["fixed_to_moving_transform"]
         self.icp_template_model_surface = icp_result["registered_model"]
 
         self.icp_template_model = self._transform_model_dataset(
             self.template_model,
-            self.icp_forward_point_transform,
+            self.icp_moving_to_fixed_transform,
         )
 
         if self.template_labelmap is not None:
             self.icp_template_labelmap = self.transform_tools.transform_image(
                 self.template_labelmap,
-                self.icp_inverse_point_transform,
+                self.icp_fixed_to_moving_transform,
                 self.patient_image,
                 interpolation_method="nearest",
             )
@@ -565,8 +567,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         self.fitted_reference_labelmap = self.icp_template_labelmap
 
         return {
-            "inverse_point_transform": self.icp_inverse_point_transform,
-            "forward_point_transform": self.icp_forward_point_transform,
+            "fixed_to_moving_transform": self.icp_fixed_to_moving_transform,
+            "moving_to_fixed_transform": self.icp_moving_to_fixed_transform,
             "fitted_reference_model": self.icp_template_model,
             "fitted_reference_mesh": self.icp_template_model_surface,
             "fitted_reference_labelmap": self.icp_template_labelmap,
@@ -582,10 +584,10 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
 
         Returns:
             dict: Dictionary containing:
-                - 'forward_point_transform': DisplacementFieldTransform mapping
+                - 'moving_to_fixed_transform': DisplacementFieldTransform mapping
                   un-aligned template points to their PCA-deformed positions.
                   It excludes the ICP alignment, which is applied separately.
-                - 'inverse_point_transform': its inverse
+                - 'fixed_to_moving_transform': its inverse
                 - 'pca_coefficients': PCA shape coefficients
                 - 'fitted_reference_mesh': PCA-registered model surface
 
@@ -603,15 +605,15 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
             self.pca_template_labelmap = self.icp_template_labelmap
             identity_transform = itk.CenteredAffineTransform[itk.D, 3].New()
             identity_transform.SetIdentity()
-            self.pca_forward_point_transform = identity_transform
-            self.pca_inverse_point_transform = identity_transform
+            self.pca_moving_to_fixed_transform = identity_transform
+            self.pca_fixed_to_moving_transform = identity_transform
             return {
                 "pca_coefficients": None,
                 "fitted_reference_model": self.pca_template_model,
                 "fitted_reference_mesh": self.pca_template_model_surface,
                 "fitted_reference_labelmap": self.pca_template_labelmap,
-                "forward_point_transform": self.pca_forward_point_transform,
-                "inverse_point_transform": self.pca_inverse_point_transform,
+                "moving_to_fixed_transform": self.pca_moving_to_fixed_transform,
+                "fixed_to_moving_transform": self.pca_fixed_to_moving_transform,
             }
 
         # PCA modes are directions in the statistical model's own training
@@ -644,7 +646,7 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
             pca_template_model=pca_template_model,
             pca_model=self.pca_model,
             pca_number_of_modes=self.number_of_pca_components,
-            post_pca_transform=self.icp_forward_point_transform,
+            post_pca_transform=self.icp_moving_to_fixed_transform,
             fixed_model=fixed_model,
             fixed_distance_map=fixed_distance_map,
             reference_image=self.patient_image,
@@ -673,11 +675,11 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         pca_transforms = self.pca_registrar.compute_pca_transforms(
             reference_image=pca_field_reference_image,
         )
-        self.pca_forward_point_transform = pca_transforms["forward_point_transform"]
-        self.pca_inverse_point_transform = pca_transforms["inverse_point_transform"]
+        self.pca_moving_to_fixed_transform = pca_transforms["moving_to_fixed_transform"]
+        self.pca_fixed_to_moving_transform = pca_transforms["fixed_to_moving_transform"]
 
         if self.log_level == logging.DEBUG:
-            tfm_field = self.pca_forward_point_transform.GetDisplacementField()
+            tfm_field = self.pca_moving_to_fixed_transform.GetDisplacementField()
             tfm_arr = itk.GetArrayFromImage(tfm_field)
             tfm_x_arr = tfm_arr[:, :, :, 0]
             tfm_y_arr = tfm_arr[:, :, :, 1]
@@ -690,19 +692,19 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
             tfm_z_img.CopyInformation(tfm_field)
 
         if self.use_surface:
-            # forward_point_transform excludes the post-PCA step and is defined
+            # moving_to_fixed_transform excludes the post-PCA step and is defined
             # in the un-aligned template frame, so warp the raw volumetric
             # template with it and then apply the ICP alignment.
-            assert self.icp_forward_point_transform is not None, (
+            assert self.icp_moving_to_fixed_transform is not None, (
                 "ICP forward transform must be set"
             )
             deformed_template_model = self._transform_model_dataset(
                 self.template_model,
-                self.pca_forward_point_transform,
+                self.pca_moving_to_fixed_transform,
             )
             self.pca_template_model = self._transform_model_dataset(
                 deformed_template_model,
-                self.icp_forward_point_transform,
+                self.icp_moving_to_fixed_transform,
             )
         else:
             self.pca_template_model = registered_model
@@ -719,12 +721,12 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
             # applies its transforms in reverse order of addition, so the ICP
             # inverse is added last. Resampling the raw template labelmap in one
             # step also avoids a second round of nearest-neighbor sampling.
-            assert self.icp_inverse_point_transform is not None, (
+            assert self.icp_fixed_to_moving_transform is not None, (
                 "ICP inverse transform must be set"
             )
             pca_image_transform = itk.CompositeTransform[itk.D, 3].New()
-            pca_image_transform.AddTransform(self.pca_inverse_point_transform)
-            pca_image_transform.AddTransform(self.icp_inverse_point_transform)
+            pca_image_transform.AddTransform(self.pca_fixed_to_moving_transform)
+            pca_image_transform.AddTransform(self.icp_fixed_to_moving_transform)
             self.pca_template_labelmap = self.transform_tools.transform_image(
                 self.template_labelmap,
                 pca_image_transform,
@@ -740,8 +742,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
 
         return {
             "pca_coefficients": self.pca_coefficients,
-            "forward_point_transform": self.pca_forward_point_transform,
-            "inverse_point_transform": self.pca_inverse_point_transform,
+            "moving_to_fixed_transform": self.pca_moving_to_fixed_transform,
+            "fixed_to_moving_transform": self.pca_fixed_to_moving_transform,
             "fitted_reference_model": self.pca_template_model,
             "fitted_reference_mesh": self.pca_template_model_surface,
             "fitted_reference_labelmap": self.pca_template_labelmap,
@@ -755,8 +757,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
 
         Returns:
             dict: Dictionary containing:
-                - 'forward_transform': template to patient space transform
-                - 'inverse_transform': patient to template space transform
+                - 'fixed_to_moving_transform': template to patient space transform
+                - 'moving_to_fixed_transform': patient to template space transform
                 - 'fitted_reference_mesh': Transformed template model surface
                 - 'fitted_reference_labelmap': Transformed template labelmap
         """
@@ -801,8 +803,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         )
 
         # Store results
-        self.l2l_forward_transform = l2l_result["forward_transform"]
-        self.l2l_inverse_transform = l2l_result["inverse_transform"]
+        self.l2l_fixed_to_moving_transform = l2l_result["fixed_to_moving_transform"]
+        self.l2l_moving_to_fixed_transform = l2l_result["moving_to_fixed_transform"]
         self.l2l_template_model_surface = l2l_result["registered_model"]
 
         self.fitted_reference_mesh = self.l2l_template_model_surface
@@ -810,7 +812,7 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         if self.pca_template_labelmap is not None:
             self.l2l_template_labelmap = self.transform_tools.transform_image(
                 self.pca_template_labelmap,
-                self.l2l_forward_transform,
+                self.l2l_fixed_to_moving_transform,
                 self.patient_image,
                 interpolation_method="nearest",
             )
@@ -822,8 +824,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         self.log_info("Stage 3 complete: Labelmap-to-labelmap registration finished.")
 
         return {
-            "forward_transform": self.l2l_forward_transform,
-            "inverse_transform": self.l2l_inverse_transform,
+            "fixed_to_moving_transform": self.l2l_fixed_to_moving_transform,
+            "moving_to_fixed_transform": self.l2l_moving_to_fixed_transform,
             "fitted_reference_mesh": self.l2l_template_model_surface,
             "fitted_reference_labelmap": self.l2l_template_labelmap,
         }
@@ -838,8 +840,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
 
         Returns:
             dict: Dictionary containing:
-                - 'inverse_transform': patient to template space transform
-                - 'forward_transform': template to patient space transform
+                - 'moving_to_fixed_transform': patient to template space transform
+                - 'fixed_to_moving_transform': template to patient space transform
                 - 'fitted_reference_mesh': Transformed template model surface
                 - 'fitted_reference_labelmap': Transformed template labelmap
         """
@@ -910,8 +912,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         result = self.registrar_Greedy.register(
             moving_image=template_labelmap, moving_mask=template_mask
         )
-        self.l2i_inverse_transform = result["inverse_transform"]
-        self.l2i_forward_transform = result["forward_transform"]
+        self.l2i_moving_to_fixed_transform = result["moving_to_fixed_transform"]
+        self.l2i_fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
         if use_ICON_refinement:
             # Configure Icon registration
@@ -920,12 +922,12 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
 
             # Perform Icon registration, refining the alignment found so far
             result = self.registrar_ICON.register_from(
-                self.l2i_forward_transform,
+                self.l2i_fixed_to_moving_transform,
                 template_labelmap,
                 moving_mask=template_mask,
             )
-            self.l2i_inverse_transform = result["inverse_transform"]
-            self.l2i_forward_transform = result["forward_transform"]
+            self.l2i_moving_to_fixed_transform = result["moving_to_fixed_transform"]
+            self.l2i_fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
         # Transform model with result - use the best available pre-L2I surface.
         source_surface = (
@@ -942,14 +944,14 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
             pv.PolyData,
             self._transform_model_dataset(
                 source_surface,
-                self.l2i_inverse_transform,
+                self.l2i_moving_to_fixed_transform,
                 with_deformation_magnitude=True,
             ),
         )
 
         self.l2i_template_labelmap = self.transform_tools.transform_image(
             propagated_labelmap,
-            self.l2i_forward_transform,
+            self.l2i_fixed_to_moving_transform,
             self.patient_image,
             interpolation_method="nearest",
         )
@@ -961,8 +963,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         self.fitted_reference_labelmap = self.l2i_template_labelmap
 
         return {
-            "inverse_transform": self.l2i_inverse_transform,
-            "forward_transform": self.l2i_forward_transform,
+            "moving_to_fixed_transform": self.l2i_moving_to_fixed_transform,
+            "fixed_to_moving_transform": self.l2i_fixed_to_moving_transform,
             "fitted_reference_mesh": self.l2i_template_model_surface,
             "fitted_reference_labelmap": self.l2i_template_labelmap,
         }
@@ -999,8 +1001,8 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
             # applied again here.
             assert self.pca_registrar is not None, "PCA registrar must be set"
             pca_transform = (
-                self.pca_forward_point_transform
-                or self.pca_registrar.forward_point_transform
+                self.pca_moving_to_fixed_transform
+                or self.pca_registrar.moving_to_fixed_transform
             )
             if pca_transform is not None:
                 transform_steps.append(("PCA", pca_transform))
@@ -1008,12 +1010,16 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
                 transform_steps.append(
                     ("PCA post-transform", self.pca_registrar.post_pca_transform)
                 )
-        elif self.icp_forward_point_transform is not None:
-            transform_steps.append(("ICP", self.icp_forward_point_transform))
-        if self.use_l2l_registration and self.l2l_inverse_transform is not None:
-            transform_steps.append(("Labelmap-to-labelmap", self.l2l_inverse_transform))
-        if self.use_l2i_registration and self.l2i_inverse_transform is not None:
-            transform_steps.append(("Labelmap-to-image", self.l2i_inverse_transform))
+        elif self.icp_moving_to_fixed_transform is not None:
+            transform_steps.append(("ICP", self.icp_moving_to_fixed_transform))
+        if self.use_l2l_registration and self.l2l_moving_to_fixed_transform is not None:
+            transform_steps.append(
+                ("Labelmap-to-labelmap", self.l2l_moving_to_fixed_transform)
+            )
+        if self.use_l2i_registration and self.l2i_moving_to_fixed_transform is not None:
+            transform_steps.append(
+                ("Labelmap-to-image", self.l2i_moving_to_fixed_transform)
+            )
 
         for i, (name, tfm) in enumerate(transform_steps, start=1):
             self.log_progress(i, len(transform_steps), prefix=f"Applying {name}")

--- a/src/monai_physio/workflow_fit_statistical_model_to_patient.py
+++ b/src/monai_physio/workflow_fit_statistical_model_to_patient.py
@@ -540,7 +540,6 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         )
 
         # Store results
-        # Note: Point transforms are in opposite direction from image transforms
         self.icp_moving_to_fixed_transform = icp_result["moving_to_fixed_transform"]
         self.icp_fixed_to_moving_transform = icp_result["fixed_to_moving_transform"]
         self.icp_template_model_surface = icp_result["registered_model"]

--- a/src/monai_physio/workflow_reconstruct_highres_4d_ct.py
+++ b/src/monai_physio/workflow_reconstruct_highres_4d_ct.py
@@ -69,9 +69,9 @@ class WorkflowReconstructHighres4DCT(MONAIPhysioBase):
             reference image as-is, or a pixel-by-pixel mean/max composite of
             the reference image and all registered time-series images
         registrar (RegisterTimeSeriesImages): Internal registration object
-        forward_transforms (list[itk.Transform]): one per frame; each warps its
+        fixed_to_moving_transforms (list[itk.Transform]): one per frame; each warps its
             moving image onto the reference grid
-        inverse_transforms (list[itk.Transform]): one per frame; each warps the
+        moving_to_fixed_transforms (list[itk.Transform]): one per frame; each warps the
             reference image onto that frame's moving grid (used for reconstruction)
         losses (list[float]): Registration loss values
         reconstructed_images (list[itk.Image]): Reconstructed high-resolution images
@@ -86,7 +86,7 @@ class WorkflowReconstructHighres4DCT(MONAIPhysioBase):
         >>>
         >>> # Access results
         >>> reconstructed = result['reconstructed_images']
-        >>> transforms = result['forward_transforms']
+        >>> transforms = result['fixed_to_moving_transforms']
         >>> losses = result['losses']
     """
 
@@ -167,8 +167,8 @@ class WorkflowReconstructHighres4DCT(MONAIPhysioBase):
         )
 
         # Results storage
-        self.forward_transforms: Optional[list[itk.Transform]] = None
-        self.inverse_transforms: Optional[list[itk.Transform]] = None
+        self.fixed_to_moving_transforms: Optional[list[itk.Transform]] = None
+        self.moving_to_fixed_transforms: Optional[list[itk.Transform]] = None
         self.losses: Optional[list[float]] = None
         self.reconstructed_images: Optional[list[itk.Image]] = None
 
@@ -226,9 +226,9 @@ class WorkflowReconstructHighres4DCT(MONAIPhysioBase):
 
         Returns:
             dict: Dictionary containing:
-                - 'forward_transforms' (list[itk.Transform]): one per frame;
+                - 'fixed_to_moving_transforms' (list[itk.Transform]): one per frame;
                   each warps its moving image onto the reference grid
-                - 'inverse_transforms' (list[itk.Transform]): one per frame;
+                - 'moving_to_fixed_transforms' (list[itk.Transform]): one per frame;
                   each warps the reference image onto that frame's moving grid
                   (see docs/developer/transform_conventions)
                 - 'losses' (list[float]): Registration loss value for each image
@@ -263,8 +263,8 @@ class WorkflowReconstructHighres4DCT(MONAIPhysioBase):
         )
 
         # Store results
-        self.forward_transforms = result["forward_transforms"]
-        self.inverse_transforms = result["inverse_transforms"]
+        self.fixed_to_moving_transforms = result["fixed_to_moving_transforms"]
+        self.moving_to_fixed_transforms = result["moving_to_fixed_transforms"]
         self.losses = result["losses"]
 
         self.log_info("Stage 1 complete: Time series registration finished.")
@@ -273,8 +273,8 @@ class WorkflowReconstructHighres4DCT(MONAIPhysioBase):
         self.log_info(f"  Max loss: {max(self.losses):.6f}")
 
         return {
-            "forward_transforms": self.forward_transforms,
-            "inverse_transforms": self.inverse_transforms,
+            "fixed_to_moving_transforms": self.fixed_to_moving_transforms,
+            "moving_to_fixed_transforms": self.moving_to_fixed_transforms,
             "losses": self.losses,
         }
 
@@ -327,11 +327,11 @@ class WorkflowReconstructHighres4DCT(MONAIPhysioBase):
 
         Raises:
             RuntimeError: If reconstruction fails
-            ValueError: If inverse_transforms is not set (call register_time_series first)
+            ValueError: If moving_to_fixed_transforms is not set (call register_time_series first)
         """
-        if self.inverse_transforms is None:
+        if self.moving_to_fixed_transforms is None:
             raise ValueError(
-                "inverse_transforms not set. Call register_time_series() first."
+                "moving_to_fixed_transforms not set. Call register_time_series() first."
             )
 
         self.log_section(
@@ -346,9 +346,9 @@ class WorkflowReconstructHighres4DCT(MONAIPhysioBase):
         # Reconstruct time series
         self.reconstructed_images = self.registrar.reconstruct_time_series(
             moving_images=self.time_series_images,
-            inverse_transforms=self.inverse_transforms,
+            moving_to_fixed_transforms=self.moving_to_fixed_transforms,
             upsample_to_fixed_resolution=self.upsample_to_fixed_resolution,
-            forward_transforms=self.forward_transforms,
+            fixed_to_moving_transforms=self.fixed_to_moving_transforms,
             composite_mode=self.composite_mode,
         )
 
@@ -372,8 +372,8 @@ class WorkflowReconstructHighres4DCT(MONAIPhysioBase):
 
         Returns:
             dict: Dictionary containing all results:
-                - 'forward_transforms' (list[itk.Transform]): Registration transforms
-                - 'inverse_transforms' (list[itk.Transform]): Inverse transforms
+                - 'fixed_to_moving_transforms' (list[itk.Transform]): Registration transforms
+                - 'moving_to_fixed_transforms' (list[itk.Transform]): Inverse transforms
                 - 'losses' (list[float]): Registration loss values
                 - 'reconstructed_images' (list[itk.Image]): Reconstructed high-res images
 
@@ -407,8 +407,8 @@ class WorkflowReconstructHighres4DCT(MONAIPhysioBase):
         )
 
         return {
-            "forward_transforms": self.forward_transforms,
-            "inverse_transforms": self.inverse_transforms,
+            "fixed_to_moving_transforms": self.fixed_to_moving_transforms,
+            "moving_to_fixed_transforms": self.moving_to_fixed_transforms,
             "losses": self.losses,
             "reconstructed_images": self.reconstructed_images,
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -722,22 +722,33 @@ def test_transforms(
     """
     small_data_dir = test_directories["slicer_heart_small_data"]
     frame_tag = "001_to_007"
-    inverse_transform_path = small_data_dir / f"ants_inverse_transform_{frame_tag}.hdf"
-    forward_transform_path = small_data_dir / f"ants_forward_transform_{frame_tag}.hdf"
+    moving_to_fixed_transform_path = (
+        small_data_dir / f"ants_moving_to_fixed_transform_{frame_tag}.hdf"
+    )
+    fixed_to_moving_transform_path = (
+        small_data_dir / f"ants_fixed_to_moving_transform_{frame_tag}.hdf"
+    )
 
-    if inverse_transform_path.exists() and forward_transform_path.exists():
+    if (
+        moving_to_fixed_transform_path.exists()
+        and fixed_to_moving_transform_path.exists()
+    ):
         logger.info("Loading existing ANTs registration results")
         try:
-            inverse_transform = itk.transformread(str(inverse_transform_path))
-            forward_transform = itk.transformread(str(forward_transform_path))
+            moving_to_fixed_transform = itk.transformread(
+                str(moving_to_fixed_transform_path)
+            )
+            fixed_to_moving_transform = itk.transformread(
+                str(fixed_to_moving_transform_path)
+            )
             return {
-                "inverse_transform": inverse_transform,
-                "forward_transform": forward_transform,
+                "moving_to_fixed_transform": moving_to_fixed_transform,
+                "fixed_to_moving_transform": fixed_to_moving_transform,
             }
         except (RuntimeError, Exception) as e:
             logger.warning("Error loading transforms: %s; regenerating", e)
-            inverse_transform_path.unlink(missing_ok=True)
-            forward_transform_path.unlink(missing_ok=True)
+            moving_to_fixed_transform_path.unlink(missing_ok=True)
+            fixed_to_moving_transform_path.unlink(missing_ok=True)
 
     # Perform registration if files don't exist or loading failed
     logger.info("Performing ANTs registration")
@@ -747,14 +758,18 @@ def test_transforms(
     registrar_ANTS.set_fixed_image(fixed_image)
     result = registrar_ANTS.register(moving_image=moving_image)
 
-    inverse_transform = result["inverse_transform"]
-    forward_transform = result["forward_transform"]
+    moving_to_fixed_transform = result["moving_to_fixed_transform"]
+    fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
-    itk.transformwrite(inverse_transform, str(inverse_transform_path), compression=True)
-    itk.transformwrite(forward_transform, str(forward_transform_path), compression=True)
+    itk.transformwrite(
+        moving_to_fixed_transform, str(moving_to_fixed_transform_path), compression=True
+    )
+    itk.transformwrite(
+        fixed_to_moving_transform, str(fixed_to_moving_transform_path), compression=True
+    )
     return {
-        "inverse_transform": inverse_transform,
-        "forward_transform": forward_transform,
+        "moving_to_fixed_transform": moving_to_fixed_transform,
+        "fixed_to_moving_transform": fixed_to_moving_transform,
     }
 
 
@@ -824,7 +839,7 @@ class KnownShiftCase:
 
     ``moving`` is built by resampling ``fixed`` through a translation of
     ``shift_mm``, so ``moving(q) == fixed(q + shift_mm)``. Warping ``moving``
-    back onto the fixed grid therefore requires a ``forward_transform`` of
+    back onto the fixed grid therefore requires a ``fixed_to_moving_transform`` of
     ``-shift_mm``, which gives an absolute accuracy target instead of the
     "did it return something" checks that let a sign error go unnoticed.
     """
@@ -860,17 +875,20 @@ class KnownShiftCase:
         self._fixed_array = itk.array_from_image(fixed_image)
         self._foreground = self._fixed_array >= np.percentile(self._fixed_array, 70)
 
-    def center_error_mm(self, forward_transform: itk.Transform) -> float:
+    def center_error_mm(self, fixed_to_moving_transform: itk.Transform) -> float:
         """Distance, in mm, between the recovered and true displacement."""
         displacement = np.array(
-            list(forward_transform.TransformPoint(self._center))
+            list(fixed_to_moving_transform.TransformPoint(self._center))
         ) - np.array(self._center)
         return float(np.linalg.norm(displacement - self.expected_displacement))
 
-    def foreground_ncc(self, forward_transform: itk.Transform) -> float:
+    def foreground_ncc(self, fixed_to_moving_transform: itk.Transform) -> float:
         """Normalized cross-correlation after warping moving onto the fixed grid."""
         warped = self.transform_tools.transform_image(
-            self.moving, forward_transform, self.fixed, interpolation_method="linear"
+            self.moving,
+            fixed_to_moving_transform,
+            self.fixed,
+            interpolation_method="linear",
         )
         moved = itk.array_from_image(warped)[self._foreground]
         target = self._fixed_array[self._foreground]
@@ -908,7 +926,7 @@ class KnownAffineCase:
 
     ``moving`` is built by resampling ``fixed`` through ``A``, so
     ``moving(q) == fixed(A(q))``. Warping ``moving`` back onto the fixed grid
-    therefore needs a ``forward_transform`` of ``A^-1``, which is the exact
+    therefore needs a ``fixed_to_moving_transform`` of ``A^-1``, which is the exact
     answer every probe is measured against.
     """
 
@@ -1029,11 +1047,11 @@ class KnownAffineCase:
         points.append(self._center.tolist())
         return points
 
-    def probe_errors_mm(self, forward_transform: itk.Transform) -> np.ndarray:
+    def probe_errors_mm(self, fixed_to_moving_transform: itk.Transform) -> np.ndarray:
         """Return the per-probe distance, in mm, from the exact answer."""
         errors = []
         for point in self.probe_points():
-            recovered = np.array(list(forward_transform.TransformPoint(point)))
+            recovered = np.array(list(fixed_to_moving_transform.TransformPoint(point)))
             exact = np.array(list(self.expected.TransformPoint(point)))
             errors.append(float(np.linalg.norm(recovered - exact)))
         return np.asarray(errors)

--- a/tests/test_image_tools.py
+++ b/tests/test_image_tools.py
@@ -251,14 +251,14 @@ class TestImageTools:
         img_output_dir.mkdir(exist_ok=True)
 
         fixed_image = test_images[0]
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         print("\nTesting imwriteVD3 and imreadVD3...")
 
         # Generate a deformation field using TransformTools
         transform_tools = TransformTools()
         deformation_field = transform_tools.convert_transform_to_displacement_field(
-            forward_transform, fixed_image
+            fixed_to_moving_transform, fixed_image
         )
 
         # Verify it's double precision vector image

--- a/tests/test_register_images_ants.py
+++ b/tests/test_register_images_ants.py
@@ -104,29 +104,41 @@ class TestRegisterImagesANTS:
 
         # Verify result is a dictionary
         assert isinstance(result, dict), "Result should be a dictionary"
-        assert "inverse_transform" in result, "Missing inverse_transform in result"
-        assert "forward_transform" in result, "Missing forward_transform in result"
+        assert "moving_to_fixed_transform" in result, (
+            "Missing moving_to_fixed_transform in result"
+        )
+        assert "fixed_to_moving_transform" in result, (
+            "Missing fixed_to_moving_transform in result"
+        )
 
-        inverse_transform = result["inverse_transform"]
-        forward_transform = result["forward_transform"]
+        moving_to_fixed_transform = result["moving_to_fixed_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
         # Verify transforms are valid
-        assert inverse_transform is not None, "inverse_transform is None"
-        assert forward_transform is not None, "forward_transform is None"
+        assert moving_to_fixed_transform is not None, (
+            "moving_to_fixed_transform is None"
+        )
+        assert fixed_to_moving_transform is not None, (
+            "fixed_to_moving_transform is None"
+        )
 
         print("Registration complete without mask")
-        print(f"  inverse_transform type: {type(inverse_transform).__name__}")
-        print(f"  forward_transform type: {type(forward_transform).__name__}")
+        print(
+            f"  moving_to_fixed_transform type: {type(moving_to_fixed_transform).__name__}"
+        )
+        print(
+            f"  fixed_to_moving_transform type: {type(fixed_to_moving_transform).__name__}"
+        )
 
         # Save transforms
         itk.transformwrite(
-            [inverse_transform],
-            str(reg_output_dir / "ants_inverse_transform_no_mask.hdf"),
+            [moving_to_fixed_transform],
+            str(reg_output_dir / "ants_moving_to_fixed_transform_no_mask.hdf"),
             compression=True,
         )
         itk.transformwrite(
-            [forward_transform],
-            str(reg_output_dir / "ants_forward_transform_no_mask.hdf"),
+            [fixed_to_moving_transform],
+            str(reg_output_dir / "ants_fixed_to_moving_transform_no_mask.hdf"),
             compression=True,
         )
         print(f"  Saved transforms to: {reg_output_dir}")
@@ -201,26 +213,34 @@ class TestRegisterImagesANTS:
 
         # Verify result
         assert isinstance(result, dict), "Result should be a dictionary"
-        assert "inverse_transform" in result, "Missing inverse_transform in result"
-        assert "forward_transform" in result, "Missing forward_transform in result"
+        assert "moving_to_fixed_transform" in result, (
+            "Missing moving_to_fixed_transform in result"
+        )
+        assert "fixed_to_moving_transform" in result, (
+            "Missing fixed_to_moving_transform in result"
+        )
 
-        inverse_transform = result["inverse_transform"]
-        forward_transform = result["forward_transform"]
+        moving_to_fixed_transform = result["moving_to_fixed_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
-        assert inverse_transform is not None, "inverse_transform is None"
-        assert forward_transform is not None, "forward_transform is None"
+        assert moving_to_fixed_transform is not None, (
+            "moving_to_fixed_transform is None"
+        )
+        assert fixed_to_moving_transform is not None, (
+            "fixed_to_moving_transform is None"
+        )
 
         print("Registration complete with masks")
 
         # Save transforms
         itk.transformwrite(
-            [inverse_transform],
-            str(reg_output_dir / "ants_inverse_transform_with_mask.hdf"),
+            [moving_to_fixed_transform],
+            str(reg_output_dir / "ants_moving_to_fixed_transform_with_mask.hdf"),
             compression=True,
         )
         itk.transformwrite(
-            [forward_transform],
-            str(reg_output_dir / "ants_forward_transform_with_mask.hdf"),
+            [fixed_to_moving_transform],
+            str(reg_output_dir / "ants_fixed_to_moving_transform_with_mask.hdf"),
             compression=True,
         )
 
@@ -243,14 +263,17 @@ class TestRegisterImagesANTS:
         registrar_ANTS.set_fixed_image(fixed_image)
         result = registrar_ANTS.register(moving_image=moving_image)
 
-        forward_transform = result["forward_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
         print("\nApplying transform to moving image...")
 
         # Apply transform
         transform_tools = TransformTools()
         registered_image = transform_tools.transform_image(
-            moving_image, forward_transform, fixed_image, interpolation_method="linear"
+            moving_image,
+            fixed_to_moving_transform,
+            fixed_image,
+            interpolation_method="linear",
         )
 
         # Verify registered image
@@ -309,10 +332,10 @@ class TestRegisterImagesANTS:
         registrar.set_fixed_image(known_shift_case.fixed)
 
         result = registrar.register(moving_image=known_shift_case.moving)
-        forward_transform = result["forward_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
-        error_mm = known_shift_case.center_error_mm(forward_transform)
-        ncc = known_shift_case.foreground_ncc(forward_transform)
+        error_mm = known_shift_case.center_error_mm(fixed_to_moving_transform)
+        ncc = known_shift_case.foreground_ncc(fixed_to_moving_transform)
         unregistered_ncc = known_shift_case.unregistered_ncc()
 
         print("\nANTs known-shift recovery:")
@@ -355,8 +378,12 @@ class TestRegisterImagesANTS:
         )
 
         assert isinstance(result, dict), "Result should be a dictionary"
-        assert result["inverse_transform"] is not None, "inverse_transform is None"
-        assert result["forward_transform"] is not None, "forward_transform is None"
+        assert result["moving_to_fixed_transform"] is not None, (
+            "moving_to_fixed_transform is None"
+        )
+        assert result["fixed_to_moving_transform"] is not None, (
+            "fixed_to_moving_transform is None"
+        )
 
         print("Registration with initial transform complete")
 
@@ -369,8 +396,8 @@ class TestRegisterImagesANTS:
         """Verify the register_from() composition path with metrics.
 
         Exercises the two initial-transform inputs the platform actually uses
-        (identity and a prior deformable forward_transform, as in prior-based
-        time-series registration) and confirms the composed forward_transform
+        (identity and a prior deformable fixed_to_moving_transform, as in prior-based
+        time-series registration) and confirms the composed fixed_to_moving_transform
         warps the moving image onto the fixed grid. Scored with foreground NCC
         over the brightest 30% of the fixed image (tissue/blood pool). See
         docs/developer/transform_conventions.
@@ -404,10 +431,10 @@ class TestRegisterImagesANTS:
 
         transform_tools = TransformTools()
 
-        def warp_score(forward_transform: Any) -> float:
+        def warp_score(fixed_to_moving_transform: Any) -> float:
             warped = transform_tools.transform_image(
                 moving_image,
-                forward_transform,
+                fixed_to_moving_transform,
                 fixed_image,
                 interpolation_method="linear",
             )
@@ -419,7 +446,7 @@ class TestRegisterImagesANTS:
         registrar_ANTS.set_modality("ct")
         registrar_ANTS.set_fixed_image(fixed_image)
         baseline = registrar_ANTS.register(moving_image=moving_image)
-        ncc_baseline = warp_score(baseline["forward_transform"])
+        ncc_baseline = warp_score(baseline["fixed_to_moving_transform"])
 
         # Identity initial: the composition machinery must be a no-op.
         identity = itk.AffineTransform[itk.D, 3].New()
@@ -428,17 +455,17 @@ class TestRegisterImagesANTS:
         registrar_identity.set_modality("ct")
         registrar_identity.set_fixed_image(fixed_image)
         identity_result = registrar_identity.register_from(identity, moving_image)
-        ncc_identity = warp_score(identity_result["forward_transform"])
+        ncc_identity = warp_score(identity_result["fixed_to_moving_transform"])
 
         # Prior deformable initial: the realistic time-series prior use case.
         registrar_prior = RegisterImagesANTS()
         registrar_prior.set_modality("ct")
         registrar_prior.set_fixed_image(fixed_image)
         prior_result = registrar_prior.register_from(
-            baseline["forward_transform"],
+            baseline["fixed_to_moving_transform"],
             moving_image,
         )
-        ncc_prior = warp_score(prior_result["forward_transform"])
+        ncc_prior = warp_score(prior_result["fixed_to_moving_transform"])
 
         print("\nANTS initial-transform composition metrics (foreground NCC):")
         print(f"  unregistered:          {ncc_unregistered:.4f}")
@@ -448,7 +475,7 @@ class TestRegisterImagesANTS:
 
         warped_prior = transform_tools.transform_image(
             moving_image,
-            prior_result["forward_transform"],
+            prior_result["fixed_to_moving_transform"],
             fixed_image,
             interpolation_method="linear",
         )
@@ -485,7 +512,7 @@ class TestRegisterImagesANTS:
         Regression guard for the previously-broken matrix initial_transform
         path: feeding a translation initial used to corrupt the composition
         (foreground NCC far below the unregistered pair). With the moving image
-        pre-warped by the initial, the composed forward_transform must align the
+        pre-warped by the initial, the composed fixed_to_moving_transform must align the
         moving image onto the fixed grid at least as well as the unregistered
         pair.
         """
@@ -509,7 +536,7 @@ class TestRegisterImagesANTS:
         transform_tools = TransformTools()
         warped = transform_tools.transform_image(
             moving_image,
-            result["forward_transform"],
+            result["fixed_to_moving_transform"],
             fixed_image,
             interpolation_method="linear",
         )
@@ -554,7 +581,7 @@ class TestRegisterImagesANTS:
             result = registrar.register(moving_image=moving_image)
             warped = transform_tools.transform_image(
                 moving_image,
-                result["forward_transform"],
+                result["fixed_to_moving_transform"],
                 fixed_image,
                 interpolation_method="linear",
             )
@@ -587,11 +614,11 @@ class TestRegisterImagesANTS:
             results.append(result)
 
             assert isinstance(result, dict), f"Result {i + 1} should be a dictionary"
-            assert "inverse_transform" in result, (
-                f"Missing inverse_transform in result {i + 1}"
+            assert "moving_to_fixed_transform" in result, (
+                f"Missing moving_to_fixed_transform in result {i + 1}"
             )
-            assert "forward_transform" in result, (
-                f"Missing forward_transform in result {i + 1}"
+            assert "fixed_to_moving_transform" in result, (
+                f"Missing fixed_to_moving_transform in result {i + 1}"
             )
 
         print(f"Multiple registrations complete: {len(results)} runs")
@@ -607,22 +634,26 @@ class TestRegisterImagesANTS:
         registrar_ANTS.set_fixed_image(fixed_image)
         result = registrar_ANTS.register(moving_image=moving_image)
 
-        inverse_transform = result["inverse_transform"]
-        forward_transform = result["forward_transform"]
+        moving_to_fixed_transform = result["moving_to_fixed_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
         print("\nVerifying transform types...")
 
         # Check that transforms are CompositeTransform (ANTs returns composite)
-        assert isinstance(inverse_transform, itk.CompositeTransform), (
-            f"inverse_transform should be CompositeTransform, got {type(inverse_transform)}"
+        assert isinstance(moving_to_fixed_transform, itk.CompositeTransform), (
+            f"moving_to_fixed_transform should be CompositeTransform, got {type(moving_to_fixed_transform)}"
         )
-        assert isinstance(forward_transform, itk.CompositeTransform), (
-            f"forward_transform should be CompositeTransform, got {type(forward_transform)}"
+        assert isinstance(fixed_to_moving_transform, itk.CompositeTransform), (
+            f"fixed_to_moving_transform should be CompositeTransform, got {type(fixed_to_moving_transform)}"
         )
 
         print("Transform types verified")
-        print(f"  inverse_transform: {type(inverse_transform).__name__}")
-        print(f"  forward_transform: {type(forward_transform).__name__}")
+        print(
+            f"  moving_to_fixed_transform: {type(moving_to_fixed_transform).__name__}"
+        )
+        print(
+            f"  fixed_to_moving_transform: {type(fixed_to_moving_transform).__name__}"
+        )
 
     def test_image_conversion_cycle_scalar(
         self, registrar_ANTS: RegisterImagesANTS, test_images: list[Any]

--- a/tests/test_register_images_base.py
+++ b/tests/test_register_images_base.py
@@ -108,7 +108,7 @@ def test_get_registered_image_fills_with_modality_background() -> None:
     registrar.set_modality("ct")
     registrar.set_fixed_image(_uniform_image(0.0, np.float32))
     registrar.moving_image = _uniform_image(100.0, np.float32)
-    registrar.forward_transform = _shift_transform()
+    registrar.fixed_to_moving_transform = _shift_transform()
 
     registered = registrar.get_registered_image()
 

--- a/tests/test_register_images_chain.py
+++ b/tests/test_register_images_chain.py
@@ -69,8 +69,8 @@ class _RecordingRegistrar(RegisterImagesBase):
         inverse = itk.TranslationTransform[itk.D, 3].New()
         inverse.SetOffset([-self.sentinel_value, 0.0, 0.0])
         return {
-            "forward_transform": forward,
-            "inverse_transform": inverse,
+            "fixed_to_moving_transform": forward,
+            "moving_to_fixed_transform": inverse,
             "loss": self.sentinel_value,
         }
 
@@ -93,7 +93,7 @@ def test_chain_refines_previous_stage_result() -> None:
     assert stage1.seen_moving_image is moving
     # Stage 2 registers the pre-warped image, not the caller's image.
     assert stage2.seen_moving_image is not moving
-    composed = cast(itk.Transform, result["forward_transform"])
+    composed = cast(itk.Transform, result["fixed_to_moving_transform"])
     assert list(composed.TransformPoint([0.0, 0.0, 0.0])) == [3.0, 0.0, 0.0]
     assert result["loss"] == 2.0
 
@@ -113,7 +113,7 @@ class _CompositeRegistrar(_RecordingRegistrar):
         result = super().registration_method(
             moving_image, moving_mask, moving_labelmap, moving_image_pre
         )
-        for key in ("forward_transform", "inverse_transform"):
+        for key in ("fixed_to_moving_transform", "moving_to_fixed_transform"):
             composite = itk.CompositeTransform[itk.D, 3].New()
             composite.AddTransform(cast(itk.Transform, result[key]))
             result[key] = composite
@@ -134,7 +134,7 @@ def test_chain_result_holds_no_nested_composite(tmp_path: Any) -> None:
 
     result = chain.register(_small_image())
 
-    for key in ("forward_transform", "inverse_transform"):
+    for key in ("fixed_to_moving_transform", "moving_to_fixed_transform"):
         composed = cast(itk.Transform, result[key])
         assert isinstance(composed, itk.CompositeTransform[itk.D, 3])
         for i in range(composed.GetNumberOfTransforms()):
@@ -143,7 +143,7 @@ def test_chain_result_holds_no_nested_composite(tmp_path: Any) -> None:
         itk.transformwrite(composed, str(tmp_path / f"{key}.hdf"))
 
     # Splicing the sub-transforms in must leave the mapping unchanged.
-    forward = cast(itk.Transform, result["forward_transform"])
+    forward = cast(itk.Transform, result["fixed_to_moving_transform"])
     assert list(forward.TransformPoint([0.0, 0.0, 0.0])) == [3.0, 0.0, 0.0]
 
 

--- a/tests/test_register_images_greedy.py
+++ b/tests/test_register_images_greedy.py
@@ -103,24 +103,32 @@ class TestRegisterImagesGreedy:
         result = registrar_greedy.register(moving_image=moving_image)
 
         assert isinstance(result, dict), "Result should be a dictionary"
-        assert "inverse_transform" in result, "Missing inverse_transform in result"
-        assert "forward_transform" in result, "Missing forward_transform in result"
+        assert "moving_to_fixed_transform" in result, (
+            "Missing moving_to_fixed_transform in result"
+        )
+        assert "fixed_to_moving_transform" in result, (
+            "Missing fixed_to_moving_transform in result"
+        )
 
-        inverse_transform = result["inverse_transform"]
-        forward_transform = result["forward_transform"]
+        moving_to_fixed_transform = result["moving_to_fixed_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
-        assert inverse_transform is not None, "inverse_transform is None"
-        assert forward_transform is not None, "forward_transform is None"
+        assert moving_to_fixed_transform is not None, (
+            "moving_to_fixed_transform is None"
+        )
+        assert fixed_to_moving_transform is not None, (
+            "fixed_to_moving_transform is None"
+        )
 
         print("Greedy affine registration complete without mask")
 
         itk.transformwrite(
-            [inverse_transform],
+            [moving_to_fixed_transform],
             str(reg_output_dir / "greedy_affine_inverse_no_mask.hdf"),
             compression=True,
         )
         itk.transformwrite(
-            [forward_transform],
+            [fixed_to_moving_transform],
             str(reg_output_dir / "greedy_affine_forward_no_mask.hdf"),
             compression=True,
         )
@@ -180,8 +188,8 @@ class TestRegisterImagesGreedy:
         )
 
         assert isinstance(result, dict), "Result should be a dictionary"
-        assert result["inverse_transform"] is not None
-        assert result["forward_transform"] is not None
+        assert result["moving_to_fixed_transform"] is not None
+        assert result["fixed_to_moving_transform"] is not None
 
         print("Greedy affine registration complete with masks")
 
@@ -206,10 +214,10 @@ class TestRegisterImagesGreedy:
         registrar.set_fixed_image(known_shift_case.fixed)
 
         result = registrar.register(moving_image=known_shift_case.moving)
-        forward_transform = result["forward_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
-        error_mm = known_shift_case.center_error_mm(forward_transform)
-        ncc = known_shift_case.foreground_ncc(forward_transform)
+        error_mm = known_shift_case.center_error_mm(fixed_to_moving_transform)
+        ncc = known_shift_case.foreground_ncc(fixed_to_moving_transform)
         unregistered_ncc = known_shift_case.unregistered_ncc()
 
         print(f"\nGreedy {transform_type} known-shift recovery:")
@@ -274,7 +282,9 @@ class TestRegisterImagesGreedy:
                 registrar.set_fixed_image(case.fixed)
                 result = registrar.register(moving_image=case.moving)
                 errors.append(
-                    float(case.probe_errors_mm(result["forward_transform"]).max())
+                    float(
+                        case.probe_errors_mm(result["fixed_to_moving_transform"]).max()
+                    )
                 )
             diverged = sum(1 for value in errors if value > 10.0)
             print(
@@ -322,10 +332,13 @@ class TestRegisterImagesGreedy:
         registrar_greedy.set_fixed_image(fixed_image)
         result = registrar_greedy.register(moving_image=moving_image)
 
-        forward_transform = result["forward_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
         transform_tools = TransformTools()
         registered_image = transform_tools.transform_image(
-            moving_image, forward_transform, fixed_image, interpolation_method="linear"
+            moving_image,
+            fixed_to_moving_transform,
+            fixed_image,
+            interpolation_method="linear",
         )
 
         assert registered_image is not None, "Registered image is None"

--- a/tests/test_register_images_icon.py
+++ b/tests/test_register_images_icon.py
@@ -37,10 +37,10 @@ class TestRegisterImagesICON:
         registrar.set_fixed_image(known_shift_case.fixed)
 
         result = registrar.register(moving_image=known_shift_case.moving)
-        forward_transform = result["forward_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
-        error_mm = known_shift_case.center_error_mm(forward_transform)
-        ncc = known_shift_case.foreground_ncc(forward_transform)
+        error_mm = known_shift_case.center_error_mm(fixed_to_moving_transform)
+        ncc = known_shift_case.foreground_ncc(fixed_to_moving_transform)
         unregistered_ncc = known_shift_case.unregistered_ncc()
 
         print("\nICON known-shift recovery:")
@@ -81,7 +81,7 @@ class TestRegisterImagesICON:
             registrar.set_number_of_iterations(5)
             registrar.set_fixed_image(known_shift_case.fixed)
             return registrar.register(moving_image=known_shift_case.moving)[
-                "forward_transform"
+                "fixed_to_moving_transform"
             ]
 
         size = itk.size(known_shift_case.fixed)
@@ -232,29 +232,41 @@ class TestRegisterImagesICON:
 
         # Verify result is a dictionary
         assert isinstance(result, dict), "Result should be a dictionary"
-        assert "inverse_transform" in result, "Missing inverse_transform in result"
-        assert "forward_transform" in result, "Missing forward_transform in result"
+        assert "moving_to_fixed_transform" in result, (
+            "Missing moving_to_fixed_transform in result"
+        )
+        assert "fixed_to_moving_transform" in result, (
+            "Missing fixed_to_moving_transform in result"
+        )
 
-        inverse_transform = result["inverse_transform"]
-        forward_transform = result["forward_transform"]
+        moving_to_fixed_transform = result["moving_to_fixed_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
         # Verify transforms are valid
-        assert inverse_transform is not None, "inverse_transform is None"
-        assert forward_transform is not None, "forward_transform is None"
+        assert moving_to_fixed_transform is not None, (
+            "moving_to_fixed_transform is None"
+        )
+        assert fixed_to_moving_transform is not None, (
+            "fixed_to_moving_transform is None"
+        )
 
         print("ICON registration complete without mask")
-        print(f"  inverse_transform type: {type(inverse_transform).__name__}")
-        print(f"  forward_transform type: {type(forward_transform).__name__}")
+        print(
+            f"  moving_to_fixed_transform type: {type(moving_to_fixed_transform).__name__}"
+        )
+        print(
+            f"  fixed_to_moving_transform type: {type(fixed_to_moving_transform).__name__}"
+        )
 
         # Save transforms
         itk.transformwrite(
-            [inverse_transform],
-            str(reg_output_dir / "icon_inverse_transform_no_mask.hdf"),
+            [moving_to_fixed_transform],
+            str(reg_output_dir / "icon_moving_to_fixed_transform_no_mask.hdf"),
             compression=True,
         )
         itk.transformwrite(
-            [forward_transform],
-            str(reg_output_dir / "icon_forward_transform_no_mask.hdf"),
+            [fixed_to_moving_transform],
+            str(reg_output_dir / "icon_fixed_to_moving_transform_no_mask.hdf"),
             compression=True,
         )
         print(f"  Saved transforms to: {reg_output_dir}")
@@ -330,26 +342,34 @@ class TestRegisterImagesICON:
 
         # Verify result
         assert isinstance(result, dict), "Result should be a dictionary"
-        assert "inverse_transform" in result, "Missing inverse_transform in result"
-        assert "forward_transform" in result, "Missing forward_transform in result"
+        assert "moving_to_fixed_transform" in result, (
+            "Missing moving_to_fixed_transform in result"
+        )
+        assert "fixed_to_moving_transform" in result, (
+            "Missing fixed_to_moving_transform in result"
+        )
 
-        inverse_transform = result["inverse_transform"]
-        forward_transform = result["forward_transform"]
+        moving_to_fixed_transform = result["moving_to_fixed_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
-        assert inverse_transform is not None, "inverse_transform is None"
-        assert forward_transform is not None, "forward_transform is None"
+        assert moving_to_fixed_transform is not None, (
+            "moving_to_fixed_transform is None"
+        )
+        assert fixed_to_moving_transform is not None, (
+            "fixed_to_moving_transform is None"
+        )
 
         print("ICON registration complete with masks")
 
         # Save transforms
         itk.transformwrite(
-            [inverse_transform],
-            str(reg_output_dir / "icon_inverse_transform_with_mask.hdf"),
+            [moving_to_fixed_transform],
+            str(reg_output_dir / "icon_moving_to_fixed_transform_with_mask.hdf"),
             compression=True,
         )
         itk.transformwrite(
-            [forward_transform],
-            str(reg_output_dir / "icon_forward_transform_with_mask.hdf"),
+            [fixed_to_moving_transform],
+            str(reg_output_dir / "icon_fixed_to_moving_transform_with_mask.hdf"),
             compression=True,
         )
 
@@ -373,14 +393,17 @@ class TestRegisterImagesICON:
         registrar_ICON.set_number_of_iterations(2)
         result = registrar_ICON.register(moving_image=moving_image)
 
-        forward_transform = result["forward_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
         print("\nApplying ICON transform to moving image...")
 
         # Apply transform
         transform_tools = TransformTools()
         registered_image = transform_tools.transform_image(
-            moving_image, forward_transform, fixed_image, interpolation_method="linear"
+            moving_image,
+            fixed_to_moving_transform,
+            fixed_image,
+            interpolation_method="linear",
         )
 
         # Verify registered image
@@ -421,8 +444,12 @@ class TestRegisterImagesICON:
         registrar_ICON.set_number_of_iterations(2)
         result = registrar_ICON.register(moving_image=moving_image)
 
-        inverse_transform = cast(itk.Transform, result["inverse_transform"])
-        forward_transform = cast(itk.Transform, result["forward_transform"])
+        moving_to_fixed_transform = cast(
+            itk.Transform, result["moving_to_fixed_transform"]
+        )
+        fixed_to_moving_transform = cast(
+            itk.Transform, result["fixed_to_moving_transform"]
+        )
 
         # Test point transformation
         test_point = itk.Point[itk.D, 3]()
@@ -431,8 +458,10 @@ class TestRegisterImagesICON:
         test_point[2] = float(itk.size(fixed_image)[2] / 2)
 
         # Forward then backward
-        transformed_point = forward_transform.TransformPoint(test_point)
-        back_transformed_point = inverse_transform.TransformPoint(transformed_point)
+        transformed_point = fixed_to_moving_transform.TransformPoint(test_point)
+        back_transformed_point = moving_to_fixed_transform.TransformPoint(
+            transformed_point
+        )
 
         # Calculate error
         error = np.sqrt(
@@ -502,8 +531,12 @@ class TestRegisterImagesICON:
         )
 
         assert isinstance(result, dict), "Result should be a dictionary"
-        assert result["inverse_transform"] is not None, "inverse_transform is None"
-        assert result["forward_transform"] is not None, "forward_transform is None"
+        assert result["moving_to_fixed_transform"] is not None, (
+            "moving_to_fixed_transform is None"
+        )
+        assert result["fixed_to_moving_transform"] is not None, (
+            "fixed_to_moving_transform is None"
+        )
 
         print("Registration with initial transform complete")
 
@@ -519,34 +552,44 @@ class TestRegisterImagesICON:
         registrar_ICON.set_number_of_iterations(2)
         result = registrar_ICON.register(moving_image=moving_image)
 
-        inverse_transform = result["inverse_transform"]
-        forward_transform = result["forward_transform"]
+        moving_to_fixed_transform = result["moving_to_fixed_transform"]
+        fixed_to_moving_transform = result["fixed_to_moving_transform"]
 
         print("\nVerifying ICON transform types...")
 
         # ICON returns transforms (either DisplacementFieldTransform or CompositeTransform wrapping it)
         # The important thing is that they are valid ITK transforms
-        assert inverse_transform is not None, "inverse_transform is None"
-        assert forward_transform is not None, "forward_transform is None"
+        assert moving_to_fixed_transform is not None, (
+            "moving_to_fixed_transform is None"
+        )
+        assert fixed_to_moving_transform is not None, (
+            "fixed_to_moving_transform is None"
+        )
 
         # Check if it's either a DisplacementFieldTransform or CompositeTransform
         valid_inverse = isinstance(
-            inverse_transform, (itk.DisplacementFieldTransform, itk.CompositeTransform)
+            moving_to_fixed_transform,
+            (itk.DisplacementFieldTransform, itk.CompositeTransform),
         )
         valid_forward = isinstance(
-            forward_transform, (itk.DisplacementFieldTransform, itk.CompositeTransform)
+            fixed_to_moving_transform,
+            (itk.DisplacementFieldTransform, itk.CompositeTransform),
         )
 
         assert valid_inverse, (
-            f"inverse_transform should be DisplacementFieldTransform or CompositeTransform, got {type(inverse_transform)}"
+            f"moving_to_fixed_transform should be DisplacementFieldTransform or CompositeTransform, got {type(moving_to_fixed_transform)}"
         )
         assert valid_forward, (
-            f"forward_transform should be DisplacementFieldTransform or CompositeTransform, got {type(forward_transform)}"
+            f"fixed_to_moving_transform should be DisplacementFieldTransform or CompositeTransform, got {type(fixed_to_moving_transform)}"
         )
 
         print("Transform types verified")
-        print(f"  inverse_transform: {type(inverse_transform).__name__}")
-        print(f"  forward_transform: {type(forward_transform).__name__}")
+        print(
+            f"  moving_to_fixed_transform: {type(moving_to_fixed_transform).__name__}"
+        )
+        print(
+            f"  fixed_to_moving_transform: {type(fixed_to_moving_transform).__name__}"
+        )
 
     def test_different_iteration_counts(
         self, registrar_ICON: RegisterImagesICON, test_images: list[Any]
@@ -570,8 +613,12 @@ class TestRegisterImagesICON:
             results.append(result)
 
             assert isinstance(result, dict), "Result should be a dictionary"
-            assert "inverse_transform" in result, "Missing inverse_transform"
-            assert "forward_transform" in result, "Missing forward_transform"
+            assert "moving_to_fixed_transform" in result, (
+                "Missing moving_to_fixed_transform"
+            )
+            assert "fixed_to_moving_transform" in result, (
+                "Missing fixed_to_moving_transform"
+            )
 
         print(f"Tested {len(iteration_counts)} different iteration counts")
 

--- a/tests/test_register_images_icon.py
+++ b/tests/test_register_images_icon.py
@@ -251,12 +251,10 @@ class TestRegisterImagesICON:
         )
 
         print("ICON registration complete without mask")
-        print(
-            f"  moving_to_fixed_transform type: {type(moving_to_fixed_transform).__name__}"
-        )
-        print(
-            f"  fixed_to_moving_transform type: {type(fixed_to_moving_transform).__name__}"
-        )
+        m2f_type = type(moving_to_fixed_transform).__name__
+        f2m_type = type(fixed_to_moving_transform).__name__
+        print(f"  moving_to_fixed_transform type: {m2f_type}")
+        print(f"  fixed_to_moving_transform type: {f2m_type}")
 
         # Save transforms
         itk.transformwrite(
@@ -567,20 +565,17 @@ class TestRegisterImagesICON:
         )
 
         # Check if it's either a DisplacementFieldTransform or CompositeTransform
-        valid_inverse = isinstance(
-            moving_to_fixed_transform,
-            (itk.DisplacementFieldTransform, itk.CompositeTransform),
-        )
-        valid_forward = isinstance(
-            fixed_to_moving_transform,
-            (itk.DisplacementFieldTransform, itk.CompositeTransform),
-        )
+        valid_transform_types = (itk.DisplacementFieldTransform, itk.CompositeTransform)
+        valid_m2f = isinstance(moving_to_fixed_transform, valid_transform_types)
+        valid_f2m = isinstance(fixed_to_moving_transform, valid_transform_types)
 
-        assert valid_inverse, (
-            f"moving_to_fixed_transform should be DisplacementFieldTransform or CompositeTransform, got {type(moving_to_fixed_transform)}"
+        assert valid_m2f, (
+            "moving_to_fixed_transform should be DisplacementFieldTransform or "
+            f"CompositeTransform, got {type(moving_to_fixed_transform)}"
         )
-        assert valid_forward, (
-            f"fixed_to_moving_transform should be DisplacementFieldTransform or CompositeTransform, got {type(fixed_to_moving_transform)}"
+        assert valid_f2m, (
+            "fixed_to_moving_transform should be DisplacementFieldTransform or "
+            f"CompositeTransform, got {type(fixed_to_moving_transform)}"
         )
 
         print("Transform types verified")

--- a/tests/test_register_models_pca.py
+++ b/tests/test_register_models_pca.py
@@ -305,8 +305,8 @@ def test_pca_transforms_round_trip() -> None:
     reference_image.SetOrigin([-24.0, -24.0, -24.0])
 
     transforms = registrar.compute_pca_transforms(reference_image, blur_sigma=1.5)
-    forward = transforms["forward_point_transform"]
-    inverse = transforms["inverse_point_transform"]
+    forward = transforms["moving_to_fixed_transform"]
+    inverse = transforms["fixed_to_moving_transform"]
 
     template_points = np.asarray(registrar.pca_template_model.points, dtype=np.float64)
     expected = template_points + registrar.registered_model_pca_deformation

--- a/tests/test_register_time_series_images.py
+++ b/tests/test_register_time_series_images.py
@@ -149,38 +149,46 @@ class TestRegisterTimeSeriesImages:
 
         # Verify result structure
         assert isinstance(result, dict), "Result should be a dictionary"
-        assert "forward_transforms" in result, "Missing forward_transforms in result"
-        assert "inverse_transforms" in result, "Missing inverse_transforms in result"
+        assert "fixed_to_moving_transforms" in result, (
+            "Missing fixed_to_moving_transforms in result"
+        )
+        assert "moving_to_fixed_transforms" in result, (
+            "Missing moving_to_fixed_transforms in result"
+        )
         assert "losses" in result, "Missing losses in result"
 
-        forward_transforms = result["forward_transforms"]
-        inverse_transforms = result["inverse_transforms"]
+        fixed_to_moving_transforms = result["fixed_to_moving_transforms"]
+        moving_to_fixed_transforms = result["moving_to_fixed_transforms"]
         losses = result["losses"]
 
         # Verify list lengths
-        assert len(forward_transforms) == len(moving_images), (
-            "forward_transforms length mismatch"
+        assert len(fixed_to_moving_transforms) == len(moving_images), (
+            "fixed_to_moving_transforms length mismatch"
         )
-        assert len(inverse_transforms) == len(moving_images), (
-            "inverse_transforms length mismatch"
+        assert len(moving_to_fixed_transforms) == len(moving_images), (
+            "moving_to_fixed_transforms length mismatch"
         )
         assert len(losses) == len(moving_images), "losses length mismatch"
 
         # Verify all transforms are valid
-        for i, (forward_transform, inverse_transform) in enumerate(
-            zip(forward_transforms, inverse_transforms, strict=False)
+        for i, (fixed_to_moving_transform, moving_to_fixed_transform) in enumerate(
+            zip(fixed_to_moving_transforms, moving_to_fixed_transforms, strict=False)
         ):
-            assert forward_transform is not None, f"forward_transform[{i}] is None"
-            assert inverse_transform is not None, f"inverse_transform[{i}] is None"
+            assert fixed_to_moving_transform is not None, (
+                f"fixed_to_moving_transform[{i}] is None"
+            )
+            assert moving_to_fixed_transform is not None, (
+                f"moving_to_fixed_transform[{i}] is None"
+            )
 
         print("Time series registration complete")
-        print(f"  Transforms generated: {len(forward_transforms)}")
+        print(f"  Transforms generated: {len(fixed_to_moving_transforms)}")
         print(f"  Average loss: {np.mean(losses):.6f}")
 
         transform_tools = TransformTools()
         moving_image = transform_tools.transform_image(
             moving_images[0],
-            forward_transforms[0],
+            fixed_to_moving_transforms[0],
             fixed_image,
             interpolation_method="linear",
         )
@@ -197,13 +205,13 @@ class TestRegisterTimeSeriesImages:
         # comparison (see test_register_images_greedy.py for the same
         # rationale).
         test_tools.write_result_transform(
-            forward_transforms[0], "basic_forward_transform_0.hdf"
+            fixed_to_moving_transforms[0], "basic_fixed_to_moving_transform_0.hdf"
         )
         test_tools.write_result_image(
             moving_image, "basic_time_series_registered_0.mha"
         )
         results_dir = test_directories["output"] / self._class_name
-        assert (results_dir / "basic_forward_transform_0.hdf").exists()
+        assert (results_dir / "basic_fixed_to_moving_transform_0.hdf").exists()
         assert (results_dir / "basic_time_series_registered_0.mha").exists()
 
     def test_register_time_series_from_middle_frame(
@@ -228,20 +236,22 @@ class TestRegisterTimeSeriesImages:
             register_reference=True,
         )
 
-        forward_transforms = result["forward_transforms"]
+        fixed_to_moving_transforms = result["fixed_to_moving_transforms"]
         losses = result["losses"]
 
         transform_tools = TransformTools()
         moving_image = transform_tools.transform_image(
             moving_images[0],
-            forward_transforms[0],
+            fixed_to_moving_transforms[0],
             fixed_image,
             interpolation_method="linear",
         )
 
         # Verify all transforms generated
-        for i, forward_transform in enumerate(forward_transforms):
-            assert forward_transform is not None, f"forward_transform[{i}] is None"
+        for i, fixed_to_moving_transform in enumerate(fixed_to_moving_transforms):
+            assert fixed_to_moving_transform is not None, (
+                f"fixed_to_moving_transform[{i}] is None"
+            )
 
         print("Time series registration from the middle frame complete")
         print(f"  Losses: {[f'{loss:.6f}' for loss in losses]}")
@@ -256,13 +266,14 @@ class TestRegisterTimeSeriesImages:
         # bit-reproducible across runs, so we save artifacts without
         # asserting an exact baseline match.
         test_tools.write_result_transform(
-            forward_transforms[0], "middle_frame_forward_transform_0.hdf"
+            fixed_to_moving_transforms[0],
+            "middle_frame_fixed_to_moving_transform_0.hdf",
         )
         test_tools.write_result_image(
             moving_image, "middle_frame_time_series_registered_0.mha"
         )
         results_dir = test_directories["output"] / self._class_name
-        assert (results_dir / "middle_frame_forward_transform_0.hdf").exists()
+        assert (results_dir / "middle_frame_fixed_to_moving_transform_0.hdf").exists()
         assert (results_dir / "middle_frame_time_series_registered_0.mha").exists()
 
     def test_register_time_series_identity_start(self, test_images: list[Any]) -> None:
@@ -315,7 +326,7 @@ class TestRegisterTimeSeriesImages:
                 register_reference=True,
             )
 
-            assert len(result["forward_transforms"]) == len(moving_images), (
+            assert len(result["fixed_to_moving_transforms"]) == len(moving_images), (
                 f"Wrong number of transforms for reference_frame={starting_index}"
             )
 
@@ -376,13 +387,13 @@ class TestRegisterTimeSeriesImages:
             register_reference=True,
         )
 
-        forward_transforms = result["forward_transforms"]
+        fixed_to_moving_transforms = result["fixed_to_moving_transforms"]
 
         # Apply transform to first moving image
         transform_tools = TransformTools()
         registered_image = transform_tools.transform_image(
             moving_images[0],
-            forward_transforms[0],
+            fixed_to_moving_transforms[0],
             fixed_image,
             interpolation_method="linear",
         )
@@ -428,8 +439,8 @@ class TestRegisterTimeSeriesImages:
             register_reference=True,
         )
 
-        assert len(result["forward_transforms"]) == len(moving_images)
-        assert len(result["inverse_transforms"]) == len(moving_images)
+        assert len(result["fixed_to_moving_transforms"]) == len(moving_images)
+        assert len(result["moving_to_fixed_transforms"]) == len(moving_images)
         assert len(result["losses"]) == len(moving_images)
 
         print("ICON time series registration complete")
@@ -475,7 +486,7 @@ class TestRegisterTimeSeriesImages:
             register_reference=True,
         )
 
-        assert len(result["forward_transforms"]) == len(moving_images)
+        assert len(result["fixed_to_moving_transforms"]) == len(moving_images)
 
         print("Masked time series registration complete")
 
@@ -500,14 +511,14 @@ class TestRegisterTimeSeriesImages:
             register_reference=True,
         )
 
-        forward_transforms = result["forward_transforms"]
+        fixed_to_moving_transforms = result["fixed_to_moving_transforms"]
 
         # All transforms should be generated
-        for i, forward_transform in enumerate(forward_transforms):
-            assert forward_transform is not None, f"Transform {i} is None"
+        for i, fixed_to_moving_transform in enumerate(fixed_to_moving_transforms):
+            assert fixed_to_moving_transform is not None, f"Transform {i} is None"
 
         print("Bidirectional registration successful")
-        print(f"  All {len(forward_transforms)} transforms generated")
+        print(f"  All {len(fixed_to_moving_transforms)} transforms generated")
 
 
 def _make_constant_image(value: float, size: int = 4, dtype: Any = np.float32) -> Any:
@@ -533,7 +544,7 @@ class TestReconstructTimeSeriesCompositeMode:
 
         reconstructed = registrar.reconstruct_time_series(
             moving_images=moving_images,
-            inverse_transforms=self._identity_transforms(len(moving_images)),
+            moving_to_fixed_transforms=self._identity_transforms(len(moving_images)),
             composite_mode="reference",
         )
 
@@ -554,8 +565,8 @@ class TestReconstructTimeSeriesCompositeMode:
 
         reconstructed = registrar.reconstruct_time_series(
             moving_images=moving_images,
-            inverse_transforms=self._identity_transforms(n),
-            forward_transforms=self._identity_transforms(n),
+            moving_to_fixed_transforms=self._identity_transforms(n),
+            fixed_to_moving_transforms=self._identity_transforms(n),
             composite_mode="mean",
         )
 
@@ -575,8 +586,8 @@ class TestReconstructTimeSeriesCompositeMode:
 
         reconstructed = registrar.reconstruct_time_series(
             moving_images=moving_images,
-            inverse_transforms=self._identity_transforms(n),
-            forward_transforms=self._identity_transforms(n),
+            moving_to_fixed_transforms=self._identity_transforms(n),
+            fixed_to_moving_transforms=self._identity_transforms(n),
             composite_mode="max",
         )
 
@@ -597,7 +608,7 @@ class TestReconstructTimeSeriesCompositeMode:
 
         composite = registrar._compute_composite_reference(
             moving_images=[moving_image],
-            forward_transforms=self._identity_transforms(1),
+            fixed_to_moving_transforms=self._identity_transforms(1),
             mode="mean",
         )
         arr = itk.array_from_image(composite)
@@ -624,7 +635,7 @@ class TestReconstructTimeSeriesCompositeMode:
 
         composite = registrar._compute_composite_reference(
             moving_images=[moving_image],
-            forward_transforms=self._identity_transforms(1),
+            fixed_to_moving_transforms=self._identity_transforms(1),
             mode="mean",
         )
         arr = itk.array_from_image(composite)
@@ -645,23 +656,23 @@ class TestReconstructTimeSeriesCompositeMode:
         with pytest.raises(ValueError, match="composite_mode"):
             registrar.reconstruct_time_series(
                 moving_images=moving_images,
-                inverse_transforms=self._identity_transforms(1),
-                forward_transforms=self._identity_transforms(1),
+                moving_to_fixed_transforms=self._identity_transforms(1),
+                fixed_to_moving_transforms=self._identity_transforms(1),
                 composite_mode="bogus",  # type: ignore[arg-type]
             )
 
-    def test_composite_mode_requires_forward_transforms(self) -> None:
-        """mean/max composite_mode without forward_transforms raises ValueError."""
+    def test_composite_mode_requires_fixed_to_moving_transforms(self) -> None:
+        """mean/max composite_mode without fixed_to_moving_transforms raises ValueError."""
         fixed_image = _make_constant_image(10.0)
         moving_images = [_make_constant_image(20.0)]
 
         registrar = RegisterTimeSeriesImages(registration_method=RegisterImagesGreedy())
         registrar.set_fixed_image(fixed_image)
 
-        with pytest.raises(ValueError, match="forward_transforms"):
+        with pytest.raises(ValueError, match="fixed_to_moving_transforms"):
             registrar.reconstruct_time_series(
                 moving_images=moving_images,
-                inverse_transforms=self._identity_transforms(1),
+                moving_to_fixed_transforms=self._identity_transforms(1),
                 composite_mode="mean",
             )
 

--- a/tests/test_transform_tools.py
+++ b/tests/test_transform_tools.py
@@ -285,12 +285,15 @@ class TestTransformTools:
 
         moving_image = test_images[1]
         fixed_image = test_images[0]
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         print("\nTransforming image with linear interpolation...")
 
         transformed_image = transform_tools.transform_image(
-            moving_image, forward_transform, fixed_image, interpolation_method="linear"
+            moving_image,
+            fixed_to_moving_transform,
+            fixed_image,
+            interpolation_method="linear",
         )
 
         # Verify result
@@ -325,12 +328,15 @@ class TestTransformTools:
 
         moving_image = test_images[1]
         fixed_image = test_images[0]
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         print("\nTransforming image with nearest neighbor interpolation...")
 
         transformed_image = transform_tools.transform_image(
-            moving_image, forward_transform, fixed_image, interpolation_method="nearest"
+            moving_image,
+            fixed_to_moving_transform,
+            fixed_image,
+            interpolation_method="nearest",
         )
 
         assert transformed_image is not None, "Transformed image is None"
@@ -359,12 +365,15 @@ class TestTransformTools:
 
         moving_image = test_images[1]
         fixed_image = test_images[0]
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         print("\nTransforming image with sinc interpolation...")
 
         transformed_image = transform_tools.transform_image(
-            moving_image, forward_transform, fixed_image, interpolation_method="sinc"
+            moving_image,
+            fixed_to_moving_transform,
+            fixed_image,
+            interpolation_method="sinc",
         )
 
         assert transformed_image is not None, "Transformed image is None"
@@ -388,14 +397,14 @@ class TestTransformTools:
         """Test that invalid interpolation method raises error."""
         moving_image = test_images[1]
         fixed_image = test_images[0]
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         print("\nTesting invalid interpolation method...")
 
         with pytest.raises(ValueError):
             transform_tools.transform_image(
                 moving_image,
-                forward_transform,
+                fixed_to_moving_transform,
                 fixed_image,
                 interpolation_method="invalid",
             )
@@ -409,13 +418,13 @@ class TestTransformTools:
         test_transforms: dict[str, Any],
     ) -> None:
         """Test transforming PyVista contour without deformation magnitude."""
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         print("\nTransforming contour without deformation magnitude...")
         print(f"  Original contour points: {test_contour.n_points}")
 
         transformed_contour = transform_tools.transform_pvcontour(
-            test_contour, forward_transform, with_deformation_magnitude=False
+            test_contour, fixed_to_moving_transform, with_deformation_magnitude=False
         )
 
         # Verify result
@@ -449,12 +458,12 @@ class TestTransformTools:
         tfm_output_dir = output_dir / "transform_tools"
         tfm_output_dir.mkdir(exist_ok=True)
 
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         print("\nTransforming contour with deformation magnitude...")
 
         transformed_contour = transform_tools.transform_pvcontour(
-            test_contour, forward_transform, with_deformation_magnitude=True
+            test_contour, fixed_to_moving_transform, with_deformation_magnitude=True
         )
 
         # Verify result
@@ -530,12 +539,12 @@ class TestTransformTools:
         tfm_output_dir.mkdir(exist_ok=True)
 
         fixed_image = test_images[0]
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         print("\nConverting transform to deformation field...")
 
         deformation_field = transform_tools.convert_transform_to_displacement_field(
-            forward_transform, fixed_image
+            fixed_to_moving_transform, fixed_image
         )
 
         # Verify deformation field
@@ -603,13 +612,13 @@ class TestTransformTools:
         tfm_output_dir.mkdir(exist_ok=True)
 
         fixed_image = test_images[0]
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         # First convert transform to field
         print("\nComputing Jacobian determinant from deformation field...")
 
         deformation_field = transform_tools.convert_transform_to_displacement_field(
-            forward_transform, fixed_image
+            fixed_to_moving_transform, fixed_image
         )
 
         jacobian_det = transform_tools.compute_jacobian_determinant_from_field(
@@ -649,13 +658,13 @@ class TestTransformTools:
     ) -> None:
         """Test detecting spatial folding in deformation field."""
         fixed_image = test_images[0]
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         # Convert transform to field
         print("\nDetecting folding in deformation field...")
 
         deformation_field = transform_tools.convert_transform_to_displacement_field(
-            forward_transform, fixed_image
+            fixed_to_moving_transform, fixed_image
         )
 
         # Compute jacobian determinant from field
@@ -678,7 +687,7 @@ class TestTransformTools:
         test_images: list[Any],
     ) -> None:
         """Test temporal interpolation between transforms."""
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         # Create an identity transform as second transform
         identity_tfm = itk.AffineTransform[itk.D, 3].New()
@@ -690,7 +699,7 @@ class TestTransformTools:
 
         # Interpolate at midpoint (portion=0.5)
         interpolated_tfm = transform_tools.combine_displacement_field_transforms(
-            forward_transform,
+            fixed_to_moving_transform,
             identity_tfm,
             fixed_image,
             tfm1_weight=0.5,
@@ -715,7 +724,7 @@ class TestTransformTools:
         test_images: list[Any],
     ) -> None:
         """Test composing two transforms with various weights."""
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
         fixed_image = test_images[0]
 
         # Create an identity transform as second transform
@@ -727,7 +736,7 @@ class TestTransformTools:
         # Test 1: Equal weights (should be similar to interpolation at 0.5)
         print("  Test 1: Equal weights (0.5, 0.5)")
         composed_tfm1 = transform_tools.combine_displacement_field_transforms(
-            forward_transform,
+            fixed_to_moving_transform,
             identity_tfm,
             fixed_image,
             tfm1_weight=0.5,
@@ -744,7 +753,7 @@ class TestTransformTools:
         # Test 2: First transform only (weight 1.0, 0.0)
         print("  Test 2: First transform only (1.0, 0.0)")
         composed_tfm2 = transform_tools.combine_displacement_field_transforms(
-            forward_transform,
+            fixed_to_moving_transform,
             identity_tfm,
             fixed_image,
             tfm1_weight=1.0,
@@ -757,7 +766,7 @@ class TestTransformTools:
         # Test 3: Second transform only (weight 0.0, 1.0)
         print("  Test 3: Second transform only (0.0, 1.0)")
         composed_tfm3 = transform_tools.combine_displacement_field_transforms(
-            forward_transform,
+            fixed_to_moving_transform,
             identity_tfm,
             fixed_image,
             tfm1_weight=0.0,
@@ -770,7 +779,7 @@ class TestTransformTools:
         # Test 4: Custom weights
         print("  Test 4: Custom weights (0.75, 0.25)")
         composed_tfm4 = transform_tools.combine_displacement_field_transforms(
-            forward_transform,
+            fixed_to_moving_transform,
             identity_tfm,
             fixed_image,
             tfm1_weight=0.75,
@@ -783,7 +792,7 @@ class TestTransformTools:
         # Test 5: With blur sigma
         print("  Test 5: With blur sigma (1.0, 1.0)")
         composed_tfm5 = transform_tools.combine_displacement_field_transforms(
-            forward_transform,
+            fixed_to_moving_transform,
             identity_tfm,
             fixed_image,
             tfm1_weight=0.5,
@@ -819,7 +828,7 @@ class TestTransformTools:
         print(f"  Field magnitude (0.0, 1.0): {mag3:.3f} mm")
         print(f"  Difference between (1.0,0.0) and (0.0,1.0): {diff_2_3:.3f} mm")
 
-        # The difference should be non-zero since forward_transform is not identity
+        # The difference should be non-zero since fixed_to_moving_transform is not identity
         assert diff_2_3 > 0, "Different weights should produce different results"
 
     def test_smooth_transform(
@@ -829,14 +838,14 @@ class TestTransformTools:
         test_images: list[Any],
     ) -> None:
         """Test smoothing a transform."""
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
         fixed_image = test_images[0]
 
         print("\nSmoothing transform...")
 
         # Smooth the transform
         smoothed_tfm = transform_tools.smooth_transform(
-            forward_transform, sigma=2.0, reference_image=fixed_image
+            fixed_to_moving_transform, sigma=2.0, reference_image=fixed_image
         )
 
         # Verify result
@@ -855,7 +864,7 @@ class TestTransformTools:
         test_images: list[Any],
     ) -> None:
         """Test combining transforms with spatial masks."""
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
         fixed_image = test_images[0]
 
         # Create identity transform
@@ -884,7 +893,7 @@ class TestTransformTools:
 
         # Combine transforms
         combined_tfm = transform_tools.combine_transforms_with_masks(
-            forward_transform, identity_tfm, mask1, mask2, fixed_image
+            fixed_to_moving_transform, identity_tfm, mask1, mask2, fixed_image
         )
 
         # Verify result
@@ -904,18 +913,24 @@ class TestTransformTools:
         """Test applying multiple transforms in sequence."""
         moving_image = test_images[1]
         fixed_image = test_images[0]
-        forward_transform = test_transforms["forward_transform"]
+        fixed_to_moving_transform = test_transforms["fixed_to_moving_transform"]
 
         print("\nApplying transforms multiple times...")
 
         # Apply transform once
         result1 = transform_tools.transform_image(
-            moving_image, forward_transform, fixed_image, interpolation_method="linear"
+            moving_image,
+            fixed_to_moving_transform,
+            fixed_image,
+            interpolation_method="linear",
         )
 
         # Apply transform again (should work even though it's already transformed)
         result2 = transform_tools.transform_image(
-            result1, forward_transform, fixed_image, interpolation_method="linear"
+            result1,
+            fixed_to_moving_transform,
+            fixed_image,
+            interpolation_method="linear",
         )
 
         assert result1 is not None, "First transform result is None"

--- a/tests/test_workflow_convert_image_to_usd.py
+++ b/tests/test_workflow_convert_image_to_usd.py
@@ -129,8 +129,12 @@ def test_workflow_convert_image_to_usd_default_operation(
     assert len(workflow.transformed_contours["all"]) == 1
     assert len(workflow.registration_results) == 1
     assert "all" in workflow.registration_results[0]
-    assert workflow.registration_results[0]["all"]["forward_transform"] is not None
-    assert workflow.registration_results[0]["all"]["inverse_transform"] is not None
+    assert (
+        workflow.registration_results[0]["all"]["fixed_to_moving_transform"] is not None
+    )
+    assert (
+        workflow.registration_results[0]["all"]["moving_to_fixed_transform"] is not None
+    )
 
     reference_labelmap = cast(
         itk.Image,

--- a/tests/test_workflow_create_mean_surface.py
+++ b/tests/test_workflow_create_mean_surface.py
@@ -140,7 +140,7 @@ def test_correspondence_tuning_reaches_the_registrar(monkeypatch: Any) -> None:
         def register(self, transform_type: str) -> dict[str, Any]:
             identity = itk.AffineTransform[itk.D, 3].New()
             identity.SetIdentity()
-            return {"forward_transform": identity}
+            return {"fixed_to_moving_transform": identity}
 
     monkeypatch.setattr(wcms, "RegisterModelsDistanceMaps", _Registrar)
 

--- a/tests/test_workflow_create_statistical_model.py
+++ b/tests/test_workflow_create_statistical_model.py
@@ -78,8 +78,8 @@ class _IdentityRegistrar:
         inverse_transform = itk.AffineTransform[itk.D, 3].New()
         assert transform.GetInverse(inverse_transform), "transform not invertible"
         return {
-            "forward_transform": transform,
-            "inverse_transform": inverse_transform,
+            "fixed_to_moving_transform": transform,
+            "moving_to_fixed_transform": inverse_transform,
             "registered_model": self.moving_model,
         }
 

--- a/tests/test_workflow_fit_statistical_model_to_patient.py
+++ b/tests/test_workflow_fit_statistical_model_to_patient.py
@@ -41,7 +41,7 @@ def test_transform_model_applies_staged_transform() -> None:
     transform = itk.AffineTransform[itk.D, 3].New()
     transform.SetIdentity()
     transform.SetTranslation((1.0, 2.0, 3.0))
-    workflow.icp_forward_point_transform = transform
+    workflow.icp_moving_to_fixed_transform = transform
     workflow.pca_coefficients = None
     workflow.use_l2l_registration = False
     workflow.use_l2i_registration = False
@@ -167,7 +167,7 @@ def test_transform_model_preserves_unstructured_grid_topology() -> None:
     transform = itk.AffineTransform[itk.D, 3].New()
     transform.SetIdentity()
     transform.SetTranslation((1.0, 2.0, 3.0))
-    workflow.icp_forward_point_transform = transform
+    workflow.icp_moving_to_fixed_transform = transform
     workflow.pca_coefficients = None
     workflow.use_l2l_registration = False
     workflow.use_l2i_registration = False

--- a/tutorials/tutorial_02_duke_heart_distancemap_finetune_icon.py
+++ b/tutorials/tutorial_02_duke_heart_distancemap_finetune_icon.py
@@ -347,7 +347,7 @@ if __name__ == "__main__":
     def landmark_errors(transform: itk.Transform) -> np.ndarray:
         """Distance from each mapped fixed landmark to its moving counterpart.
 
-        ``forward_transform`` is the resampling transform: it maps points on the
+        ``fixed_to_moving_transform`` is the resampling transform: it maps points on the
         fixed grid back into moving space, which is the direction the landmark
         correspondences are defined in.
         """
@@ -433,7 +433,7 @@ if __name__ == "__main__":
 
         labelmaps[method_name] = transform_tools.transform_image(
             moving_labelmap,
-            result["forward_transform"],
+            result["fixed_to_moving_transform"],
             fixed_labelmap,
             interpolation_method="nearest",
         )
@@ -442,7 +442,9 @@ if __name__ == "__main__":
                 "method": method_name,
                 "weights": str(method_weights) if method_weights else "-",
                 "registration_time_s": elapsed_s,
-                **landmark_metrics(landmark_errors(result["forward_transform"])),
+                **landmark_metrics(
+                    landmark_errors(result["fixed_to_moving_transform"])
+                ),
                 **overlap_metrics(labelmaps[method_name]),
             }
         )

--- a/tutorials/tutorial_02_lung_distancemap_finetune_icon.py
+++ b/tutorials/tutorial_02_lung_distancemap_finetune_icon.py
@@ -358,7 +358,7 @@ if __name__ == "__main__":
     def landmark_errors(transform: itk.Transform) -> np.ndarray:
         """Distance from each mapped fixed landmark to its moving counterpart.
 
-        ``forward_transform`` is the resampling transform: it maps points on the
+        ``fixed_to_moving_transform`` is the resampling transform: it maps points on the
         fixed grid back into moving space, which is the direction the landmark
         correspondences are defined in.
         """
@@ -481,11 +481,11 @@ if __name__ == "__main__":
         elapsed_s = time.perf_counter() - start_time
 
         registered_distance_maps[method_name] = transform_tools.transform_image(
-            moving_distance_map, result["forward_transform"], fixed_distance_map
+            moving_distance_map, result["fixed_to_moving_transform"], fixed_distance_map
         )
         labelmaps[method_name] = transform_tools.transform_image(
             moving_labelmap,
-            result["forward_transform"],
+            result["fixed_to_moving_transform"],
             fixed_labelmap,
             interpolation_method="nearest",
         )
@@ -496,7 +496,9 @@ if __name__ == "__main__":
                 "weights": str(method_weights) if method_weights else "-",
                 "registration_time_s": elapsed_s,
                 "loss": float(result["loss"]),
-                **landmark_metrics(landmark_errors(result["forward_transform"])),
+                **landmark_metrics(
+                    landmark_errors(result["fixed_to_moving_transform"])
+                ),
                 **overlap_metrics(labelmaps[method_name]),
             }
         )

--- a/tutorials/tutorial_02_lung_finetune_icon.py
+++ b/tutorials/tutorial_02_lung_finetune_icon.py
@@ -273,7 +273,7 @@ if __name__ == "__main__":
     def landmark_errors(transform: itk.Transform) -> np.ndarray:
         """Distance from each mapped fixed landmark to its moving counterpart.
 
-        ``forward_transform`` is the resampling transform: it maps points on the
+        ``fixed_to_moving_transform`` is the resampling transform: it maps points on the
         fixed grid back into moving space, which is the direction the landmark
         correspondences are defined in.
         """
@@ -444,16 +444,18 @@ if __name__ == "__main__":
         result = registrar.register(moving_image)
         elapsed_s = time.perf_counter() - start_time
 
-        composed_errors = landmark_errors(result["forward_transform"])
+        composed_errors = landmark_errors(result["fixed_to_moving_transform"])
         chain_diagnostics = dict(empty_chain_diagnostics)
         if chain is not None:
             # RegisterImagesChain mirrors each stage's own result onto the
-            # sub-registrar before composing, so chain.greedy.forward_transform
-            # is the stage-only Greedy result and chain.icon.forward_transform
+            # sub-registrar before composing, so chain.greedy.fixed_to_moving_transform
+            # is the stage-only Greedy result and chain.icon.fixed_to_moving_transform
             # is the residual ICON added on top of it.  Both are exact
             # transforms, scored the same way as every other row.
-            greedy_stage_errors = landmark_errors(chain.greedy.forward_transform)
-            icon_stage_transform: itk.Transform = chain.icon.forward_transform
+            greedy_stage_errors = landmark_errors(
+                chain.greedy.fixed_to_moving_transform
+            )
+            icon_stage_transform: itk.Transform = chain.icon.fixed_to_moving_transform
             residual_mm = np.array(
                 [
                     np.linalg.norm(
@@ -477,7 +479,7 @@ if __name__ == "__main__":
 
             # The Greedy stage is identical across the sweep, so score it once.
             if greedy_stage_transform is None:
-                greedy_stage_transform = chain.greedy.forward_transform
+                greedy_stage_transform = chain.greedy.fixed_to_moving_transform
                 stage_image, stage_labelmap = warp_moving(greedy_stage_transform)
                 registered_images["greedy_icon_stage0"] = stage_image
                 labelmaps["greedy_icon_stage0"] = stage_labelmap
@@ -494,7 +496,7 @@ if __name__ == "__main__":
                 )
 
         registered_images[method_name], labelmaps[method_name] = warp_moving(
-            result["forward_transform"]
+            result["fixed_to_moving_transform"]
         )
         rows.append(
             {

--- a/tutorials/tutorial_03_heart_reconstruct_highres_4d_ct.py
+++ b/tutorials/tutorial_03_heart_reconstruct_highres_4d_ct.py
@@ -99,8 +99,8 @@ if __name__ == "__main__":
     result = workflow.process()
 
     # Result saving
-    forward_transform = result["forward_transforms"]
-    inverse_transform = result["inverse_transforms"]
+    fixed_to_moving_transform = result["fixed_to_moving_transforms"]
+    moving_to_fixed_transform = result["moving_to_fixed_transforms"]
     reconstructed_images: list[itk.Image] = result["reconstructed_images"]
     reconstructed_files: list[Path] = []
     for frame_index, image in enumerate(reconstructed_images):
@@ -109,10 +109,10 @@ if __name__ == "__main__":
         reconstructed_files.append(out_path)
 
         out_path = output_dir / f"reconstructed_frame_{frame_index:03d}_fwd.hdf"
-        itk.transformwrite(forward_transform[frame_index], str(out_path))
+        itk.transformwrite(fixed_to_moving_transform[frame_index], str(out_path))
 
         out_path = output_dir / f"reconstructed_frame_{frame_index:03d}_inv.hdf"
-        itk.transformwrite(inverse_transform[frame_index], str(out_path))
+        itk.transformwrite(moving_to_fixed_transform[frame_index], str(out_path))
 
     # Testing
     tt = TestTools(

--- a/tutorials/tutorial_03_lung_reconstruct_highres_4d_ct.py
+++ b/tutorials/tutorial_03_lung_reconstruct_highres_4d_ct.py
@@ -110,8 +110,8 @@ if __name__ == "__main__":
     result = workflow.process()
 
     # Result saving
-    forward_transform = result["forward_transforms"]
-    inverse_transform = result["inverse_transforms"]
+    fixed_to_moving_transform = result["fixed_to_moving_transforms"]
+    moving_to_fixed_transform = result["moving_to_fixed_transforms"]
     reconstructed_images: list[itk.Image] = result["reconstructed_images"]
     reconstructed_files: list[Path] = []
     for frame_index, image in enumerate(reconstructed_images):
@@ -120,10 +120,10 @@ if __name__ == "__main__":
         reconstructed_files.append(out_path)
 
         out_path = output_dir / f"reconstructed_frame_{frame_index:03d}_fwd.hdf"
-        itk.transformwrite(forward_transform[frame_index], str(out_path))
+        itk.transformwrite(fixed_to_moving_transform[frame_index], str(out_path))
 
         out_path = output_dir / f"reconstructed_frame_{frame_index:03d}_inv.hdf"
-        itk.transformwrite(inverse_transform[frame_index], str(out_path))
+        itk.transformwrite(moving_to_fixed_transform[frame_index], str(out_path))
 
     # Testing
     tt = TestTools(

--- a/tutorials/tutorial_08_lung_fit_model_to_4d_patients.py
+++ b/tutorials/tutorial_08_lung_fit_model_to_4d_patients.py
@@ -274,19 +274,21 @@ if __name__ == "__main__":
                 compression=True,
             )
 
-            forward_transform = reg_result["forward_transforms"][phase_index]
+            fixed_to_moving_transform = reg_result["fixed_to_moving_transforms"][
+                phase_index
+            ]
             itk.transformwrite(
-                forward_transform,
+                fixed_to_moving_transform,
                 str(case_output_dir / f"{case_id}_{phase_id}_forward_tfm.hdf"),
             )
             itk.transformwrite(
-                reg_result["inverse_transforms"][phase_index],
+                reg_result["moving_to_fixed_transforms"][phase_index],
                 str(case_output_dir / f"{case_id}_{phase_id}_inverse_tfm.hdf"),
             )
 
             surface = transform_tools.transform_pvcontour(
                 fitted_reference_mesh,
-                forward_transform,
+                fixed_to_moving_transform,
                 with_deformation_magnitude=True,
             )
             surface_file = case_output_dir / f"{case_id}_{phase_id}_ssm_surface.vtp"

--- a/tutorials/tutorial_15_lung_leave_one_out.py
+++ b/tutorials/tutorial_15_lung_leave_one_out.py
@@ -596,7 +596,8 @@ if __name__ == "__main__":
                 reg_result = reg_workflow.process()
                 for phase_index, destination in enumerate(wanted):
                     itk.transformwrite(
-                        reg_result["forward_transforms"][phase_index], str(destination)
+                        reg_result["fixed_to_moving_transforms"][phase_index],
+                        str(destination),
                     )
 
     # Ground truth for the folds' held-out cases: every gated frame segmented on
@@ -754,7 +755,7 @@ if __name__ == "__main__":
                 # itk.transformread returns a list; a composite is written with
                 # its sub-transforms behind it, so the first entry is the whole
                 # transform either way.
-                forward_transform = itk.transformread(
+                fixed_to_moving_transform = itk.transformread(
                     str(
                         transform_dir
                         / case_id
@@ -763,7 +764,7 @@ if __name__ == "__main__":
                 )[0]
                 transform_tools.transform_pvcontour(
                     fitted_reference_mesh,
-                    forward_transform,
+                    fixed_to_moving_transform,
                     with_deformation_magnitude=True,
                 ).save(str(phase_surface_file))
 


### PR DESCRIPTION
Forward/inverse transforms were difficult to resolve given ICON's use of A/B for transforms and ICP/PCA performing point-to-point registrations in which forward/inverse were inverted compared to image registration results.

Now transforms are specific: moving_to_fixed and fixed_to_moving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - Registration and model-registration results now use direction-specific transform names: `fixed_to_moving_transform(s)` and `moving_to_fixed_transform(s)`.
  - The unused statistical-model workflow inverse-transform collection has been removed.

- **Documentation**
  - Updated guides, tutorials, examples, migration notes, and transform file naming conventions.

- **Chores**
  - Updated lint configuration, tests, scripts, and workflows to use the renamed transform outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->