### PR TITLE
ENH: Rename *_tools modules and classes to process_* naming convention

### DIFF
--- a/.agents/agents/architecture.md
+++ b/.agents/agents/architecture.md
@@ -22,10 +22,10 @@ src/monai_physio/
   segment_chest_*.py          - TotalSegmentator, VISTA-3D, NIM, Ensemble
   register_images_*.py        - ICON, ANTs, Greedy, time-series wrappers
   register_models_*.py        - ICP, PCA, distance-map registerers
-  contour_tools.py            - surface extraction from ITK masks
+  process_contours.py            - surface extraction from ITK masks
   convert_vtk_to_usd.py       - high-level VTK→USD (in-memory, PyVista)
   vtk_to_usd/                 - file-based VTK→USD subpackage
-  usd_tools.py / usd_anatomy_tools.py - USD stage utilities
+  process_usd.py / process_usd_anatomy.py - USD stage utilities
   workflow_*.py               - top-level orchestration
 ```
 

--- a/.agents/agents/implementation.md
+++ b/.agents/agents/implementation.md
@@ -19,7 +19,7 @@ tutorials may require a GPU.
 4D CT → Segmentation → Registration → Contour Extraction → USD Export
 
 Key modules: `monai_physio_base.py`, `segment_chest_*.py`, `register_images_*.py`,
-`register_models_*.py`, `contour_tools.py`, `convert_vtk_to_usd.py`, `vtk_to_usd/`,
+`register_models_*.py`, `process_contours.py`, `convert_vtk_to_usd.py`, `vtk_to_usd/`,
 `workflow_*.py`. Use `graphify query "<question>"` to locate classes before
 searching manually.
 

--- a/.agents/agents/testing.md
+++ b/.agents/agents/testing.md
@@ -17,7 +17,7 @@ test off the GPU bucket.
 
 - `tests/conftest.py` - session-scoped fixtures chaining: download → convert → segment → register
 - `tests/baselines/` - stored via Git LFS; fetch with `git lfs pull`
-- `src/monai_physio/test_tools.py` - baseline comparison utilities (`TestTools`)
+- `src/monai_physio/process_tests.py` - baseline comparison utilities (`ProcessTests`)
 - Markers (all opt-in via `--run-<bucket>`): `slow`, `requires_gpu`,
   `requires_simpleware`, `tutorial`. The `requires_data` marker
   no longer exists - tests that need downloadable data pull it through the
@@ -32,7 +32,7 @@ to the project interpreter. If activation is impossible, use
 ```powershell
 python -m pytest tests/ -v                                        # fast, recommended (slow/GPU/etc auto-skipped)
 python -m pytest tests/test_contour_tools.py -v                   # single file
-python -m pytest tests/test_contour_tools.py::TestContourTools -v # single class
+python -m pytest tests/test_contour_tools.py::TestProcessContours -v # single class
 python -m pytest tests/ -v --run-slow                             # opt into slow tests
 # typical local GPU profile; CI adds --run-simpleware --run-tutorials
 python -m pytest tests/ -v --run-gpu --run-slow
@@ -59,7 +59,7 @@ python -m pytest tests/ --create-baselines                        # create missi
    those are fixed conventions. State only what is specific to the test, such
    as the size of a synthetic volume.
 6. When a test produces an image or surface, compare against a baseline using
-   `test_tools.py` utilities (`TestTools`) rather than ad-hoc value asserts.
+   `process_tests.py` utilities (`ProcessTests`) rather than ad-hoc value asserts.
    Store baselines under `tests/baselines/` (Git LFS-tracked).
 7. Prefer images from `ROOT/data/test/slicer_heart_small`.
 8. Prefer storing results in subdirectories under `./results/<test_name>`.

--- a/.agents/skills/test-feature/SKILL.md
+++ b/.agents/skills/test-feature/SKILL.md
@@ -25,7 +25,7 @@ Instructions:
    When using synthetic inputs anyway, keep volumes ≤64 voxels per side and
    say so in the docstring.
 5. **When a test produces an image or surface as output, compare against a
-   baseline** using the `test_tools.py` utilities (e.g. `TestTools`) rather
+   baseline** using the `process_tests.py` utilities (e.g. `ProcessTests`) rather
    than ad-hoc value assertions. Store baselines under `tests/baselines/`
    (Git LFS-tracked). Run with `--create-baselines` to materialize missing
    baselines on first use; afterward, regression compares to the stored

--- a/.github/scripts/build_dashboard.py
+++ b/.github/scripts/build_dashboard.py
@@ -32,9 +32,8 @@ from __future__ import annotations
 import argparse
 import json
 import xml.etree.ElementTree as ET
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Parsers
@@ -54,7 +53,7 @@ def parse_junit(xml_path: Path) -> dict:
         }
 
     try:
-        tree = ET.parse(xml_path)  # noqa: S314
+        tree = ET.parse(xml_path)
         root = tree.getroot()
 
         suites = root.findall("testsuite") if root.tag == "testsuites" else [root]
@@ -401,9 +400,7 @@ def main() -> None:
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    timestamp = args.timestamp or datetime.now(timezone.utc).strftime(
-        "%Y-%m-%dT%H:%M:%SZ"
-    )
+    timestamp = args.timestamp or datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     data = {
         "junit": parse_junit_dir(results_dir),

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -197,20 +197,24 @@ Tests should be marked appropriately:
 ```python
 import pytest
 
+
 @pytest.mark.unit
 def test_simple_function():
     """Fast unit test"""
     pass
+
 
 @pytest.mark.integration
 def test_full_pipeline():
     """Integration test"""
     pass
 
+
 @pytest.mark.slow
 def test_long_running():
     """Long-running test"""
     pass
+
 
 @pytest.mark.requires_gpu
 def test_gpu_function():

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ graphify update .               # refresh after code changes (AST-only, no API c
   those are fixed conventions (see Data Conventions above). State only what is
   specific to the test, such as the size of a synthetic volume.
 - When a test produces an image or surface, compare against a baseline using
-  `src/monai_physio/test_tools.py` utilities such as `TestTools`.
+  `src/monai_physio/process_tests.py` utilities such as `ProcessTests`.
 - Store baselines under `tests/baselines/`, which is tracked by Git LFS. Run
   `git lfs pull` after cloning.
 - Run with `--create-baselines` to materialize missing baselines on first use.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ came from.
 - Baselines in `tests/baselines/` via Git LFS - run `git lfs pull` after cloning
 - `tests/conftest.py`: session-scoped fixtures chaining
   download → convert → segment → register
-- `src/monai_physio/test_tools.py`: baseline comparison utilities (`TestTools`, etc.)
+- `src/monai_physio/process_tests.py`: baseline comparison utilities (`ProcessTests`, etc.)
 - Markers (all opt-in via `--run-<bucket>`): `slow`, `requires_gpu`,
   `requires_simpleware`, `tutorial`. Data-dependent tests no
   longer use a marker - they pull data through fixtures and run by default.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,7 @@ Add tests in the `tests/` directory:
 import pytest
 from monai_physio import MyNewFeature
 
+
 def test_my_feature():
     feature = MyNewFeature()
     result = feature.do_something()

--- a/data/CHOP-Valve4D/README.md
+++ b/data/CHOP-Valve4D/README.md
@@ -11,10 +11,10 @@ monai-physio-download-data CHOP-Valve4D --directory data/CHOP-Valve4D
 or from Python:
 
 ```python
-from monai_physio import DataDownloadTools
+from monai_physio import DownloadData
 
-DataDownloadTools.DownloadCHOPValve4DData("data/CHOP-Valve4D")
-assert DataDownloadTools.VerifyCHOPValve4DData("data/CHOP-Valve4D")
+DownloadData.DownloadCHOPValve4DData("data/CHOP-Valve4D")
+assert DownloadData.VerifyCHOPValve4DData("data/CHOP-Valve4D")
 ```
 
 This downloads and extracts three zip archives attached to the

--- a/data/Chest-CT/README.md
+++ b/data/Chest-CT/README.md
@@ -11,10 +11,10 @@ monai-physio-download-data Chest-CT --directory data/Chest-CT
 or from Python:
 
 ```python
-from monai_physio import DataDownloadTools
+from monai_physio import DownloadData
 
-data_file = DataDownloadTools.DownloadChestCTData("data/Chest-CT")
-assert DataDownloadTools.VerifyChestCTData("data/Chest-CT")
+data_file = DownloadData.DownloadChestCTData("data/Chest-CT")
+assert DownloadData.VerifyChestCTData("data/Chest-CT")
 ```
 
 This fetches a single ~200 MB file from the MONAI Physio GitHub release

--- a/data/DirLab-4DCT/README.md
+++ b/data/DirLab-4DCT/README.md
@@ -22,9 +22,9 @@ DIR-Lab distributes each case individually and may require registration.
 Once populated, check the layout with:
 
 ```python
-from monai_physio import DataDownloadTools
+from monai_physio import DownloadData
 
-assert DataDownloadTools.VerifyDirLab4DCTData("data/DirLab-4DCT")
+assert DownloadData.VerifyDirLab4DCTData("data/DirLab-4DCT")
 ```
 
 **Directory structure after download and fixing:**
@@ -75,7 +75,7 @@ you do not need to run it; the `.mhd` files are already committed.
 
 DIR-Lab's raw `.mhd`/`.img` volumes store intensities offset by +1024 from
 Hounsfield units, not real HU. `fix_downloaded_data.py` calls
-`DataDownloadTools.FixDirLab4DCTData`, which subtracts 1024 and clips the
+`DownloadData.FixDirLab4DCTData`, which subtracts 1024 and clips the
 result to `[-1024, 1024]` for every downloaded phase, writing one
 compressed `.mha` file per phase into `data/DirLab-4DCT/` (`.gitignore`d,
 like the raw data). Run it once after downloading; tutorials and

--- a/data/DirLab-4DCT/fix_downloaded_data.py
+++ b/data/DirLab-4DCT/fix_downloaded_data.py
@@ -1,7 +1,7 @@
 # %%
 from pathlib import Path
 
-from monai_physio.data_download_tools import DataDownloadTools
+from monai_physio.download_data import DownloadData
 
 _HERE = Path(__file__).resolve().parent
 
@@ -11,4 +11,4 @@ output_dir = _HERE
 
 # Converts raw DirLab-4DCT intensities (.mhd) to clipped Hounsfield units and
 # writes each result as a compressed .mha file in output_dir.
-DataDownloadTools.FixDirLab4DCTData(input_dir, output_dir)
+DownloadData.FixDirLab4DCTData(input_dir, output_dir)

--- a/data/README.md
+++ b/data/README.md
@@ -20,7 +20,7 @@ the source of truth.
 ## Automatic Download
 
 `Slicer-Heart-CT`, `KCL-Heart-Model`, `CHOP-Valve4D`, and `Chest-CT` can be
-fetched with the `monai-physio-download-data` CLI or `DataDownloadTools`; see each
+fetched with the `monai-physio-download-data` CLI or `DownloadData`; see each
 dataset's README for the exact command. `DirLab-4DCT` has no automatic
 downloader - DIR-Lab distributes each case individually and may require
 registration, so it must be obtained manually; see

--- a/data/Slicer-Heart-CT/README.md
+++ b/data/Slicer-Heart-CT/README.md
@@ -11,10 +11,10 @@ monai-physio-download-data Slicer-Heart-CT --directory data/Slicer-Heart-CT
 or from Python:
 
 ```python
-from monai_physio import DataDownloadTools
+from monai_physio import DownloadData
 
-data_file = DataDownloadTools.DownloadSlicerHeartCTData("data/Slicer-Heart-CT")
-assert DataDownloadTools.VerifySlicerHeartCTData("data/Slicer-Heart-CT")
+data_file = DownloadData.DownloadSlicerHeartCTData("data/Slicer-Heart-CT")
+assert DownloadData.VerifySlicerHeartCTData("data/Slicer-Heart-CT")
 ```
 
 This fetches a single ~1.2 GB file from
@@ -58,7 +58,7 @@ Philadelphia):
 - Primary dataset for `experiments/Heart-GatedCT_To_USD/` and
   `experiments/Heart-VTKSeries_To_USD/`, whose
   `0-download_and_convert_4d_to_3d.py` scripts call
-  `DataDownloadTools.DownloadSlicerHeartCTData`, which downloads this
+  `DownloadData.DownloadSlicerHeartCTData`, which downloads this
   sequence and splits it into per-phase 3D `.mha` slices
 - Used in the test suite (`tests/test_download_heart_data.py`)
 - Example data for cardiac motion visualization in NVIDIA Omniverse

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -70,8 +70,8 @@ By Category
    * :class:`~monai_physio.RegisterModelsPCA` - PCA-based registration
 
 **USD Tools**
-   * :mod:`~monai_physio.usd_tools` - USD file utilities
-   * :mod:`~monai_physio.usd_anatomy_tools` - Anatomical structure tools
+   * :mod:`~monai_physio.process_usd` - USD file utilities
+   * :mod:`~monai_physio.process_usd_anatomy` - Anatomical structure tools
    * :class:`~monai_physio.ConvertVTKToUSD` - VTK to USD conversion
 
 Module Index

--- a/docs/api/physicsnemo/infer.rst
+++ b/docs/api/physicsnemo/infer.rst
@@ -94,7 +94,7 @@ surrogate at all.
 **Deformation fields.** :meth:`~WorkflowInferMovement.create_deformation_field`
 bins the per-vertex displacements and reference-surface normals onto a
 caller-supplied image grid, giving an ITK vector image you can apply to
-volumes and labelmaps with :class:`~monai_physio.TransformTools`.
+volumes and labelmaps with :class:`~monai_physio.ProcessTransforms`.
 
 See Also
 ========

--- a/docs/api/physicsnemo/manifest.rst
+++ b/docs/api/physicsnemo/manifest.rst
@@ -2,8 +2,8 @@
 The Per-Subject Manifest
 =========================
 
-.. module:: monai_physio.physicsnemo_tools
-.. currentmodule:: monai_physio.physicsnemo_tools
+.. module:: monai_physio.process_physicsnemo
+.. currentmodule:: monai_physio.process_physicsnemo
 
 The manifest is the contract between your data and the training stack. It is
 the only thing you must produce to train on your own subjects: one JSON file
@@ -45,15 +45,15 @@ decides which domain the model lives on.
 Reference
 =========
 
-:class:`PhysicsNemoTools` is re-exported from the top-level package;
+:class:`ProcessPhysicsNemo` is re-exported from the top-level package;
 ``SubjectManifest`` and ``PhaseEntry`` are not - import those by module:
 
 .. code-block:: python
 
-   from monai_physio import PhysicsNemoTools
-   from monai_physio.physicsnemo_tools import SubjectManifest
+   from monai_physio import ProcessPhysicsNemo
+   from monai_physio.process_physicsnemo import SubjectManifest
 
-   manifest = PhysicsNemoTools.parse_manifest(manifest_path)
+   manifest = ProcessPhysicsNemo.parse_manifest(manifest_path)
 
 .. autoclass:: SubjectManifest
    :exclude-members: subject_id, fitted_reference_mesh, pca_coefficients, target_array, phases
@@ -64,7 +64,7 @@ Reference
 Supporting helpers
 ==================
 
-.. autoclass:: PhysicsNemoTools
+.. autoclass:: ProcessPhysicsNemo
    :members: parse_manifest, load_target_array, load_pca_coefficients,
              build_node_features, mesh_to_edge_index, compute_edge_features
 

--- a/docs/api/segmentation/base.rst
+++ b/docs/api/segmentation/base.rst
@@ -52,7 +52,7 @@ Anatomy Taxonomy
 
 The group-to-organ mapping is held by :class:`AnatomyTaxonomy`, a small
 data class shared between the segmenter and downstream renderers
-(:class:`USDAnatomyTools`, :class:`ConvertVTKToUSD`). It is independent of
+(:class:`ProcessUSDAnatomy`, :class:`ConvertVTKToUSD`). It is independent of
 ITK and OpenUSD so segmentation code can be reasoned about without pulling
 in the rendering stack.
 
@@ -111,4 +111,4 @@ See Also
 * :doc:`simpleware`
 * :doc:`index`
 * :doc:`../../developer/segmentation`
-* :doc:`../usd/anatomy_tools` for the renderer side of the taxonomy
+* :doc:`../usd/process_usd_anatomy` for the renderer side of the taxonomy

--- a/docs/api/segmentation/nv_segment_ct_mri.rst
+++ b/docs/api/segmentation/nv_segment_ct_mri.rst
@@ -86,7 +86,7 @@ Rendering
 
 ``brain_parcellation`` is a group name this segmenter introduces. Its
 group-level entry in
-:data:`monai_physio.usd_anatomy_tools.DEFAULT_RENDER_PARAMS` is a grey-matter
+:data:`monai_physio.process_usd_anatomy.DEFAULT_RENDER_PARAMS` is a grey-matter
 look, which is the right default because most of its labels are cortical gyri
 or deep grey nuclei (caudate, putamen, thalamus, amygdala, hippocampus).
 

--- a/docs/api/usd/index.rst
+++ b/docs/api/usd/index.rst
@@ -19,8 +19,8 @@ Quick Links
 ===========
 
 **USD Modules**:
-   * :doc:`tools` - Core USD utilities
-   * :doc:`anatomy_tools` - Anatomical structure tools
+   * :doc:`process_usd` - Core USD utilities
+   * :doc:`process_usd_anatomy` - Anatomical structure tools
    * :doc:`vtk_conversion` - VTK to USD conversion (preferred high-level API)
    * :doc:`vtk_to_usd_lib` - Low-level ``vtk_to_usd`` subpackage (advanced)
 
@@ -30,8 +30,8 @@ Module Documentation
 .. toctree::
    :maxdepth: 2
 
-   tools
-   anatomy_tools
+   process_usd
+   process_usd_anatomy
    vtk_conversion
    vtk_to_usd_lib
 
@@ -57,11 +57,11 @@ Create Anatomical Scene
 
 .. code-block:: python
 
-   from monai_physio import usd_anatomy_tools
+   from monai_physio import process_usd_anatomy
 
-   stage = usd_anatomy_tools.create_anatomical_stage()
-   usd_anatomy_tools.add_heart_model(stage, "heart.vtk")
-   usd_anatomy_tools.add_lungs_model(stage, "lungs.vtk")
+   stage = process_usd_anatomy.create_anatomical_stage()
+   process_usd_anatomy.add_heart_model(stage, "heart.vtk")
+   process_usd_anatomy.add_lungs_model(stage, "lungs.vtk")
    stage.Save()
 
 See Also
@@ -72,4 +72,4 @@ See Also
 
 .. rubric:: Navigation
 
-:doc:`../model_registration/pca` | :doc:`../index` | :doc:`tools`
+:doc:`../model_registration/pca` | :doc:`../index` | :doc:`process_usd`

--- a/docs/api/usd/process_usd.rst
+++ b/docs/api/usd/process_usd.rst
@@ -1,18 +1,18 @@
 ====================================
-Transform Tools
+USD Tools
 ====================================
 
 .. currentmodule:: monai_physio
 
-Coordinate transformation and image warping utilities.
+Core utilities for USD file creation and manipulation.
 
 Module Reference
 ================
 
-.. automodule:: monai_physio.transform_tools
+.. automodule:: monai_physio.process_usd
    :members:
    :undoc-members:
 
 .. rubric:: Navigation
 
-:doc:`image_tools` | :doc:`index` | :doc:`contour_tools`
+:doc:`index` | :doc:`anatomy_tools` | :doc:`vtk_conversion`

--- a/docs/api/usd/process_usd_anatomy.rst
+++ b/docs/api/usd/process_usd_anatomy.rst
@@ -9,7 +9,7 @@ Specialized tools for anatomical structure handling in USD.
 Module Reference
 ================
 
-.. automodule:: monai_physio.usd_anatomy_tools
+.. automodule:: monai_physio.process_usd_anatomy
    :members:
    :undoc-members:
 

--- a/docs/api/utilities/download_data.rst
+++ b/docs/api/utilities/download_data.rst
@@ -10,11 +10,11 @@ tutorials and experiments.
 Module Reference
 ================
 
-.. automodule:: monai_physio.data_download_tools
+.. automodule:: monai_physio.download_data
    :members:
    :undoc-members:
    :show-inheritance:
 
 .. rubric:: Navigation
 
-:doc:`test_tools` | :doc:`index`
+:doc:`process_tests` | :doc:`index`

--- a/docs/api/utilities/image_conversion.rst
+++ b/docs/api/utilities/image_conversion.rst
@@ -19,4 +19,4 @@ Module Reference
 
 .. rubric:: Navigation
 
-:doc:`contour_tools` | :doc:`index` | :doc:`../index`
+:doc:`process_contours` | :doc:`index` | :doc:`../index`

--- a/docs/api/utilities/index.rst
+++ b/docs/api/utilities/index.rst
@@ -24,14 +24,14 @@ Quick Links
 ===========
 
 **Utility Modules**:
-   * :doc:`image_tools` - Image processing utilities
-   * :doc:`labelmap_tools` - Labelmap to registration-mask conversion
-   * :doc:`transform_tools` - Transform operations
-   * :doc:`landmark_tools` - Landmark-based registration validation
-   * :doc:`contour_tools` - Contour processing
+   * :doc:`process_images` - Image processing utilities
+   * :doc:`process_labelmaps` - Labelmap to registration-mask conversion
+   * :doc:`process_transforms` - Transform operations
+   * :doc:`process_landmarks` - Landmark-based registration validation
+   * :doc:`process_contours` - Contour processing
    * :doc:`image_conversion` - 4D image to 3D time-series utilities
-   * :doc:`test_tools` - Baseline / result comparison helpers
-   * :doc:`data_download` - Optional dataset download helpers
+   * :doc:`process_tests` - Baseline / result comparison helpers
+   * :doc:`download_data` - Optional dataset download helpers
 
 Module Documentation
 ====================
@@ -39,14 +39,14 @@ Module Documentation
 .. toctree::
    :maxdepth: 2
 
-   image_tools
-   labelmap_tools
-   transform_tools
-   landmark_tools
-   contour_tools
+   process_images
+   process_labelmaps
+   process_transforms
+   process_landmarks
+   process_contours
    image_conversion
-   test_tools
-   data_download
+   process_tests
+   download_data
 
 See Also
 ========
@@ -56,4 +56,4 @@ See Also
 
 .. rubric:: Navigation
 
-:doc:`../usd/vtk_conversion` | :doc:`../index` | :doc:`image_tools`
+:doc:`../usd/vtk_conversion` | :doc:`../index` | :doc:`process_images`

--- a/docs/api/utilities/process_contours.rst
+++ b/docs/api/utilities/process_contours.rst
@@ -9,10 +9,10 @@ Contour extraction and processing utilities.
 Module Reference
 ================
 
-.. automodule:: monai_physio.contour_tools
+.. automodule:: monai_physio.process_contours
    :members:
    :undoc-members:
 
 .. rubric:: Navigation
 
-:doc:`transform_tools` | :doc:`index` | :doc:`image_conversion`
+:doc:`process_transforms` | :doc:`index` | :doc:`image_conversion`

--- a/docs/api/utilities/process_images.rst
+++ b/docs/api/utilities/process_images.rst
@@ -9,10 +9,10 @@ Image I/O, preprocessing, and manipulation utilities.
 Module Reference
 ================
 
-.. automodule:: monai_physio.image_tools
+.. automodule:: monai_physio.process_images
    :members:
    :undoc-members:
 
 .. rubric:: Navigation
 
-:doc:`index` | :doc:`transform_tools` | :doc:`contour_tools`
+:doc:`index` | :doc:`process_transforms` | :doc:`process_contours`

--- a/docs/api/utilities/process_labelmaps.rst
+++ b/docs/api/utilities/process_labelmaps.rst
@@ -10,10 +10,10 @@ label exclusion and physically isotropic dilation.
 Module Reference
 ================
 
-.. automodule:: monai_physio.labelmap_tools
+.. automodule:: monai_physio.process_labelmaps
    :members:
    :undoc-members:
 
 .. rubric:: Navigation
 
-:doc:`index` | :doc:`image_tools` | :doc:`transform_tools`
+:doc:`index` | :doc:`process_images` | :doc:`process_transforms`

--- a/docs/api/utilities/process_landmarks.rst
+++ b/docs/api/utilities/process_landmarks.rst
@@ -13,16 +13,16 @@ reports and the DIR-Lab benchmark is scored on.
 Module Reference
 ================
 
-.. automodule:: monai_physio.landmark_tools
+.. automodule:: monai_physio.process_landmarks
    :members:
    :undoc-members:
 
 See Also
 ========
 
-* :doc:`transform_tools`
+* :doc:`process_transforms`
 * :doc:`../registration/index`
 
 .. rubric:: Navigation
 
-:doc:`transform_tools` | :doc:`index` | :doc:`contour_tools`
+:doc:`process_transforms` | :doc:`index` | :doc:`process_contours`

--- a/docs/api/utilities/process_tests.rst
+++ b/docs/api/utilities/process_tests.rst
@@ -10,11 +10,11 @@ pytest suite.
 Module Reference
 ================
 
-.. automodule:: monai_physio.test_tools
+.. automodule:: monai_physio.process_tests
    :members:
    :undoc-members:
    :show-inheritance:
 
 .. rubric:: Navigation
 
-:doc:`image_conversion` | :doc:`index` | :doc:`data_download`
+:doc:`image_conversion` | :doc:`index` | :doc:`download_data`

--- a/docs/api/utilities/process_transforms.rst
+++ b/docs/api/utilities/process_transforms.rst
@@ -1,18 +1,18 @@
 ====================================
-USD Tools
+Transform Tools
 ====================================
 
 .. currentmodule:: monai_physio
 
-Core utilities for USD file creation and manipulation.
+Coordinate transformation and image warping utilities.
 
 Module Reference
 ================
 
-.. automodule:: monai_physio.usd_tools
+.. automodule:: monai_physio.process_transforms
    :members:
    :undoc-members:
 
 .. rubric:: Navigation
 
-:doc:`index` | :doc:`anatomy_tools` | :doc:`vtk_conversion`
+:doc:`process_images` | :doc:`index` | :doc:`process_contours`

--- a/docs/api/workflows.rst
+++ b/docs/api/workflows.rst
@@ -95,7 +95,7 @@ Image to VTK
    import itk
 
    from monai_physio import (
-       ContourTools,
+       ProcessContours,
        SegmentChestTotalSegmentatorWithContrast,
        WorkflowConvertImageToVTK,
    )
@@ -109,7 +109,7 @@ Image to VTK
        anatomy_groups=["heart", "major_vessels"],
    )
 
-   ContourTools.save_combined_surfaces(
+   ProcessContours.save_combined_surfaces(
        result["surfaces"],
        "./output/patient01_surfaces.vtp",
    )

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -16,7 +16,7 @@ Data Flow
    4D CT / time-series CT
           |
           v
-   ConvertImage4DTo3D / ImageTools
+   ConvertImage4DTo3D / ProcessImages
           |
           v
    RegisterTimeSeriesImages
@@ -30,7 +30,7 @@ Data Flow
    SegmentNVSegmentCTMRI (CT + MRI)
           |
           v
-   ContourTools + TransformTools
+   ProcessContours + ProcessTransforms
           |
           v
    WorkflowConvertImageToVTK / ConvertVTKToUSD / WorkflowConvertVTKToUSD
@@ -177,7 +177,7 @@ it produces - a new segmenter for a new organ or data type only has to
 declare that map once. Everything downstream reads it rather than
 special-casing the segmenter: ``ConvertVTKToUSD`` groups label-mode mesh
 prims under per-anatomy-group Xforms (``/World/{name}/{group}/{organ}``)
-straight from the taxonomy, and ``USDAnatomyTools`` looks up
+straight from the taxonomy, and ``ProcessUSDAnatomy`` looks up
 :data:`DEFAULT_RENDER_PARAMS` by group name to assign the matching
 OmniSurface material. A group without a registered look still renders (via
 the ``"other"`` fallback), so a new segmentation class is usable end-to-end -

--- a/docs/cli_scripts/byod_tutorials.rst
+++ b/docs/cli_scripts/byod_tutorials.rst
@@ -280,7 +280,7 @@ Viewing Results
 
    import monai_physio as mphysio
 
-   mesh = mphysio.USDTools().load_usd_as_vtk("output.usd")
+   mesh = mphysio.ProcessUSD().load_usd_as_vtk("output.usd")
    print(mesh.n_points, mesh.n_cells)
 
 PyVista reads the VTK input files used above, but local validation with

--- a/docs/cli_scripts/download_data.rst
+++ b/docs/cli_scripts/download_data.rst
@@ -68,7 +68,7 @@ into per-phase 3-D volumes:
    data/Slicer-Heart-CT/slice_000.mha ... slice_020.mha
 
 The command uses
-:meth:`monai_physio.data_download_tools.DataDownloadTools.DownloadSlicerHeartCTData`,
+:meth:`monai_physio.download_data.DownloadData.DownloadSlicerHeartCTData`,
 so repeated runs reuse the existing non-empty file and skip the split once
 the ``slice_???.mha`` files are present.
 
@@ -80,7 +80,7 @@ For ``KCL-Heart-Model``, the command downloads, extracts, and reuses:
    data/KCL-Heart-Model/input_meshes/01.vtk ... 20.vtk
 
 The command uses
-:meth:`monai_physio.data_download_tools.DataDownloadTools.DownloadKCLHeartModelData`,
+:meth:`monai_physio.download_data.DownloadData.DownloadKCLHeartModelData`,
 which fetches each per-model ``.tar.gz`` archive from Zenodo, extracts its
 mesh, and skips archives whose target ``.vtk`` file is already present.
 
@@ -93,7 +93,7 @@ For ``CHOP-Valve4D``, the command downloads, extracts, and reuses:
    data/CHOP-Valve4D/CT/        (source CT volume and Simpleware segmentation)
 
 The command uses
-:meth:`monai_physio.data_download_tools.DataDownloadTools.DownloadCHOPValve4DData`,
+:meth:`monai_physio.download_data.DownloadData.DownloadCHOPValve4DData`,
 which fetches each subdirectory's zip archive from the MONAI Physio GitHub
 release and skips a subdirectory once it has its expected extracted files
 (the CT volume or Simpleware segmentation for ``CT/``, ``.vtk`` meshes for
@@ -107,7 +107,7 @@ For ``Chest-CT``, the command downloads and reuses a single volume:
    data/Chest-CT/Chest-CT.mha
 
 The command uses
-:meth:`monai_physio.data_download_tools.DataDownloadTools.DownloadChestCTData`,
+:meth:`monai_physio.download_data.DownloadData.DownloadChestCTData`,
 which fetches the volume from the MONAI Physio GitHub release and reuses an
 existing non-empty file, so re-running resumes an interrupted download.
 

--- a/docs/cli_scripts/infer_physicsnemo.rst
+++ b/docs/cli_scripts/infer_physicsnemo.rst
@@ -68,7 +68,7 @@ and the reference-surface normals onto that image's voxel grid:
 
 This writes ``deformation_field.mha`` and ``surface_normal_field.mha`` -
 apply them to volumes and labelmaps with
-:class:`~monai_physio.TransformTools`.
+:class:`~monai_physio.ProcessTransforms`.
 
 Options
 =======

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
-
 # Add the source directory to the path
 sys.path.insert(0, os.path.abspath("../src"))
 

--- a/docs/cookbook/add_a_registration_method.rst
+++ b/docs/cookbook/add_a_registration_method.rst
@@ -106,8 +106,8 @@ Notes
   multi-stage pipeline, and
   :class:`~monai_physio.RegisterTimeSeriesImages` will apply it across a whole
   4D series, without either class knowing about it.
-* Use ``TransformTools.transform_image()`` and
-  ``TransformTools.transform_pvcontour()`` to apply results - they encode the
+* Use ``ProcessTransforms.transform_image()`` and
+  ``ProcessTransforms.transform_pvcontour()`` to apply results - they encode the
   direction rules.
 * Registering *models* to patients is a different base class; see
   :doc:`/developer/registration_models`.

--- a/docs/cookbook/add_a_segmentation_method.rst
+++ b/docs/cookbook/add_a_segmentation_method.rst
@@ -67,7 +67,7 @@ for ``"other"``.
 
 .. code-block:: python
 
-   from monai_physio.usd_anatomy_tools import DEFAULT_RENDER_PARAMS
+   from monai_physio.process_usd_anatomy import DEFAULT_RENDER_PARAMS
 
    DEFAULT_RENDER_PARAMS["brain"] = {
        "name": "Brain",

--- a/docs/developer/architecture.rst
+++ b/docs/developer/architecture.rst
@@ -24,7 +24,7 @@ Architecture Diagram
       +--------------+-------------+-------------+
                          |
                          v
-               ContourTools / TransformTools
+               ProcessContours / ProcessTransforms
                          |
                          v
               ConvertVTKToUSD / vtk_to_usd

--- a/docs/developer/core.rst
+++ b/docs/developer/core.rst
@@ -34,9 +34,9 @@ Class Boundaries
 * Workflows orchestrate complete pipelines.
 * Registration classes estimate transforms.
 * Segmentation classes return ITK images or dictionaries of ITK masks.
-* ``TransformTools`` applies transforms to images and PyVista contours.
-* ``ContourTools`` creates and transforms VTK/PyVista surface data.
-* ``USDTools`` and ``USDAnatomyTools`` operate on USD stages and files.
+* ``ProcessTransforms`` applies transforms to images and PyVista contours.
+* ``ProcessContours`` creates and transforms VTK/PyVista surface data.
+* ``ProcessUSD`` and ``ProcessUSDAnatomy`` operate on USD stages and files.
 
 Public APIs should be documented in ``docs/api``.
 

--- a/docs/developer/migration_next.md
+++ b/docs/developer/migration_next.md
@@ -63,9 +63,7 @@ result = RegisterImagesANTS().register(moving_image)
 warped = transform_tools.transform_image(
     moving_image, result["forward_transform"], fixed_image
 )
-warped_points = transform_tools.transform_pvcontour(
-    points, result["inverse_transform"]
-)
+warped_points = transform_tools.transform_pvcontour(points, result["inverse_transform"])
 
 # PCA/ICP model registration
 result = registrar.compute_pca_transforms(reference_image)
@@ -241,6 +239,69 @@ only the qualified one:
 Remove any now-obsolete `from monai_physio.physicsnemo_tools import
 <function>` line once its call sites are updated; the free functions no
 longer exist on that module (`distributed_context` is the one exception).
+
+## `*_tools`/`*Tools` module and class family - renamed to `process_*`/`Process*`
+
+**Change:** the object-first `*_tools.py`/`*Tools` naming used throughout
+`src/monai_physio/` is renamed to match the verb-first convention used
+elsewhere in the project (`workflow_train_physicsnemo.py`,
+`register_images_ants.py`, `segment_chest_total_segmentator.py`):
+
+| Old module / class | New module / class |
+|---|---|
+| `contour_tools.py` / `ContourTools` | `process_contours.py` / `ProcessContours` |
+| `transform_tools.py` / `TransformTools` | `process_transforms.py` / `ProcessTransforms` |
+| `test_tools.py` / `TestTools` | `process_tests.py` / `ProcessTests` |
+| `image_tools.py` / `ImageTools` | `process_images.py` / `ProcessImages` |
+| `physicsnemo_tools.py` / `PhysicsNemoTools` | `process_physicsnemo.py` / `ProcessPhysicsNemo` |
+| `usd_anatomy_tools.py` / `USDAnatomyTools` | `process_usd_anatomy.py` / `ProcessUSDAnatomy` |
+| `usd_tools.py` / `USDTools` | `process_usd.py` / `ProcessUSD` |
+| `labelmap_tools.py` / `LabelmapTools` | `process_labelmaps.py` / `ProcessLabelmaps` |
+| `landmark_tools.py` / `LandmarkTools` | `process_landmarks.py` / `ProcessLandmarks` |
+| `data_download_tools.py` / `DataDownloadTools` | `download_data.py` / `DownloadData` |
+
+Only import paths and PascalCase class names changed. Lowercase instance
+attributes and pytest fixtures that hold instances of these classes (for
+example `self.image_tools`, or the `contour_tools` pytest fixture) are
+unaffected. The corresponding Sphinx API pages also moved (e.g.
+`docs/api/utilities/image_tools.rst` -> `docs/api/utilities/process_images.rst`,
+`docs/api/usd/tools.rst` -> `docs/api/usd/process_usd.rst`,
+`docs/api/usd/anatomy_tools.rst` -> `docs/api/usd/process_usd_anatomy.rst`,
+`docs/api/utilities/data_download.rst` -> `docs/api/utilities/download_data.rst`),
+so bookmarked ReadTheDocs URLs for those pages change.
+
+**Why:** extends the verb-first naming already used by every workflow,
+registration, and segmentation module in the project to what was previously
+an inconsistent, object-first `*_tools` family, and reads naturally at call
+sites (`ProcessContours().merge(...)`).
+
+**Before**
+
+```python
+from monai_physio import ContourTools, ImageTools, USDTools
+
+contours = ContourTools()
+image = ImageTools()
+usd = USDTools()
+```
+
+**After**
+
+```python
+from monai_physio import ProcessContours, ProcessImages, ProcessUSD
+
+contours = ProcessContours()
+image = ProcessImages()
+usd = ProcessUSD()
+```
+
+**Automated conversion:** `py utils/rename_tools_to_process.py --dry-run`
+to preview, then `py utils/rename_tools_to_process.py` to apply. The script
+performs the `git mv` for each renamed module, its dedicated test file (where
+one exists), and its Sphinx API page, then rewrites imports, dotted
+`monai_physio.<module>` references, and whole-word PascalCase class names
+tree-wide. It is retained in `utils/` for reuse rather than deleted after
+running.
 
 ## Entry template
 

--- a/docs/developer/registration_images.rst
+++ b/docs/developer/registration_images.rst
@@ -98,8 +98,8 @@ Development Notes
 
 * Use masks when registration should focus on a specific anatomy.
 * Check transform direction before applying transforms to contours or images.
-* Use ``TransformTools.transform_image()`` for resampling images.
-* Use ``TransformTools.transform_pvcontour()`` for PyVista contours.
+* Use ``ProcessTransforms.transform_image()`` for resampling images.
+* Use ``ProcessTransforms.transform_pvcontour()`` for PyVista contours.
 
 See Also
 ========

--- a/docs/developer/segmentation.rst
+++ b/docs/developer/segmentation.rst
@@ -86,7 +86,7 @@ USD renderer doesn't fall back to the generic ``"other"`` material:
 
 .. code-block:: python
 
-   from monai_physio.usd_anatomy_tools import DEFAULT_RENDER_PARAMS
+   from monai_physio.process_usd_anatomy import DEFAULT_RENDER_PARAMS
 
    DEFAULT_RENDER_PARAMS["brain"] = {
        "name": "Brain",

--- a/docs/developer/transform_conventions.rst
+++ b/docs/developer/transform_conventions.rst
@@ -25,7 +25,7 @@ Every registration class -- image (:class:`monai_physio.RegisterImagesANTS`,
 Because the name states the direction literally, mapping a *point* needs no
 lookup table -- just pick the transform whose name matches the source and
 target point space you have. Warping an *image* is different:
-:func:`TransformTools.transform_image` samples whichever grid you are
+:func:`ProcessTransforms.transform_image` samples whichever grid you are
 building the output on, so the transform is picked by output grid, not by
 source/target space (see below).
 
@@ -36,15 +36,15 @@ Image warping vs. point warping use opposite transforms
 ========================================================
 
 ITK resampling is a *pull-back* operation. To build the warped image on the
-fixed grid, :func:`TransformTools.transform_image` (an ``itk.ResampleImageFilter``)
+fixed grid, :func:`ProcessTransforms.transform_image` (an ``itk.ResampleImageFilter``)
 visits every fixed-grid sample ``q`` and looks up the moving image at
 ``transform.TransformPoint(q)``. The transform it needs therefore maps
 **fixed-space coordinates to moving-space coordinates** --
 ``fixed_to_moving_transform``.
 
 Warping a *point* (landmark, contour vertex, mesh node) is a *push-forward*
-operation: :func:`TransformTools.transform_pvcontour` /
-:func:`TransformTools.transform_dataset` apply ``transform.TransformPoint(p)``
+operation: :func:`ProcessTransforms.transform_pvcontour` /
+:func:`ProcessTransforms.transform_dataset` apply ``transform.TransformPoint(p)``
 directly to each input point. To move a moving-space landmark to its location
 in the fixed image, the transform must map **moving-space coordinates to
 fixed-space coordinates** -- ``moving_to_fixed_transform``.
@@ -58,16 +58,16 @@ fixed-space coordinates** -- ``moving_to_fixed_transform``.
      - Helper
    * - Warp the **moving image** into fixed space (onto the fixed grid)
      - ``fixed_to_moving_transform``
-     - :func:`TransformTools.transform_image`
+     - :func:`ProcessTransforms.transform_image`
    * - Warp **moving points / contours / landmarks** into fixed space
      - ``moving_to_fixed_transform``
-     - :func:`TransformTools.transform_pvcontour`
+     - :func:`ProcessTransforms.transform_pvcontour`
    * - Warp the **fixed image** into moving space (e.g. time-series reconstruction)
      - ``moving_to_fixed_transform``
-     - :func:`TransformTools.transform_image`
+     - :func:`ProcessTransforms.transform_image`
    * - Warp **fixed points / contours / landmarks** into moving space
      - ``fixed_to_moving_transform``
-     - :func:`TransformTools.transform_pvcontour`
+     - :func:`ProcessTransforms.transform_pvcontour`
 
 .. note::
 

--- a/docs/developer/usd_generation.rst
+++ b/docs/developer/usd_generation.rst
@@ -153,24 +153,24 @@ DistantLight emits along its local -Z, the same direction the camera looks,
 so the anatomy is lit from the viewing direction in stages that carry no
 other light. The light is created only when valid, non-degenerate bounds
 exist; otherwise no light is authored. The camera is also baked into stages
-produced by ``TransformTools.convert_transform_to_usd_visualization`` and
-``USDTools.merge_usd_files``; the helper is idempotent so re-merging a USD
+produced by ``ProcessTransforms.convert_transform_to_usd_visualization`` and
+``ProcessUSD.merge_usd_files``; the helper is idempotent so re-merging a USD
 that already has a Camera does not produce a duplicate transform op.
 
-Anatomy Materials with USDAnatomyTools
+Anatomy Materials with ProcessUSDAnatomy
 ==========================================
 
-:class:`monai_physio.USDAnatomyTools` applies OmniSurface materials to
+:class:`monai_physio.ProcessUSDAnatomy` applies OmniSurface materials to
 labeled meshes after conversion. It reads :class:`AnatomyTaxonomy` from the
 segmenter to find which prim names map to which group, and looks up the
 material parameters in its ``render_params`` dict (initialized from the
-module-level :data:`monai_physio.usd_anatomy_tools.DEFAULT_RENDER_PARAMS`).
+module-level :data:`monai_physio.process_usd_anatomy.DEFAULT_RENDER_PARAMS`).
 
 .. code-block:: python
 
-   from monai_physio import USDAnatomyTools
+   from monai_physio import ProcessUSDAnatomy
 
-   tools = USDAnatomyTools(stage)
+   tools = ProcessUSDAnatomy(stage)
    tools.enhance_meshes(seg)
    stage.Export('painted.usd')
 
@@ -179,7 +179,7 @@ module-level defaults (affects future instances) or a single instance:
 
 .. code-block:: python
 
-   from monai_physio.usd_anatomy_tools import DEFAULT_RENDER_PARAMS
+   from monai_physio.process_usd_anatomy import DEFAULT_RENDER_PARAMS
 
    DEFAULT_RENDER_PARAMS["brain"] = {
        "name": "Brain",

--- a/docs/developer/utilities.rst
+++ b/docs/developer/utilities.rst
@@ -13,9 +13,9 @@ Transform Tools
 
    import itk
 
-   from monai_physio import TransformTools
+   from monai_physio import ProcessTransforms
 
-   tools = TransformTools()
+   tools = ProcessTransforms()
    transform = itk.transformread("fixed_to_moving_transform.hdf")
    moving = itk.imread("moving.mha")
    reference = itk.imread("reference.mha")
@@ -29,12 +29,12 @@ For PyVista contours:
    import itk
    import pyvista as pv
 
-   from monai_physio import TransformTools
+   from monai_physio import ProcessTransforms
 
    mesh = pv.read("heart_t0.vtp")
    transform = itk.transformread("fixed_to_moving_transform.hdf")
 
-   transformed = TransformTools().transform_pvcontour(mesh, transform)
+   transformed = ProcessTransforms().transform_pvcontour(mesh, transform)
 
 Contour Tools
 =============
@@ -43,10 +43,10 @@ Contour Tools
 
    import itk
 
-   from monai_physio import ContourTools
+   from monai_physio import ProcessContours
 
    mask = itk.imread("heart_mask.nrrd")
-   contour = ContourTools().extract_contours(mask)
+   contour = ProcessContours().extract_contours(mask)
    contour.save("heart_surface.vtp")
 
 USD Tools
@@ -54,9 +54,9 @@ USD Tools
 
 .. code-block:: python
 
-   from monai_physio import USDTools
+   from monai_physio import ProcessUSD
 
-   tools = USDTools()
+   tools = ProcessUSD()
    tools.merge_usd_files(
        "combined.usd",
        ["heart.usd", "lung.usd", "vessels.usd"],
@@ -69,17 +69,17 @@ USD Anatomy Tools
 
    from pxr import Usd
 
-   from monai_physio import USDAnatomyTools
+   from monai_physio import ProcessUSDAnatomy
 
    stage = Usd.Stage.Open("anatomy.usd")
-   painter = USDAnatomyTools(stage)
+   painter = ProcessUSDAnatomy(stage)
    painter.apply_anatomy_material_to_mesh("/World/Heart", "heart")
    stage.Export("anatomy_painted.usd")
 
 Image Tools
 ===========
 
-``ImageTools`` contains conversion and small image helpers used internally by
+``ProcessImages`` contains conversion and small image helpers used internally by
 registration and transform utilities. Prefer direct ITK I/O for ordinary
 example code:
 

--- a/docs/developer/workflows.rst
+++ b/docs/developer/workflows.rst
@@ -33,7 +33,7 @@ Current Workflow Mapping
    * - ``monai-physio-convert-image-4d-to-3d``
      - :class:`monai_physio.ConvertImage4DTo3D` (a converter, not a workflow)
    * - ``monai-physio-download-data``
-     - :class:`monai_physio.DataDownloadTools` (a utility, not a workflow)
+     - :class:`monai_physio.DownloadData` (a utility, not a workflow)
    * - ``monai-physio-visualize-pca-modes``
      - Reads a ``pca_model.json`` directly; no workflow class
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -305,10 +305,10 @@ or from Python:
 
 .. code-block:: python
 
-   from monai_physio import DataDownloadTools
+   from monai_physio import DownloadData
 
-   data_file = DataDownloadTools.DownloadSlicerHeartCTData("data/Slicer-Heart-CT")
-   assert DataDownloadTools.VerifySlicerHeartCTData("data/Slicer-Heart-CT")
+   data_file = DownloadData.DownloadSlicerHeartCTData("data/Slicer-Heart-CT")
+   assert DownloadData.VerifySlicerHeartCTData("data/Slicer-Heart-CT")
 
 See :doc:`cli_scripts/download_data` for sizes, source URLs, and directory
 layouts for every dataset.

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -450,7 +450,7 @@ Adapt to your data
    the phases - that is what the workflow is really designed for. Tune
    ``number_of_iterations_greedy`` down for a fast smoke test. The saved
    ``.hdf`` transforms are reusable:
-   :class:`~monai_physio.TransformTools` applies them to meshes and labelmaps.
+   :class:`~monai_physio.ProcessTransforms` applies them to meshes and labelmaps.
 
 Tutorial 4: CT Segmentation to VTK Surfaces
 ===========================================
@@ -592,7 +592,7 @@ Adapt to your data
    in order, for an animated scene instead of a static one (drop
    ``static_merge``), and set ``frames_per_second`` to control playback.
    ``appearance="anatomy"`` binds per-organ materials through
-   :class:`~monai_physio.USDAnatomyTools`; set ``anatomy_type`` to force one
+   :class:`~monai_physio.ProcessUSDAnatomy`; set ``anatomy_type`` to force one
    palette onto every object, or ``object_names`` to name the prims yourself.
    For file-in, file-out conversion without Python, see
    :doc:`cli_scripts/vtk_to_usd`.
@@ -1087,7 +1087,7 @@ Script
 
 Workflow
    :class:`~monai_physio.WorkflowConvertImageToVTK` (lung) or
-   :class:`~monai_physio.ContourTools` (heart),
+   :class:`~monai_physio.ProcessContours` (heart),
    :class:`~monai_physio.WorkflowFitStatisticalModelToPatient`, then
    :meth:`~monai_physio.WorkflowInferMovement.process_time_series`.
 
@@ -1177,7 +1177,7 @@ Workflow
    :class:`~monai_physio.WorkflowInferMovement` over both Tutorial 9 networks,
    :class:`~monai_physio.WorkflowFitStatisticalModelToPatient` for the heart fit,
    and :class:`~monai_physio.ConvertVTKToUSD` with
-   :class:`~monai_physio.USDAnatomyTools` for the animation.
+   :class:`~monai_physio.ProcessUSDAnatomy` for the animation.
 
 Dataset
    ``data/Chest-CT/Chest-CT.mha``, one ungated breath-hold scan, plus Tutorial 7
@@ -1222,7 +1222,7 @@ Inner API usage
           fitted_reference_mesh=lung_fitted_reference_mesh_file,
           direction="forward",
       )
-      transform = TransformTools().smooth_deformation_field_transform(
+      transform = ProcessTransforms().smooth_deformation_field_transform(
           field["deformation_field"], 15.0, field["weight_image"]
       )
 
@@ -1410,8 +1410,8 @@ Script
 Workflow
    :class:`~monai_physio.WorkflowCreateStatisticalModel` with
    ``solve_for_surface_pca=False`` on a tetrahedral template built by
-   :meth:`~monai_physio.ContourTools.extract_tetrahedra` and
-   :meth:`~monai_physio.ContourTools.trim_tetrahedra_to_surface`, then
+   :meth:`~monai_physio.ProcessContours.extract_tetrahedra` and
+   :meth:`~monai_physio.ProcessContours.trim_tetrahedra_to_surface`, then
    :class:`~monai_physio.WorkflowFitStatisticalModelToPatient` per case and
    gated frame.
 

--- a/experiments/Convert_VTK_To_USD/convert_chop_alterra_valve_to_usd.py
+++ b/experiments/Convert_VTK_To_USD/convert_chop_alterra_valve_to_usd.py
@@ -30,8 +30,8 @@ from pathlib import Path
 
 from monai_physio import ConvertVTKToUSD
 
-# Import USDTools for post-processing colormap
-from monai_physio.usd_tools import USDTools
+# Import ProcessUSD for post-processing colormap
+from monai_physio.process_usd import ProcessUSD
 
 # %% [markdown]
 # ## 1. Discover and Organize Time-Series Files
@@ -146,7 +146,7 @@ stage = (
 )
 
 # %%
-usd_tools = USDTools()
+usd_tools = ProcessUSD()
 # ConvertVTKToUSD places prims at /World/{basename}/{part_name}.
 vessel_paths = usd_tools.list_mesh_paths_under(stage, parent_path="/World/AlterraValve")
 if separate_by == "connectivity":

--- a/experiments/Convert_VTK_To_USD/convert_chop_tpv25_valve_to_usd.py
+++ b/experiments/Convert_VTK_To_USD/convert_chop_tpv25_valve_to_usd.py
@@ -30,8 +30,8 @@ from pathlib import Path
 
 from monai_physio import ConvertVTKToUSD
 
-# Import USDTools for post-processing colormap
-from monai_physio.usd_tools import USDTools
+# Import ProcessUSD for post-processing colormap
+from monai_physio.process_usd import ProcessUSD
 
 # %% [markdown]
 # ## 1. Discover and Organize Time-Series Files
@@ -145,7 +145,7 @@ stage = (
 )
 
 # %%
-usd_tools = USDTools()
+usd_tools = ProcessUSD()
 # ConvertVTKToUSD places prims at /World/{basename}/{part_name}.
 vessel_paths = usd_tools.list_mesh_paths_under(stage, parent_path="/World/TPV25Valve")
 if separate_by == "connectivity":

--- a/experiments/Convert_VTK_To_USD/convert_vtk_to_usd_using_class.py
+++ b/experiments/Convert_VTK_To_USD/convert_vtk_to_usd_using_class.py
@@ -29,7 +29,7 @@ import numpy as np
 import pyvista as pv
 from pxr import Usd, UsdGeom, UsdShade
 
-from monai_physio import ContourTools, ConvertVTKToUSD
+from monai_physio import ConvertVTKToUSD, ProcessContours
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -57,7 +57,7 @@ print(f"\nOutput directory: {output_dir}")
 vtp_file = output_dir / "average_surface.vtp"
 if not vtp_file.exists():
     vtk_mesh = pv.read(vtk_file)
-    contour_tools = ContourTools()
+    contour_tools = ProcessContours()
     vtp_surface = vtk_mesh.extract_surface(algorithm="dataset_surface")
     vtp_surface.save(vtp_file)
 print(f"  VTP: {vtp_file.exists()} - {vtp_file}")

--- a/experiments/Heart-Create_Statistical_Model/1-input_meshes_to_input_surfaces.py
+++ b/experiments/Heart-Create_Statistical_Model/1-input_meshes_to_input_surfaces.py
@@ -6,7 +6,6 @@
 
 # %%
 import os
-
 from glob import glob
 from pathlib import Path
 
@@ -48,7 +47,7 @@ for vtk_file in vtk_files:
         print(f"    Surface mesh: {surface.n_cells} cells, {surface.n_points} points")
 
     except Exception as e:
-        print(f"  Error processing {vtk_file}: {str(e)}")
+        print(f"  Error processing {vtk_file}: {e!s}")
 
 print("\n" + "=" * 50)
 print("Processing complete!")

--- a/experiments/Heart-Create_Statistical_Model/2-input_surfaces_to_surfaces_aligned.py
+++ b/experiments/Heart-Create_Statistical_Model/2-input_surfaces_to_surfaces_aligned.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 import pyvista as pv
 
-from monai_physio.contour_tools import ContourTools
+from monai_physio.process_contours import ProcessContours
 from monai_physio.register_models_icp import RegisterModelsICP
 
 _HERE = Path(__file__).parent
@@ -73,7 +73,7 @@ aligned_meshes = {}
 transforms_point_forward = {}  # Moving to Fixed point transforms (moving_to_fixed_transform)
 transforms_point_inverse = {}  # Fixed to Moving point transforms (fixed_to_moving_transform)
 
-contour_tools = ContourTools()
+contour_tools = ProcessContours()
 
 # Process each mesh
 for mesh_file in mesh_files:

--- a/experiments/Heart-Create_Statistical_Model/3-registration_based_correspondence.py
+++ b/experiments/Heart-Create_Statistical_Model/3-registration_based_correspondence.py
@@ -25,13 +25,13 @@ import numpy as np
 import pandas as pd
 import pyvista as pv
 
-from monai_physio.contour_tools import ContourTools
+from monai_physio.process_contours import ProcessContours
 from monai_physio.register_models_distance_maps import RegisterModelsDistanceMaps
 
 _HERE = Path(__file__).parent
 
-# Initialize ContourTools
-contour_tools = ContourTools()
+# Initialize ProcessContours
+contour_tools = ProcessContours()
 
 # Setup paths
 input_dir = _HERE / "kcl-heart-model/surfaces_aligned"

--- a/experiments/Heart-Create_Statistical_Model/4-surfaces_aligned_correspond_to_pca_inputs.py
+++ b/experiments/Heart-Create_Statistical_Model/4-surfaces_aligned_correspond_to_pca_inputs.py
@@ -5,7 +5,7 @@ import itk
 import numpy as np
 import pyvista as pv
 
-from monai_physio.contour_tools import ContourTools
+from monai_physio.process_contours import ProcessContours
 
 _HERE = Path(__file__).parent
 
@@ -18,7 +18,7 @@ output_dir = _HERE / "kcl-heart-model/pca_inputs"
 # Create output directory
 output_dir.mkdir(exist_ok=True)
 
-contour_tools = ContourTools()
+contour_tools = ProcessContours()
 
 template_mesh = pv.read(_HERE / "kcl-heart-model/average_surface.vtp")
 

--- a/experiments/Heart-Create_Statistical_Model/5-compute_pca_model.py
+++ b/experiments/Heart-Create_Statistical_Model/5-compute_pca_model.py
@@ -12,13 +12,11 @@
 
 # %%
 import json
-
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pyvista as pv
-
 from sklearn.decomposition import PCA  # SparsePCA, ...
 
 _HERE = Path(__file__).parent

--- a/experiments/Heart-Create_Statistical_Model/README.md
+++ b/experiments/Heart-Create_Statistical_Model/README.md
@@ -158,7 +158,7 @@ workflow = WorkflowFitStatisticalModelToPatient(
     fixed_meshes=patient_surfaces,
     fixed_image=patient_ct,
     pca_json="pca_model.json",  # From this experiment
-    pca_number_of_modes=10
+    pca_number_of_modes=10,
 )
 
 registered_mesh = workflow.process()["registered_template_model_surface"]

--- a/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/0-cardiacGatedCT_segment_and_landmark.py
+++ b/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/0-cardiacGatedCT_segment_and_landmark.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import itk
 
 from monai_physio import SegmentHeartSimpleware
-from monai_physio.landmark_tools import LandmarkTools
+from monai_physio.process_landmarks import ProcessLandmarks
 
 # %%
 # Discover data (mirrors recon_4d.py)
@@ -98,7 +98,7 @@ def segment_images(
                 itk.imwrite(labelmap, str(labelmap_path), compression=True)
 
                 landmarks = segmenter.get_landmarks()
-                LandmarkTools().write_landmarks_3dslicer(landmarks, landmark_path)
+                ProcessLandmarks().write_landmarks_3dslicer(landmarks, landmark_path)
 
             image_to_labelmap[os.path.join(src_dir, f)] = str(labelmap_path)
 

--- a/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/1-initial_registration.py
+++ b/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/1-initial_registration.py
@@ -15,12 +15,12 @@ from typing import Optional
 import itk
 import numpy as np
 
-from monai_physio.labelmap_tools import LabelmapTools
-from monai_physio.landmark_tools import LandmarkTools
+from monai_physio.process_labelmaps import ProcessLabelmaps
+from monai_physio.process_landmarks import ProcessLandmarks
+from monai_physio.process_transforms import ProcessTransforms
 from monai_physio.register_images_ants import RegisterImagesANTS
 from monai_physio.register_images_greedy import RegisterImagesGreedy
 from monai_physio.register_images_icon import RegisterImagesICON
-from monai_physio.transform_tools import TransformTools
 
 # %%
 ref_data_dir = Path("d:/MONAI-Physio/duke_data/ref_images")
@@ -53,9 +53,9 @@ fixed_image_resolution_mm = 0.0
 
 debug_subjects = []  # ["pm0002", "pm0003", "pm0004"]
 
-labelmap_tools = LabelmapTools()
-landmark_tools = LandmarkTools()
-transform_tools = TransformTools()
+labelmap_tools = ProcessLabelmaps()
+landmark_tools = ProcessLandmarks()
+transform_tools = ProcessTransforms()
 
 # %%
 ref_files = sorted(
@@ -151,7 +151,7 @@ def landmark_rms_errors(
 def load_or_derive_mask(labelmap: itk.Image, mask_path: Path) -> itk.Image:
     """Return the cached ``<stem>_labelmap_mask.nii.gz`` next to the
     labelmap, or derive it via
-    :meth:`LabelmapTools.convert_labelmap_to_mask` (threshold ``>0`` plus
+    :meth:`ProcessLabelmaps.convert_labelmap_to_mask` (threshold ``>0`` plus
     3 mm physical-radius dilation) and write it out so subsequent runs and
     the ICON eval reuse the same mask.
     """

--- a/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/3-eval_icon.py
+++ b/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/3-eval_icon.py
@@ -30,9 +30,9 @@ from monai_physio import (
     RegisterTimeSeriesImages,
     SegmentHeartSimpleware,
 )
-from monai_physio.labelmap_tools import LabelmapTools
-from monai_physio.landmark_tools import LandmarkTools
-from monai_physio.transform_tools import TransformTools
+from monai_physio.process_labelmaps import ProcessLabelmaps
+from monai_physio.process_landmarks import ProcessLandmarks
+from monai_physio.process_transforms import ProcessTransforms
 
 
 def _build_registrar(
@@ -172,17 +172,17 @@ print("All test subjects have exactly one ref.nii.gz")
 # %% [markdown]
 # ## 3. Reader instance used in the per-frame inner loop
 #
-# Landmarks are read with :meth:`LandmarkTools.read_landmarks_3dslicer` -
+# Landmarks are read with :meth:`ProcessLandmarks.read_landmarks_3dslicer` -
 # they were written as ``<stem>_landmark.mrk.json`` (3D Slicer Markups JSON,
 # LPS) by ``0-cardiacGatedCT_segment_and_landmark.py``.  Binary registration
-# masks come from :meth:`LabelmapTools.convert_labelmap_to_mask` (``>0``
+# masks come from :meth:`ProcessLabelmaps.convert_labelmap_to_mask` (``>0``
 # threshold plus 5 mm dilation), matching the loss-function masks used
 # during finetuning in ``1-finetune_icon.py``.
 
 # %%
-landmark_tools = LandmarkTools()
-labelmap_tools = LabelmapTools()
-transform_tools = TransformTools()
+landmark_tools = ProcessLandmarks()
+labelmap_tools = ProcessLabelmaps()
+transform_tools = ProcessTransforms()
 segmenter = SegmentHeartSimpleware()
 
 

--- a/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/registration_test.py
+++ b/experiments/Heart-GatedCT-OptimizedLongitudinalRegistration/registration_test.py
@@ -15,10 +15,10 @@ from pathlib import Path
 
 import itk
 
+from monai_physio.process_transforms import ProcessTransforms
 from monai_physio.register_images_ants import RegisterImagesANTS
 from monai_physio.register_images_greedy import RegisterImagesGreedy
 from monai_physio.register_images_icon import RegisterImagesICON
-from monai_physio.transform_tools import TransformTools
 
 # %% [markdown]
 # ## 1. Configuration and hard-coded paths
@@ -99,7 +99,7 @@ print(f"{method} registration done in {elapsed:.1f} s, loss={loss:.4f}")
 # three backends (ANTS, ICON, Greedy).
 
 # %%
-transform_tools = TransformTools()
+transform_tools = ProcessTransforms()
 warp_t_start = time.perf_counter()
 warped_image = transform_tools.transform_image(
     moving_image,

--- a/experiments/Heart-GatedCT_To_USD/0-download_and_convert_4d_to_3d.py
+++ b/experiments/Heart-GatedCT_To_USD/0-download_and_convert_4d_to_3d.py
@@ -2,7 +2,7 @@
 import shutil
 from pathlib import Path
 
-from monai_physio.data_download_tools import DataDownloadTools
+from monai_physio.download_data import DownloadData
 
 _HERE = Path(__file__).resolve().parent
 
@@ -13,7 +13,7 @@ output_dir = _HERE / "results"
 output_dir.mkdir(parents=True, exist_ok=True)
 
 # Downloads TruncalValve_4DCT.seq.nrrd and splits it into slice_???.mha.
-DataDownloadTools.DownloadSlicerHeartCTData(data_dir)
+DownloadData.DownloadSlicerHeartCTData(data_dir)
 
 # %%
 # Save the mid-stroke slice as the fixed/reference image

--- a/experiments/Heart-GatedCT_To_USD/1-register_images.py
+++ b/experiments/Heart-GatedCT_To_USD/1-register_images.py
@@ -3,11 +3,11 @@ from pathlib import Path
 
 import itk
 
+from monai_physio.process_transforms import ProcessTransforms
 from monai_physio.register_images_ants import RegisterImagesANTS
 from monai_physio.segment_chest_total_segmentator_with_contrast import (
     SegmentChestTotalSegmentatorWithContrast,
 )
-from monai_physio.transform_tools import TransformTools
 
 # nnUNetv2 (used by TotalSegmentator) spawns a multiprocessing.Pool. On Windows
 # the spawn start method re-imports this script in each child; without the
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         print(f"  Done registering whole image for slice {i:03d}.")
         moving_to_fixed_transform = results["moving_to_fixed_transform"]
         fixed_to_moving_transform = results["fixed_to_moving_transform"]
-        moving_image_reg = TransformTools().transform_image(
+        moving_image_reg = ProcessTransforms().transform_image(
             moving_image, fixed_to_moving_transform, fixed_image, "sinc"
         )  # Final resampling with sinc
         itk.imwrite(
@@ -136,7 +136,7 @@ if __name__ == "__main__":
         print(f"  Done registering dynamic anatomy mask for slice {i:03d}.")
         moving_to_fixed_transform = results["moving_to_fixed_transform"]
         fixed_to_moving_transform = results["fixed_to_moving_transform"]
-        moving_image_reg_dynamic_anatomy = TransformTools().transform_image(
+        moving_image_reg_dynamic_anatomy = ProcessTransforms().transform_image(
             moving_image, fixed_to_moving_transform, fixed_image, "sinc"
         )  # Final resampling with sinc
         itk.imwrite(
@@ -175,7 +175,7 @@ if __name__ == "__main__":
         print(f"  Done registering static anatomy mask for slice {i:03d}.")
         moving_to_fixed_transform = results["moving_to_fixed_transform"]
         fixed_to_moving_transform = results["fixed_to_moving_transform"]
-        moving_image_reg_static = TransformTools().transform_image(
+        moving_image_reg_static = ProcessTransforms().transform_image(
             moving_image, fixed_to_moving_transform, fixed_image, "sinc"
         )  # Final resampling with sinc
         itk.imwrite(

--- a/experiments/Heart-GatedCT_To_USD/2-generate_segmentation.py
+++ b/experiments/Heart-GatedCT_To_USD/2-generate_segmentation.py
@@ -5,7 +5,7 @@ import itk
 import numpy as np
 import pyvista as pv
 
-from monai_physio.contour_tools import ContourTools
+from monai_physio.process_contours import ProcessContours
 from monai_physio.segment_chest_total_segmentator_with_contrast import (
     SegmentChestTotalSegmentatorWithContrast,
 )
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     contrast_mask = result["contrast"]
 
     # %%
-    con = ContourTools()
+    con = ProcessContours()
     all_contours = con.extract_contours(labelmap_image)
     all_contours.save(os.path.join(output_dir, f"{outname}.all_mask.vtp"))
 

--- a/experiments/Heart-GatedCT_To_USD/3-transform_dynamic_and_static_contours.py
+++ b/experiments/Heart-GatedCT_To_USD/3-transform_dynamic_and_static_contours.py
@@ -5,9 +5,9 @@ import itk
 import pyvista as pv
 
 from monai_physio import ConvertVTKToUSD
-from monai_physio.contour_tools import ContourTools
+from monai_physio.process_contours import ProcessContours
+from monai_physio.process_usd_anatomy import ProcessUSDAnatomy
 from monai_physio.segment_chest_total_segmentator import SegmentChestTotalSegmentator
-from monai_physio.usd_anatomy_tools import USDAnatomyTools
 
 # Defensive: this script only reads `seg.all_mask_ids` today, but if anyone
 # ever adds a `seg.segment(...)` call it would trigger the nnUNet
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     def transform_contours(
         contours, transform_filenames, frame_indices, base_name, output_dir
     ):
-        con = ContourTools()
+        con = ProcessContours()
         for i, transform_filename in zip(frame_indices, transform_filenames):
             fixed_to_moving_transform = itk.transformread(transform_filename)[0]
             print(f"Applying transform {transform_filename} to {base_name}")
@@ -75,7 +75,7 @@ if __name__ == "__main__":
             os.path.join(output_dir, f"{project_name}.{base_name}.usd"),
         )
 
-        painter = USDAnatomyTools(stage)
+        painter = ProcessUSDAnatomy(stage)
         painter.enhance_meshes(seg)
         if os.path.exists(
             os.path.join(output_dir, f"{project_name}.{base_name}_painted.usd")

--- a/experiments/Heart-GatedCT_To_USD/4-merge_dynamic_and_static_usd.py
+++ b/experiments/Heart-GatedCT_To_USD/4-merge_dynamic_and_static_usd.py
@@ -1,12 +1,12 @@
 # %%
 import os
 
-from monai_physio.usd_tools import USDTools
+from monai_physio.process_usd import ProcessUSD
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 
 # %%
-usd_tools = USDTools()
+usd_tools = ProcessUSD()
 
 _merged = os.path.join(_HERE, "results", "Slicer_CardiacGatedCT.merged_painted.usd")
 _dynamic = os.path.join(

--- a/experiments/Heart-Simpleware_Segmentation/README.md
+++ b/experiments/Heart-Simpleware_Segmentation/README.md
@@ -201,6 +201,7 @@ Enable detailed logging:
 
 ```python
 import logging
+
 segmenter = SegmentHeartSimpleware(log_level=logging.DEBUG)
 ```
 
@@ -228,7 +229,9 @@ workflow.set_static_labelmap(result["labelmap"])
 ### Statistical Model Registration
 Register segmentation with heart model using `Heart-Statistical_Model_To_Patient`:
 ```python
-from monai_physio.workflow_fit_statistical_model_to_patient import WorkflowFitStatisticalModelToPatient
+from monai_physio.workflow_fit_statistical_model_to_patient import (
+    WorkflowFitStatisticalModelToPatient,
+)
 
 workflow = WorkflowFitStatisticalModelToPatient()
 workflow.set_patient_segmentation(result["labelmap"])
@@ -246,6 +249,7 @@ lv_volume_ml = np.sum(lv_mask) * voxel_volume / 1000
 
 # Create mesh for computational modeling
 from monai_physio.convert_vtk_to_usd import create_mesh_from_mask
+
 lv_mesh = create_mesh_from_mask(lv_mask)
 ```
 
@@ -262,7 +266,8 @@ segmenter.set_target_spacing(2.0)  # Use 2mm instead of 1mm
 2. **Use region of interest**:
 ```python
 # Crop image to heart region before segmentation
-from monai_physio.image_tools import crop_to_roi
+from monai_physio.process_images import crop_to_roi
+
 cropped_image = crop_to_roi(input_image, roi_bounds)
 ```
 

--- a/experiments/Heart-Simpleware_Segmentation/simpleware_heart_segmentation.py
+++ b/experiments/Heart-Simpleware_Segmentation/simpleware_heart_segmentation.py
@@ -32,7 +32,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pyvista as pv
 
-from monai_physio.landmark_tools import LandmarkTools
+from monai_physio.process_landmarks import ProcessLandmarks
 from monai_physio.segment_heart_simpleware import SegmentHeartSimpleware
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -211,7 +211,7 @@ if input_image is not None:
         # Save landmarks
         print("\nSaving landmarks...")
         landmarks = segmenter.get_landmarks()
-        LandmarkTools().write_landmarks_3dslicer(
+        ProcessLandmarks().write_landmarks_3dslicer(
             landmarks=landmarks, path=os.path.join(output_dir, "landmarks.mrk.json")
         )
 

--- a/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_model_icp_itk.py
+++ b/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_model_icp_itk.py
@@ -24,11 +24,11 @@ import pyvista as pv
 
 # Import from MONAI Physio package
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
+    ProcessTransforms,
     RegisterModelsICPITK,
-    TransformTools,
 )
-from monai_physio.image_tools import ImageTools
+from monai_physio.process_images import ProcessImages
 
 # %% [markdown]
 # ## Define File Paths
@@ -62,7 +62,7 @@ print(f"  Original spacing: {itk.spacing(patient_image)}")
 
 # Resample to 1mm isotropic spacing
 print("Resampling to isotropic...")
-patient_image = ImageTools().make_isotropic_image(patient_image)
+patient_image = ProcessImages().make_isotropic_image(patient_image)
 
 print(f"  Resampled size: {itk.size(patient_image)}")
 print(f"  Resampled spacing: {itk.spacing(patient_image)}")
@@ -125,7 +125,7 @@ itk.imwrite(
 # ## Convert Segmentation Mask to a Surface
 
 # %%
-contour_tools = ContourTools()
+contour_tools = ProcessContours()
 patient_heart_surface = contour_tools.extract_contours(patient_heart_mask)
 
 # %% [markdown]
@@ -177,7 +177,7 @@ print("  Saved ICP transform")
 # %%
 # Apply ICP transform to the full average mesh (not just surface)
 # This gets the volumetric mesh into patient space for PCA registration
-transform_tools = TransformTools()
+transform_tools = ProcessTransforms()
 icp_registered_model = transform_tools.transform_pvcontour(
     template_model, icp_moving_to_fixed_transform
 )

--- a/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_model_registration_pca.py
+++ b/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_model_registration_pca.py
@@ -26,12 +26,12 @@ import pyvista as pv
 
 # Import from MONAI Physio package
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
+    ProcessTransforms,
     RegisterModelsICP,
     RegisterModelsPCA,
-    TransformTools,
 )
-from monai_physio.image_tools import ImageTools
+from monai_physio.process_images import ProcessImages
 
 # %% [markdown]
 # ## Define File Paths
@@ -73,7 +73,7 @@ print(f"  Original spacing: {itk.spacing(patient_image)}")
 
 # Resample to 1mm isotropic spacing
 print("Resampling to isotropic...")
-patient_image = ImageTools().make_isotropic_image(patient_image)
+patient_image = ProcessImages().make_isotropic_image(patient_image)
 
 print(f"  Resampled size: {itk.size(patient_image)}")
 print(f"  Resampled spacing: {itk.spacing(patient_image)}")
@@ -136,7 +136,7 @@ itk.imwrite(
 # ## Convert Segmentation Mask to a Surface
 
 # %%
-contour_tools = ContourTools()
+contour_tools = ProcessContours()
 patient_surface = contour_tools.extract_contours(patient_heart_mask_image)
 
 # %% [markdown]
@@ -187,7 +187,7 @@ print("  Saved ICP transform")
 # %%
 # Apply ICP transform to the full average mesh (not just surface)
 # This gets the volumetric mesh into patient space for PCA registration
-transform_tools = TransformTools()
+transform_tools = ProcessTransforms()
 icp_registered_model = transform_tools.transform_pvcontour(
     template_model, icp_moving_to_fixed_transform
 )

--- a/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_patient.py
+++ b/experiments/Heart-Statistical_Model_To_Patient/heart_model_to_patient.py
@@ -13,7 +13,7 @@ import pyvista as pv
 
 # Import from MONAI Physio package
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
     SegmentChestTotalSegmentator,
     WorkflowFitStatisticalModelToPatient,
 )
@@ -117,7 +117,7 @@ if __name__ == "__main__":
         )
 
     # %%
-    patient_model = ContourTools().extract_contours(patient_mask)
+    patient_model = ProcessContours().extract_contours(patient_mask)
     patient_model.save(str(output_dir / "patient_mesh.vtp"))
     patient_model = pv.read(str(output_dir / "patient_mesh.vtp"))
 

--- a/experiments/Heart-VTKSeries_To_USD/0-download_and_convert_4d_to_3d.py
+++ b/experiments/Heart-VTKSeries_To_USD/0-download_and_convert_4d_to_3d.py
@@ -1,7 +1,7 @@
 # %%
 import os
 
-from monai_physio.data_download_tools import DataDownloadTools
+from monai_physio.download_data import DownloadData
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -13,4 +13,4 @@ if not os.path.exists(output_dir):
     os.makedirs(output_dir)
 
 # Downloads TruncalValve_4DCT.seq.nrrd and splits it into slice_???.mha.
-DataDownloadTools.DownloadSlicerHeartCTData(data_dir)
+DownloadData.DownloadSlicerHeartCTData(data_dir)

--- a/experiments/Heart-VTKSeries_To_USD/1-heart_vtkseries_to_usd.py
+++ b/experiments/Heart-VTKSeries_To_USD/1-heart_vtkseries_to_usd.py
@@ -19,14 +19,14 @@ if __name__ == "__main__":
         # Segment chest from CT images to generate vtk files
         import itk
 
-        from monai_physio.contour_tools import ContourTools
+        from monai_physio.process_contours import ProcessContours
         from monai_physio.segment_chest_total_segmentator_with_contrast import (
             SegmentChestTotalSegmentatorWithContrast,
         )
 
         input_images = sorted(glob.glob(os.path.join(_DATA_DIR, "slice_*.mha")))
         seg = SegmentChestTotalSegmentatorWithContrast()
-        con = ContourTools()
+        con = ProcessContours()
         for i, img_path in enumerate(input_images):
             print(f"Segmenting {img_path}...")
             img = itk.imread(img_path)

--- a/experiments/Heart_and_Lungs_Motion/0-heart_and_lungs_beating_heart.py
+++ b/experiments/Heart_and_Lungs_Motion/0-heart_and_lungs_beating_heart.py
@@ -69,7 +69,7 @@ from monai_physio import (
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
 )
-from monai_physio import physicsnemo_tools as pnt
+from monai_physio import process_physicsnemo as pnt
 
 
 def _ensure_mgn_inference_assets(
@@ -109,9 +109,9 @@ def _ensure_mgn_inference_assets(
     edge_index_file = model_dir / "shared_edge_index.pt"
     edge_feats_file = model_dir / "shared_edge_features.pt"
     if not edge_index_file.exists() or not edge_feats_file.exists():
-        edge_index = pnt.PhysicsNemoTools.mesh_to_edge_index(mean_surface)
+        edge_index = pnt.ProcessPhysicsNemo.mesh_to_edge_index(mean_surface)
         coords = np.asarray(mean_surface.points, dtype=np.float32)
-        edge_feats = pnt.PhysicsNemoTools.compute_edge_features(coords, edge_index)
+        edge_feats = pnt.ProcessPhysicsNemo.compute_edge_features(coords, edge_index)
         torch.save(edge_index, str(edge_index_file))
         torch.save(edge_feats, str(edge_feats_file))
 

--- a/experiments/Heart_and_Lungs_Motion/1-heart_and_lungs_combined.py
+++ b/experiments/Heart_and_Lungs_Motion/1-heart_and_lungs_combined.py
@@ -74,7 +74,7 @@ import itk
 import numpy as np
 import pyvista as pv
 
-from monai_physio import ImageTools, TransformTools, WorkflowConvertVTKToUSD
+from monai_physio import ProcessImages, ProcessTransforms, WorkflowConvertVTKToUSD
 
 # Gaussian sigma (mm) used to smooth the sparse cardiac deformation fields.
 SMOOTHING_SIGMA_MM = 10.0
@@ -86,7 +86,7 @@ SURFACE_DECIMATION_REDUCTION = 0.0
 # Taubin (non-shrinking) smoothing iterations (0 = no smoothing).
 SURFACE_SMOOTHING_ITERATIONS = 0
 
-_transform_tools = TransformTools()
+_transform_tools = ProcessTransforms()
 
 
 def _condition_surface(
@@ -118,7 +118,7 @@ def _smoothed_cardiac_transform(
     and Gaussian-smoothed by ``sigma_mm`` (in physical millimeters).
     """
     field = itk.imread(str(field_file))
-    field_double = ImageTools().convert_array_to_image_of_vectors(
+    field_double = ProcessImages().convert_array_to_image_of_vectors(
         itk.array_from_image(field), reference_image=field, ptype=itk.D
     )
     field_transform = itk.DisplacementFieldTransform[itk.D, 3].New()

--- a/experiments/Lung-GatedCT_To_USD/0-register_dirlab_4dct.py
+++ b/experiments/Lung-GatedCT_To_USD/0-register_dirlab_4dct.py
@@ -6,10 +6,10 @@ import itk
 import numpy as np
 from data_dirlab_4d_ct import DataDirLab4DCT
 
-from monai_physio.image_tools import ImageTools
+from monai_physio.process_images import ProcessImages
+from monai_physio.process_transforms import ProcessTransforms
 from monai_physio.register_images_icon import RegisterImagesICON
 from monai_physio.segment_chest_total_segmentator import SegmentChestTotalSegmentator
-from monai_physio.transform_tools import TransformTools
 
 # nnUNetv2 (used by TotalSegmentator) spawns a multiprocessing.Pool. On Windows
 # the spawn start method re-imports this script in each child; without the
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     # %%
     def dilate_mask(mask: Optional[itk.image], dilation: int) -> Optional[itk.image]:
         if mask is not None:
-            return ImageTools().binary_dilate_image(mask, dilation, 1, 0)
+            return ProcessImages().binary_dilate_image(mask, dilation, 1, 0)
         return None
 
     def register_image(
@@ -71,7 +71,7 @@ if __name__ == "__main__":
         moving_to_fixed_transform = results["moving_to_fixed_transform"]
         fixed_to_moving_transform = results["fixed_to_moving_transform"]
         print("Registering image...Done!")
-        moving_image_reg = TransformTools().transform_image(
+        moving_image_reg = ProcessTransforms().transform_image(
             moving_image, fixed_to_moving_transform, fixed_image, "sinc"
         )  # Final resampling with sinc
         itk.imwrite(

--- a/experiments/Lung-GatedCT_To_USD/1-make_dirlab_models.py
+++ b/experiments/Lung-GatedCT_To_USD/1-make_dirlab_models.py
@@ -7,7 +7,7 @@ import pyvista as pv
 from data_dirlab_4d_ct import DataDirLab4DCT
 
 from monai_physio import ConvertVTKToUSD
-from monai_physio.contour_tools import ContourTools
+from monai_physio.process_contours import ProcessContours
 from monai_physio.segment_chest_total_segmentator import SegmentChestTotalSegmentator
 
 # Defensive: today this script only reads `seg.all_mask_ids`, but if anyone
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         """
         Transform a list of contours to a list of transformed contours.
         """
-        con_tools = ContourTools()
+        con_tools = ProcessContours()
         new_contours = []
         for i in range(10):
             moving_to_fixed_transform = itk.transformread(
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         )
 
     # %%
-    con_tools = ContourTools()
+    con_tools = ProcessContours()
 
     seg = SegmentChestTotalSegmentator()
     for case_name in case_names:

--- a/experiments/Lung-GatedCT_To_USD/2-paint_dirlab_models.py
+++ b/experiments/Lung-GatedCT_To_USD/2-paint_dirlab_models.py
@@ -4,11 +4,11 @@ from pathlib import Path
 from data_dirlab_4d_ct import DataDirLab4DCT
 from pxr import Usd
 
+from monai_physio.process_usd_anatomy import ProcessUSDAnatomy
 from monai_physio.segment_chest_total_segmentator import SegmentChestTotalSegmentator
-from monai_physio.usd_anatomy_tools import USDAnatomyTools
 
 # Defensive: today this script only instantiates SegmentChestTotalSegmentator
-# to read its anatomy labels for USDAnatomyTools, but if anyone adds a
+# to read its anatomy labels for ProcessUSDAnatomy, but if anyone adds a
 # `seg.segment(...)` call it would trigger the nnUNet multiprocessing.Pool
 # which re-imports the script on Windows (spawn start method) and crashes
 # with a spawn-cascade RuntimeError. Guard pre-emptively.
@@ -25,6 +25,6 @@ if __name__ == "__main__":
     for anatomy in ["all", "static_anatomy", "dynamic_anatomy"]:
         for case_name in case_names:
             stage = Usd.Stage.Open(f"{output_dir}/{case_name}_{anatomy}_lungGated.usd")
-            painter = USDAnatomyTools(stage)
+            painter = ProcessUSDAnatomy(stage)
             painter.enhance_meshes(seg)
             stage.Export(f"{output_dir}/{case_name}_{anatomy}_lungGated_painted.usd")

--- a/experiments/Lung-GatedCT_To_USD/Experiment_ArrangeOnStage.py
+++ b/experiments/Lung-GatedCT_To_USD/Experiment_ArrangeOnStage.py
@@ -3,7 +3,7 @@ import os
 
 from data_dirlab_4d_ct import DataDirLab4DCT
 
-from monai_physio.usd_tools import USDTools
+from monai_physio.process_usd import ProcessUSD
 
 # %%
 os.makedirs("Results_ArrangeOnStage", exist_ok=True)
@@ -14,7 +14,7 @@ case_names = [
     DataDirLab4DCT().get_case_names()[1],
 ]
 
-usd_tools = USDTools()
+usd_tools = ProcessUSD()
 
 for label in ["dynamic_anatomy", "static_anatomy"]:
     usd_file_names = [

--- a/experiments/Lung-GatedCT_To_USD/Experiment_CombineModels.py
+++ b/experiments/Lung-GatedCT_To_USD/Experiment_CombineModels.py
@@ -4,7 +4,7 @@ import os
 import itk
 import pyvista as pv
 
-from monai_physio.transform_tools import TransformTools
+from monai_physio.process_transforms import ProcessTransforms
 
 # %%
 os.makedirs("results_CombineModels", exist_ok=True)
@@ -22,7 +22,7 @@ img_tfm_other_t00 = itk.transformread(
 )[0]
 
 # %%
-tfm_tools = TransformTools()
+tfm_tools = ProcessTransforms()
 
 lung_mask_t00 = tfm_tools.transform_image(lung_mask_t30, img_tfm_lung_t00, all_mask_t00)
 other_mask_t00 = tfm_tools.transform_image(

--- a/experiments/Lung-GatedCT_To_USD/Experiment_SegReg.py
+++ b/experiments/Lung-GatedCT_To_USD/Experiment_SegReg.py
@@ -3,8 +3,7 @@ import os
 
 import itk
 
-from monai_physio import RegisterImagesICON
-from monai_physio import SegmentChestTotalSegmentator
+from monai_physio import RegisterImagesICON, SegmentChestTotalSegmentator
 
 # nnUNetv2 (used by TotalSegmentator) spawns a multiprocessing.Pool. On Windows
 # the spawn start method re-imports this script in each child; without the

--- a/experiments/Lung-GatedCT_To_USD/data_dirlab_4d_ct.py
+++ b/experiments/Lung-GatedCT_To_USD/data_dirlab_4d_ct.py
@@ -5,7 +5,7 @@ data for the DirLab 4DCT dataset.
 
 DirLab-4DCT's raw ``.mhd``/``.img`` volumes are not in Hounsfield units; run
 ``data/DirLab-4DCT/fix_downloaded_data.py`` (backed by
-``DataDownloadTools.FixDirLab4DCTData``) once to write corrected ``.mha``
+``DownloadData.FixDirLab4DCTData``) once to write corrected ``.mha``
 volumes before using this dataset. That script's output is what this
 directory's ``case_names`` are meant to be read from.
 """

--- a/experiments/Lung-GatedCT_To_USD_NV/0-register_dirlab_4dct.py
+++ b/experiments/Lung-GatedCT_To_USD_NV/0-register_dirlab_4dct.py
@@ -6,10 +6,10 @@ import itk
 import numpy as np
 from data_dirlab_4d_ct import DataDirLab4DCT
 
-from monai_physio.image_tools import ImageTools
+from monai_physio.process_images import ProcessImages
+from monai_physio.process_transforms import ProcessTransforms
 from monai_physio.register_images_icon import RegisterImagesICON
 from monai_physio.segment_nv_segment_ct_mri import SegmentNVSegmentCTMRI
-from monai_physio.transform_tools import TransformTools
 
 # The NV-Segment-CTMR bundle runs a MONAI DataLoader that may spawn worker
 # processes. On Windows the spawn start method re-imports this script in each
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     # %%
     def dilate_mask(mask: Optional[itk.image], dilation: int) -> Optional[itk.image]:
         if mask is not None:
-            return ImageTools().binary_dilate_image(mask, dilation, 1, 0)
+            return ProcessImages().binary_dilate_image(mask, dilation, 1, 0)
         return None
 
     def register_image(
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         moving_to_fixed_transform = results["moving_to_fixed_transform"]
         fixed_to_moving_transform = results["fixed_to_moving_transform"]
         print("Registering image...Done!")
-        moving_image_reg = TransformTools().transform_image(
+        moving_image_reg = ProcessTransforms().transform_image(
             moving_image, fixed_to_moving_transform, fixed_image, "sinc"
         )  # Final resampling with sinc
         itk.imwrite(

--- a/experiments/Lung-GatedCT_To_USD_NV/1-make_dirlab_models.py
+++ b/experiments/Lung-GatedCT_To_USD_NV/1-make_dirlab_models.py
@@ -7,7 +7,7 @@ import pyvista as pv
 from data_dirlab_4d_ct import DataDirLab4DCT
 
 from monai_physio import ConvertVTKToUSD
-from monai_physio.contour_tools import ContourTools
+from monai_physio.process_contours import ProcessContours
 from monai_physio.segment_nv_segment_ct_mri import SegmentNVSegmentCTMRI
 
 # Defensive: today this script only reads `seg.taxonomy`, but if anyone adds a
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         """
         Transform a list of contours to a list of transformed contours.
         """
-        con_tools = ContourTools()
+        con_tools = ProcessContours()
         new_contours = []
         for i in range(10):
             moving_to_fixed_transform = itk.transformread(
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         )
 
     # %%
-    con_tools = ContourTools()
+    con_tools = ProcessContours()
 
     seg = SegmentNVSegmentCTMRI()
     for case_name in case_names:

--- a/experiments/Lung-GatedCT_To_USD_NV/2-paint_dirlab_models.py
+++ b/experiments/Lung-GatedCT_To_USD_NV/2-paint_dirlab_models.py
@@ -4,11 +4,11 @@ from pathlib import Path
 from data_dirlab_4d_ct import DataDirLab4DCT
 from pxr import Usd
 
+from monai_physio.process_usd_anatomy import ProcessUSDAnatomy
 from monai_physio.segment_nv_segment_ct_mri import SegmentNVSegmentCTMRI
-from monai_physio.usd_anatomy_tools import USDAnatomyTools
 
 # Defensive: today this script only instantiates SegmentNVSegmentCTMRI to read
-# its anatomy labels for USDAnatomyTools, but if anyone adds a
+# its anatomy labels for ProcessUSDAnatomy, but if anyone adds a
 # `seg.segment(...)` call the model pipeline's MONAI DataLoader may spawn
 # worker processes, which re-import the script on Windows (spawn start method)
 # and crash with a spawn-cascade RuntimeError. Guard pre-emptively.
@@ -25,6 +25,6 @@ if __name__ == "__main__":
     for anatomy in ["all", "static_anatomy", "dynamic_anatomy"]:
         for case_name in case_names:
             stage = Usd.Stage.Open(f"{output_dir}/{case_name}_{anatomy}_lungGated.usd")
-            painter = USDAnatomyTools(stage)
+            painter = ProcessUSDAnatomy(stage)
             painter.enhance_meshes(seg)
             stage.Export(f"{output_dir}/{case_name}_{anatomy}_lungGated_painted.usd")

--- a/experiments/Reconstruct4DCT/reconstruct_4d_ct.py
+++ b/experiments/Reconstruct4DCT/reconstruct_4d_ct.py
@@ -4,7 +4,7 @@ import os
 import itk
 import numpy as np
 
-from monai_physio import RegisterImagesGreedy, TransformTools
+from monai_physio import ProcessTransforms, RegisterImagesGreedy
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -52,7 +52,7 @@ def register_slices(
     reference_image_reg_use_identity,
     portion_of_prior_to_use=0.0,
 ):
-    tfm_tools = TransformTools()
+    tfm_tools = ProcessTransforms()
 
     img = images[reference_image_num]
     fixed_to_moving_transform = None
@@ -288,7 +288,7 @@ for reg_tool_name, reg_tool, num_iterations in reg_method_data:
     moving_to_fixed_transform_arr = results["moving_to_fixed_transforms"]
 
 # %%
-tfm_tool = TransformTools()
+tfm_tool = ProcessTransforms()
 
 load_data = True
 

--- a/experiments/Reconstruct4DCT/reconstruct_4d_ct_class.py
+++ b/experiments/Reconstruct4DCT/reconstruct_4d_ct_class.py
@@ -17,12 +17,12 @@ import itk
 import numpy as np
 
 from monai_physio import (
+    ProcessTransforms,
     RegisterImagesBase,
     RegisterImagesGreedy,
     RegisterImagesGreedyICON,
     RegisterImagesICON,
     RegisterTimeSeriesImages,
-    TransformTools,
 )
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -128,7 +128,7 @@ for file in files:
 #
 
 # %%
-tfm_tools = TransformTools()
+tfm_tools = ProcessTransforms()
 
 # Loop through each registration method
 for method_idx, registration_method_name in enumerate(registration_method_names):

--- a/src/monai_physio/__init__.py
+++ b/src/monai_physio/__init__.py
@@ -54,25 +54,33 @@ if _installer is not None and _installer.strip() == "pip":
 
 # Data processing utilities
 from .anatomy_taxonomy import AnatomyGroup, AnatomyTaxonomy
-from .contour_tools import ContourTools
 from .convert_image_4d_to_3d import ConvertImage4DTo3D
 from .convert_vtk_to_usd import ConvertVTKToUSD
-from .data_download_tools import DataDownloadTools
+from .download_data import DownloadData
 from .evaluate_movement_base import EvaluateMovementBase, MovementGroundTruth
 from .evaluate_movement_duke_heart import EvaluateMovementDukeHeart
 from .evaluate_movement_lung import EvaluateMovementLung
-
-# Utility classes
-from .image_tools import ImageTools
 from .infer_physicsnemo_base import InferPhysicsNeMoBase
 from .infer_physicsnemo_mgn import InferPhysicsNeMoMGN
 from .infer_physicsnemo_mlp import InferPhysicsNeMoMLP
-from .labelmap_tools import LabelmapTools
-from .landmark_tools import LandmarkTools
 
 # Base classes
 from .monai_physio_base import MONAIPhysioBase
-from .physicsnemo_tools import DistributedContext, PhysicsNemoTools, distributed_context
+from .process_contours import ProcessContours
+
+# Utility classes
+from .process_images import ProcessImages
+from .process_labelmaps import ProcessLabelmaps
+from .process_landmarks import ProcessLandmarks
+from .process_physicsnemo import (
+    DistributedContext,
+    ProcessPhysicsNemo,
+    distributed_context,
+)
+from .process_tests import ProcessTests
+from .process_transforms import ProcessTransforms
+from .process_usd import ProcessUSD
+from .process_usd_anatomy import ProcessUSDAnatomy
 from .register_images_ants import RegisterImagesANTS
 
 # Registration classes
@@ -99,16 +107,12 @@ from .segment_heart_simpleware_trimmed_branches import (
     SegmentHeartSimplewareTrimmedBranches,
 )
 from .segment_nv_segment_ct_mri import SegmentNVSegmentCTMRI
-from .test_tools import TestTools
 from .train_physicsnemo_base import TrainPhysicsNeMoBase
 from .train_physicsnemo_mgn import TrainPhysicsNeMoMGN
 from .train_physicsnemo_mlp import TrainPhysicsNeMoMLP
 from .train_physicsnemo_physics_informed_motion import (
     TrainPhysicsNeMoPhysicsInformedMotion,
 )
-from .transform_tools import TransformTools
-from .usd_anatomy_tools import USDAnatomyTools
-from .usd_tools import USDTools
 from .workflow_convert_image_to_usd import WorkflowConvertImageToUSD
 
 # Core workflow processor
@@ -130,28 +134,28 @@ __all__ = [
     "AnatomyGroup",
     # Anatomy taxonomy (shared between segmenters and USD renderer)
     "AnatomyTaxonomy",
-    "ContourTools",
+    "ProcessContours",
     # Data processing utilities
     "ConvertImage4DTo3D",
     "ConvertVTKToUSD",
-    "DataDownloadTools",
+    "DownloadData",
     # Distributed execution
     "DistributedContext",
     "EvaluateMovementBase",
     "EvaluateMovementDukeHeart",
     "EvaluateMovementLung",
     # Utility classes
-    "ImageTools",
+    "ProcessImages",
     # Inference method classes
     "InferPhysicsNeMoBase",
     "InferPhysicsNeMoMGN",
     "InferPhysicsNeMoMLP",
-    "LabelmapTools",
-    "LandmarkTools",
+    "ProcessLabelmaps",
+    "ProcessLandmarks",
     # Base classes
     "MONAIPhysioBase",
     "MovementGroundTruth",
-    "PhysicsNemoTools",
+    "ProcessPhysicsNemo",
     "RegisterImagesANTS",
     # Registration classes
     "RegisterImagesBase",
@@ -172,15 +176,15 @@ __all__ = [
     "SegmentHeartSimpleware",
     "SegmentHeartSimplewareTrimmedBranches",
     "SegmentNVSegmentCTMRI",
-    "TestTools",
+    "ProcessTests",
     # Training method classes
     "TrainPhysicsNeMoBase",
     "TrainPhysicsNeMoMGN",
     "TrainPhysicsNeMoMLP",
     "TrainPhysicsNeMoPhysicsInformedMotion",
-    "TransformTools",
-    "USDAnatomyTools",
-    "USDTools",
+    "ProcessTransforms",
+    "ProcessUSDAnatomy",
+    "ProcessUSD",
     "WorkflowConvertImageToUSD",
     # Workflow classes
     "WorkflowConvertImageToVTK",

--- a/src/monai_physio/anatomy_taxonomy.py
+++ b/src/monai_physio/anatomy_taxonomy.py
@@ -6,7 +6,7 @@ minimal data type that maps anatomical groups (``heart``, ``lung``, ``bone``,
 
 The taxonomy is the single source of truth for the label hierarchy. Both
 :class:`monai_physio.SegmentAnatomyBase` (which populates one via its
-subclasses) and :class:`monai_physio.USDAnatomyTools` (which consumes one
+subclasses) and :class:`monai_physio.ProcessUSDAnatomy` (which consumes one
 when applying materials) depend on this class. The two consumers do not
 depend on each other, which lets either side be used without the other.
 

--- a/src/monai_physio/cli/__init__.py
+++ b/src/monai_physio/cli/__init__.py
@@ -1,9 +1,9 @@
 """Command-line interface modules for MONAI Physio."""
 
 __all__ = [
+    "convert_image_4d_to_3d",
     "convert_image_to_usd",
     "convert_image_to_vtk",
-    "convert_image_4d_to_3d",
     "convert_vtk_to_usd",
     "create_statistical_model",
     "download_data",

--- a/src/monai_physio/cli/convert_image_to_vtk.py
+++ b/src/monai_physio/cli/convert_image_to_vtk.py
@@ -167,7 +167,7 @@ Examples
     print("=" * 70)
 
     try:
-        from .. import ContourTools, WorkflowConvertImageToVTK
+        from .. import ProcessContours, WorkflowConvertImageToVTK
 
         workflow = WorkflowConvertImageToVTK(
             segmentation_method=build_segmentation_method(
@@ -202,13 +202,13 @@ Examples
     try:
         if args.output_mode == "combined":
             stem = f"{prefix}_surfaces" if prefix else "surfaces"
-            surface_file = ContourTools.save_combined_surfaces(
+            surface_file = ProcessContours.save_combined_surfaces(
                 surfaces, os.path.join(args.output_dir, f"{stem}.vtp")
             )
             print(f"  Combined surface -> {surface_file}")
         else:
             # One file per anatomy group or per individual label
-            saved_surfaces = ContourTools.save_surfaces(
+            saved_surfaces = ProcessContours.save_surfaces(
                 surfaces, args.output_dir, prefix=prefix
             )
             for name, path in saved_surfaces.items():

--- a/src/monai_physio/cli/convert_vtk_to_usd.py
+++ b/src/monai_physio/cli/convert_vtk_to_usd.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pyvista as pv
 
-from ..usd_anatomy_tools import DEFAULT_RENDER_PARAMS
+from ..process_usd_anatomy import DEFAULT_RENDER_PARAMS
 
 # Anatomy types accepted by --anatomy-type, sourced from the renderer's
 # registered defaults so that new groups/organs registered in

--- a/src/monai_physio/cli/download_data.py
+++ b/src/monai_physio/cli/download_data.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from ..data_download_tools import DataDownloadTools
+from ..download_data import DownloadData
 
 SLICER_HEART_CT = "Slicer-Heart-CT"
 KCL_HEART_MODEL = "KCL-Heart-Model"
@@ -50,22 +50,22 @@ Examples:
     output_dir = Path(directory)
 
     if args.data_name == SLICER_HEART_CT:
-        data_file = DataDownloadTools.DownloadSlicerHeartCTData(output_dir)
+        data_file = DownloadData.DownloadSlicerHeartCTData(output_dir)
         print(f"Downloaded {SLICER_HEART_CT} to: {data_file}")
         return 0
 
     if args.data_name == KCL_HEART_MODEL:
-        data_dir = DataDownloadTools.DownloadKCLHeartModelData(output_dir)
+        data_dir = DownloadData.DownloadKCLHeartModelData(output_dir)
         print(f"Downloaded {KCL_HEART_MODEL} to: {data_dir}")
         return 0
 
     if args.data_name == CHOP_VALVE4D:
-        data_dir = DataDownloadTools.DownloadCHOPValve4DData(output_dir)
+        data_dir = DownloadData.DownloadCHOPValve4DData(output_dir)
         print(f"Downloaded {CHOP_VALVE4D} to: {data_dir}")
         return 0
 
     if args.data_name == CHEST_CT:
-        data_file = DataDownloadTools.DownloadChestCTData(output_dir)
+        data_file = DownloadData.DownloadChestCTData(output_dir)
         print(f"Downloaded {CHEST_CT} to: {data_file}")
         return 0
 

--- a/src/monai_physio/convert_vtk_to_usd.py
+++ b/src/monai_physio/convert_vtk_to_usd.py
@@ -508,7 +508,7 @@ class ConvertVTKToUSD(MONAIPhysioBase):
         becomes a USD primvar at convert time (``vtk_cell_<output_name>`` or
         ``vtk_point_<output_name>``) and can be selected as the
         ``color_by_array`` for set_colormap or as the target primvar for
-        ``USDTools.apply_colormap_from_primvar``.
+        ``ProcessUSD.apply_colormap_from_primvar``.
 
         Tensor layout (row-major)::
 
@@ -972,7 +972,7 @@ class ConvertVTKToUSD(MONAIPhysioBase):
             vtk_mesh = vtk_mesh.extract_surface(algorithm="dataset_surface")
 
         # Get per-cell label IDs. 'SegmentationLabelIds' is written by
-        # ContourTools.save_combined_surfaces when merging per-label surfaces;
+        # ProcessContours.save_combined_surfaces when merging per-label surfaces;
         # 'boundary_labels' comes from contouring a multi-label labelmap.
         if "SegmentationLabelIds" in vtk_mesh.cell_data:
             label_array = vtk_mesh.cell_data["SegmentationLabelIds"]

--- a/src/monai_physio/download_data.py
+++ b/src/monai_physio/download_data.py
@@ -27,7 +27,7 @@ _DOWNLOAD_TIMEOUT_SECONDS = 60.0
 _logger = logging.getLogger(__name__)
 
 
-class DataDownloadTools:
+class DownloadData:
     """Download and verify optional MONAI Physio example datasets."""
 
     SLICER_HEART_CT_URL = (
@@ -57,13 +57,11 @@ class DataDownloadTools:
         data_dir = Path(dirname)
         data_dir.mkdir(parents=True, exist_ok=True)
 
-        data_file = data_dir / DataDownloadTools.SLICER_HEART_CT_FILENAME
+        data_file = data_dir / DownloadData.SLICER_HEART_CT_FILENAME
         if not (data_file.exists() and data_file.stat().st_size > 0):
-            DataDownloadTools._DownloadFile(
-                DataDownloadTools.SLICER_HEART_CT_URL, data_file
-            )
+            DownloadData._DownloadFile(DownloadData.SLICER_HEART_CT_URL, data_file)
 
-        slice_basename = DataDownloadTools.SLICER_HEART_CT_SLICE_BASENAME
+        slice_basename = DownloadData.SLICER_HEART_CT_SLICE_BASENAME
         if not any(data_dir.glob(f"{slice_basename}_???.mha")):
             # Convert into a temp directory first, then atomically move each
             # finished frame into data_dir, so a failed or interrupted
@@ -78,7 +76,7 @@ class DataDownloadTools:
                     tmp_slice_file.replace(data_dir / tmp_slice_file.name)
             _logger.info(
                 "Converted %s to %s_???.mha frames",
-                DataDownloadTools.SLICER_HEART_CT_FILENAME,
+                DownloadData.SLICER_HEART_CT_FILENAME,
                 slice_basename,
             )
         return data_file
@@ -121,7 +119,7 @@ class DataDownloadTools:
     @staticmethod
     def VerifySlicerHeartCTData(dirname: Union[str, Path]) -> bool:
         """Return True when Slicer-Heart-CT has the expected 4-D CT file."""
-        return (Path(dirname) / DataDownloadTools.SLICER_HEART_CT_FILENAME).is_file()
+        return (Path(dirname) / DownloadData.SLICER_HEART_CT_FILENAME).is_file()
 
     KCL_HEART_MODEL_MESH_COUNT = 20
     KCL_HEART_MODEL_INDIVIDUAL_URL_TEMPLATE = (
@@ -151,27 +149,27 @@ class DataDownloadTools:
         input_meshes_dir = data_dir / "input_meshes"
         input_meshes_dir.mkdir(parents=True, exist_ok=True)
 
-        for index in range(1, DataDownloadTools.KCL_HEART_MODEL_MESH_COUNT + 1):
+        for index in range(1, DownloadData.KCL_HEART_MODEL_MESH_COUNT + 1):
             target_file = input_meshes_dir / f"{index:02d}.vtk"
             if target_file.exists() and target_file.stat().st_size > 0:
                 continue
-            url = DataDownloadTools.KCL_HEART_MODEL_INDIVIDUAL_URL_TEMPLATE.format(
+            url = DownloadData.KCL_HEART_MODEL_INDIVIDUAL_URL_TEMPLATE.format(
                 index=index
             )
-            DataDownloadTools._DownloadAndExtractTarMember(
+            DownloadData._DownloadAndExtractTarMember(
                 url, member_name=f"{index:02d}.vtk", target_file=target_file
             )
             _logger.info(
                 "Downloaded %02d.vtk (%d/%d)",
                 index,
                 index,
-                DataDownloadTools.KCL_HEART_MODEL_MESH_COUNT,
+                DownloadData.KCL_HEART_MODEL_MESH_COUNT,
             )
 
         average_file = data_dir / "average_mesh.vtk"
         if not (average_file.exists() and average_file.stat().st_size > 0):
-            DataDownloadTools._DownloadAndExtractTarMember(
-                DataDownloadTools.KCL_HEART_MODEL_AVERAGE_URL,
+            DownloadData._DownloadAndExtractTarMember(
+                DownloadData.KCL_HEART_MODEL_AVERAGE_URL,
                 member_name="average.vtk",
                 target_file=average_file,
             )
@@ -250,12 +248,12 @@ class DataDownloadTools:
         for (
             subdir_name,
             asset_name,
-        ) in DataDownloadTools.CHOP_VALVE4D_ASSETS.items():
+        ) in DownloadData.CHOP_VALVE4D_ASSETS.items():
             target_dir = data_dir / subdir_name
-            if DataDownloadTools._CHOPValve4DSubdirIsPopulated(target_dir):
+            if DownloadData._CHOPValve4DSubdirIsPopulated(target_dir):
                 continue
-            url = DataDownloadTools.CHOP_VALVE4D_RELEASE_URL + asset_name
-            DataDownloadTools._DownloadAndExtractZip(url, target_dir)
+            url = DownloadData.CHOP_VALVE4D_RELEASE_URL + asset_name
+            DownloadData._DownloadAndExtractZip(url, target_dir)
             _logger.info("Downloaded %s (%s)", subdir_name, asset_name)
         return data_dir
 
@@ -312,11 +310,9 @@ class DataDownloadTools:
         experiments.
         """
         data_dir = Path(dirname)
-        has_ct = DataDownloadTools._CHOPValve4DSubdirIsPopulated(data_dir / "CT")
-        has_alterra = DataDownloadTools._CHOPValve4DSubdirIsPopulated(
-            data_dir / "Alterra"
-        )
-        has_tpv25 = DataDownloadTools._CHOPValve4DSubdirIsPopulated(data_dir / "TPV25")
+        has_ct = DownloadData._CHOPValve4DSubdirIsPopulated(data_dir / "CT")
+        has_alterra = DownloadData._CHOPValve4DSubdirIsPopulated(data_dir / "Alterra")
+        has_tpv25 = DownloadData._CHOPValve4DSubdirIsPopulated(data_dir / "TPV25")
         return has_ct or (has_alterra and has_tpv25)
 
     CHEST_CT_URL = (
@@ -343,15 +339,15 @@ class DataDownloadTools:
         data_dir = Path(dirname)
         data_dir.mkdir(parents=True, exist_ok=True)
 
-        data_file = data_dir / DataDownloadTools.CHEST_CT_FILENAME
+        data_file = data_dir / DownloadData.CHEST_CT_FILENAME
         if not (data_file.exists() and data_file.stat().st_size > 0):
-            DataDownloadTools._DownloadFile(DataDownloadTools.CHEST_CT_URL, data_file)
+            DownloadData._DownloadFile(DownloadData.CHEST_CT_URL, data_file)
         return data_file
 
     @staticmethod
     def VerifyChestCTData(dirname: Union[str, Path]) -> bool:
         """Return True when Chest-CT has its expected CT volume."""
-        return (Path(dirname) / DataDownloadTools.CHEST_CT_FILENAME).is_file()
+        return (Path(dirname) / DownloadData.CHEST_CT_FILENAME).is_file()
 
     @staticmethod
     def _MetaImageHeaderHasBackingData(mhd_file: Path) -> bool:
@@ -387,13 +383,13 @@ class DataDownloadTools:
         has_case_dir_layout = has_case_dir_layout or (
             case1_dir.is_dir()
             and any(
-                DataDownloadTools._MetaImageHeaderHasBackingData(mhd_file)
+                DownloadData._MetaImageHeaderHasBackingData(mhd_file)
                 for mhd_file in case1_dir.glob("*.mhd")
             )
         )
 
         has_pack_layout = any(data_dir.glob("Case1Pack_T*.mha")) or any(
-            DataDownloadTools._MetaImageHeaderHasBackingData(mhd_file)
+            DownloadData._MetaImageHeaderHasBackingData(mhd_file)
             for mhd_file in data_dir.glob("Case1Pack_T*.mhd")
         )
         return has_case_dir_layout or has_pack_layout
@@ -430,13 +426,11 @@ class DataDownloadTools:
 
         output_files = []
         for mhd_file in sorted(Path(dirname).rglob("*.mhd")):
-            if not DataDownloadTools._MetaImageHeaderHasBackingData(mhd_file):
+            if not DownloadData._MetaImageHeaderHasBackingData(mhd_file):
                 continue
             image = itk.imread(str(mhd_file))
-            image_arr = (
-                itk.array_from_image(image) - DataDownloadTools.DIRLAB_4DCT_HU_OFFSET
-            )
-            image_arr = np.clip(image_arr, *DataDownloadTools.DIRLAB_4DCT_HU_CLIP_RANGE)
+            image_arr = itk.array_from_image(image) - DownloadData.DIRLAB_4DCT_HU_OFFSET
+            image_arr = np.clip(image_arr, *DownloadData.DIRLAB_4DCT_HU_CLIP_RANGE)
             fixed_image = itk.image_from_array(image_arr)
             fixed_image.CopyInformation(image)
             target_dir = output_dir if output_dir is not None else mhd_file.parent

--- a/src/monai_physio/infer_physicsnemo_base.py
+++ b/src/monai_physio/infer_physicsnemo_base.py
@@ -48,15 +48,15 @@ class InferPhysicsNeMoBase(MONAIPhysioBase):
             log_level: Logging level. Default: ``logging.INFO``.
         """
         super().__init__(class_name=self.__class__.__name__, log_level=log_level)
-        self._model: "torch.nn.Module"
-        self._device: "torch.device"
+        self._model: torch.nn.Module
+        self._device: torch.device
 
-    def build_model(self, meta: dict) -> "torch.nn.Module":
+    def build_model(self, meta: dict) -> torch.nn.Module:
         """Rebuild the (uncompiled) network from checkpoint metadata."""
         raise NotImplementedError
 
     def load_artifacts(
-        self, model_directory: Path, n_points: int, device: "torch.device"
+        self, model_directory: Path, n_points: int, device: torch.device
     ) -> None:
         """Load any architecture-specific artifacts (MGN graph tensors)."""
         raise NotImplementedError
@@ -65,7 +65,7 @@ class InferPhysicsNeMoBase(MONAIPhysioBase):
         """Run the network over all nodes; return the ``(n, n_target)`` output."""
         raise NotImplementedError
 
-    def set_model(self, model: "torch.nn.Module", device: "torch.device") -> None:
+    def set_model(self, model: torch.nn.Module, device: torch.device) -> None:
         """Attach the loaded model and its device before predicting."""
         self._model = model
         self._device = device

--- a/src/monai_physio/infer_physicsnemo_mgn.py
+++ b/src/monai_physio/infer_physicsnemo_mgn.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 
 from .infer_physicsnemo_base import InferPhysicsNeMoBase
-from .physicsnemo_tools import PhysicsNemoTools
+from .process_physicsnemo import ProcessPhysicsNemo
 
 if TYPE_CHECKING:  # typed for mypy; imported lazily at runtime
     import torch
@@ -24,7 +24,7 @@ class InferPhysicsNeMoMGN(InferPhysicsNeMoBase):
     model_tag = "mgn"
 
     def build_model(self, meta: dict) -> torch.nn.Module:
-        MeshGraphNet = PhysicsNemoTools.import_meshgraphnet()
+        MeshGraphNet = ProcessPhysicsNemo.import_meshgraphnet()
 
         num_layers = int(meta.get("num_layers", 2))
         hidden_dim = int(meta["hidden_dim"])

--- a/src/monai_physio/infer_physicsnemo_mlp.py
+++ b/src/monai_physio/infer_physicsnemo_mlp.py
@@ -19,7 +19,7 @@ class InferPhysicsNeMoMLP(InferPhysicsNeMoBase):
     model_tag = "mlp"
     _INFER_CHUNK = 262144
 
-    def build_model(self, meta: dict) -> "torch.nn.Module":
+    def build_model(self, meta: dict) -> torch.nn.Module:
         try:
             from physicsnemo.models.mlp import FullyConnected
         except ImportError as exc:  # pragma: no cover - broken environment
@@ -40,7 +40,7 @@ class InferPhysicsNeMoMLP(InferPhysicsNeMoBase):
         return cast("torch.nn.Module", model)
 
     def load_artifacts(
-        self, model_directory: Path, n_points: int, device: "torch.device"
+        self, model_directory: Path, n_points: int, device: torch.device
     ) -> None:
         # The MLP has no shared graph artifacts.
         return None

--- a/src/monai_physio/monai_physio_base.py
+++ b/src/monai_physio/monai_physio_base.py
@@ -60,7 +60,7 @@ class ClassNameFilter(logging.Filter):
 
         # Extract class name from the message (format: "ClassName - message")
         if hasattr(record, "class_name"):
-            return cast(str, getattr(record, "class_name")) in self.allowed_classes
+            return cast(str, record.class_name) in self.allowed_classes
 
         return True  # Show messages without class name attribute
 

--- a/src/monai_physio/process_contours.py
+++ b/src/monai_physio/process_contours.py
@@ -15,10 +15,10 @@ import pyacvd
 import pyvista as pv
 import trimesh
 
-from .image_tools import ImageTools
 from .monai_physio_base import MONAIPhysioBase
-from .transform_tools import TransformTools
-from .usd_anatomy_tools import USDAnatomyTools
+from .process_images import ProcessImages
+from .process_transforms import ProcessTransforms
+from .process_usd_anatomy import ProcessUSDAnatomy
 
 # VTK_VOXEL lists its eight corners in (i, j, k) raster order; VTK_HEXAHEDRON
 # wants the bottom quad wound consistently, then the matching top quad.
@@ -44,27 +44,27 @@ _LABEL_SURFACE_PAD = 3
 _CONTOUR_ANISOTROPY_LIMIT = 1.5
 
 
-class ContourTools(MONAIPhysioBase):
+class ProcessContours(MONAIPhysioBase):
     """
     Tools for creating and manipulating contours.
     """
 
     def __init__(self, log_level: int | str = logging.INFO):
-        """Initialize ContourTools.
+        """Initialize ProcessContours.
 
         Args:
             log_level: Logging level (default: logging.INFO)
         """
         super().__init__(class_name=self.__class__.__name__, log_level=log_level)
 
-        # USDAnatomyTools builds its color tables in __init__ without touching
+        # ProcessUSDAnatomy builds its color tables in __init__ without touching
         # the stage, so stage=None is safe for these lookup-only uses.
-        self._anatomy_tools = USDAnatomyTools(stage=None, log_level=log_level)
+        self._anatomy_tools = ProcessUSDAnatomy(stage=None, log_level=log_level)
 
     def apply_anatomy_color(
         self, mesh: pv.DataSet, anatomy_names: Sequence[str]
     ) -> None:
-        """Attach a structure's :class:`USDAnatomyTools` color **in-place**.
+        """Attach a structure's :class:`ProcessUSDAnatomy` color **in-place**.
 
         Sets, as :meth:`WorkflowConvertImageToVTK._annotate` does, so geometry
         from here colors the same way in Paraview, PyVista, and the USD
@@ -76,7 +76,7 @@ class ContourTools(MONAIPhysioBase):
         Args:
             mesh: Surface or volume mesh to annotate.
             anatomy_names: Names tried in order, most specific first, e.g. an
-                organ name followed by its anatomy group.  ``USDAnatomyTools``
+                organ name followed by its anatomy group.  ``ProcessUSDAnatomy``
                 carries overrides for some organs (``myocardium``) but not
                 others (``left_ventricle``), so a group name is the usual
                 second entry.  Falls back to ``'other'`` when none resolves.
@@ -973,7 +973,7 @@ class ContourTools(MONAIPhysioBase):
         Returns:
             pv.PolyData: The transformed contours with deformation magnitude
         """
-        new_contours = TransformTools().transform_pvcontour(
+        new_contours = ProcessTransforms().transform_pvcontour(
             contours, tfm, with_deformation_magnitude=with_deformation_magnitude
         )
 
@@ -1426,7 +1426,7 @@ class ContourTools(MONAIPhysioBase):
             [deformation_field_x, deformation_field_y, deformation_field_z], axis=-1
         )
 
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
         deformation_field_img = image_tools.convert_array_to_image_of_vectors(
             deformation_field, reference_image, ptype=ptype
         )

--- a/src/monai_physio/process_images.py
+++ b/src/monai_physio/process_images.py
@@ -16,7 +16,7 @@ from numpy.typing import NDArray
 from .monai_physio_base import MONAIPhysioBase
 
 
-class ImageTools(MONAIPhysioBase):
+class ProcessImages(MONAIPhysioBase):
     """
     Utilities for medical image format conversions and processing.
 
@@ -25,7 +25,7 @@ class ImageTools(MONAIPhysioBase):
     pixel type). Supports both scalar and vector (multi-component) images.
 
     Example:
-        >>> tools = ImageTools()
+        >>> tools = ProcessImages()
         >>> # Convert ITK to SimpleITK
         >>> sitk_image = tools.convert_itk_image_to_sitk(itk_image)
         >>> # Convert back to ITK
@@ -33,7 +33,7 @@ class ImageTools(MONAIPhysioBase):
     """
 
     def __init__(self, log_level: int | str = logging.INFO) -> None:
-        """Initialize ImageTools.
+        """Initialize ProcessImages.
 
         Args:
             log_level: Logging level (default: logging.INFO)
@@ -50,7 +50,7 @@ class ImageTools(MONAIPhysioBase):
     ) -> itk.image:
         """Transform an ITK image using a specified transform and interpolation.
 
-        Delegates to :meth:`TransformTools.transform_image`; imported
+        Delegates to :meth:`ProcessTransforms.transform_image`; imported
         locally since ``transform_tools`` imports this module.
 
         Args:
@@ -74,9 +74,9 @@ class ImageTools(MONAIPhysioBase):
         Raises:
             ValueError: If interpolation_method is not one of the supported options
         """
-        from .transform_tools import TransformTools
+        from .process_transforms import ProcessTransforms
 
-        return TransformTools(log_level=self.log_level).transform_image(
+        return ProcessTransforms(log_level=self.log_level).transform_image(
             image,
             transform,
             reference_image,
@@ -98,7 +98,7 @@ class ImageTools(MONAIPhysioBase):
             itk.Image[itk.Vector[itk.D,3],3]: Vector image with double precision
 
         Example:
-            >>> displacement_field = ImageTools().imreadVD3('deformation.mha')
+            >>> displacement_field = ProcessImages().imreadVD3('deformation.mha')
         """
         # Read as float precision vector image
         image = itk.imread(filename)
@@ -122,7 +122,7 @@ class ImageTools(MONAIPhysioBase):
             compression (bool): Whether to use compression (default: True)
 
         Example:
-            >>> ImageTools().imwriteVD3(displacement_field, 'deformation.mha')
+            >>> ProcessImages().imwriteVD3(displacement_field, 'deformation.mha')
         """
         # Convert to float precision for writing
         if "VD" not in str(type(image)):
@@ -149,7 +149,7 @@ class ImageTools(MONAIPhysioBase):
             SimpleITK image with identical data and metadata
 
         Example:
-            >>> tools = ImageTools()
+            >>> tools = ProcessImages()
             >>> itk_image = itk.imread('image.nii.gz')
             >>> sitk_image = tools.convert_itk_image_to_sitk(itk_image)
         """
@@ -198,7 +198,7 @@ class ImageTools(MONAIPhysioBase):
             ITK image with identical data and metadata
 
         Example:
-            >>> tools = ImageTools()
+            >>> tools = ProcessImages()
             >>> sitk_image = sitk.ReadImage('image.nii.gz')
             >>> itk_image = tools.convert_sitk_image_to_itk(sitk_image)
         """
@@ -375,7 +375,7 @@ class ImageTools(MONAIPhysioBase):
 
     @staticmethod
     def _per_axis_values(
-        value: Union[float, int, list, tuple, NDArray[Any]],
+        value: Union[float, list, tuple, NDArray[Any]],
         dimension: int,
         name: str,
     ) -> list[float]:

--- a/src/monai_physio/process_labelmaps.py
+++ b/src/monai_physio/process_labelmaps.py
@@ -1,7 +1,7 @@
 """
 Labelmap Tools for MONAI Physio
 
-This module provides the :class:`LabelmapTools` class with the definitive
+This module provides the :class:`ProcessLabelmaps` class with the definitive
 utility for turning a multi-label (or binary) segmentation labelmap into a
 binary registration mask, optionally excluding specific labels and dilating
 the result by a physical radius in millimeters.
@@ -16,7 +16,7 @@ import numpy as np
 from .monai_physio_base import MONAIPhysioBase
 
 
-class LabelmapTools(MONAIPhysioBase):
+class ProcessLabelmaps(MONAIPhysioBase):
     """
     Utilities for converting segmentation labelmaps into registration masks.
 
@@ -28,7 +28,7 @@ class LabelmapTools(MONAIPhysioBase):
     identically everywhere in the platform.
 
     Example:
-        >>> tools = LabelmapTools()
+        >>> tools = ProcessLabelmaps()
         >>> # Binary mask of every labeled voxel, dilated 5 mm
         >>> mask = tools.convert_labelmap_to_mask(labelmap, dilation_in_mm=5.0)
         >>> # Exclude the table/background labels 8 and 9 before masking
@@ -38,7 +38,7 @@ class LabelmapTools(MONAIPhysioBase):
     """
 
     def __init__(self, log_level: int | str = logging.INFO) -> None:
-        """Initialize LabelmapTools.
+        """Initialize ProcessLabelmaps.
 
         Args:
             log_level: Logging level (default: logging.INFO)

--- a/src/monai_physio/process_landmarks.py
+++ b/src/monai_physio/process_landmarks.py
@@ -1,7 +1,7 @@
 """
 Tools for reading and writing anatomical landmarks.
 
-This module provides the :class:`LandmarkTools` class with utilities for
+This module provides the :class:`ProcessLandmarks` class with utilities for
 reading and writing point landmarks in 3D Slicer's Markups JSON
 (``.mrk.json``) format and in a simple CSV format. Landmarks are kept in
 memory in LPS world coordinates (ITK's native frame, matching the rest of
@@ -25,7 +25,7 @@ _MRK_JSON_SCHEMA = (
 )
 
 
-class LandmarkTools(MONAIPhysioBase):
+class ProcessLandmarks(MONAIPhysioBase):
     """
     Read and write anatomical landmarks in LPS world coordinates.
 
@@ -43,13 +43,13 @@ class LandmarkTools(MONAIPhysioBase):
     outputs are always written in LPS.
 
     Example:
-        >>> tools = LandmarkTools()
+        >>> tools = ProcessLandmarks()
         >>> landmarks = tools.read_landmarks_3dslicer('points.mrk.json')
         >>> tools.write_landmarks_csv(landmarks, 'points.csv')
     """
 
     def __init__(self, log_level: int | str = logging.INFO):
-        """Initialize the LandmarkTools class.
+        """Initialize the ProcessLandmarks class.
 
         Args:
             log_level: Logging level (default: logging.INFO)

--- a/src/monai_physio/process_physicsnemo.py
+++ b/src/monai_physio/process_physicsnemo.py
@@ -2,26 +2,26 @@
 
 This module holds the pieces common to the MeshGraphNet (MGN) and fully
 connected (MLP) PhysicsNeMo workflows so the workflow classes stay focused on
-orchestration. :class:`PhysicsNemoTools` provides:
+orchestration. :class:`ProcessPhysicsNemo` provides:
 
-- :meth:`PhysicsNemoTools.import_meshgraphnet` - import PhysicsNeMo's
+- :meth:`ProcessPhysicsNemo.import_meshgraphnet` - import PhysicsNeMo's
   ``MeshGraphNet``, reporting install faults clearly.
-- :class:`SubjectManifest` / :meth:`PhysicsNemoTools.parse_manifest` - the
+- :class:`SubjectManifest` / :meth:`ProcessPhysicsNemo.parse_manifest` - the
   per-subject JSON manifest that lists a fitted reference mesh, a PCA
   shape-parameter file, the name of the point-data array holding the training
   targets, and the phase meshes that carry that array with their stages.
-- :meth:`PhysicsNemoTools.load_target_array` - read one phase's
+- :meth:`ProcessPhysicsNemo.load_target_array` - read one phase's
   ``(n_points, n_target)`` target values out of a mesh's point data.
-- :meth:`PhysicsNemoTools.build_node_features` - the shared per-vertex
+- :meth:`ProcessPhysicsNemo.build_node_features` - the shared per-vertex
   feature layout ``[mean_coords_norm, pca_norm (tiled), stage]`` used by both
   networks.
-- :meth:`PhysicsNemoTools.mesh_to_edge_index` /
-  :meth:`PhysicsNemoTools.compute_edge_features` - MGN mesh-graph
+- :meth:`ProcessPhysicsNemo.mesh_to_edge_index` /
+  :meth:`ProcessPhysicsNemo.compute_edge_features` - MGN mesh-graph
   construction from the shared template mesh (surface or volumetric).
-- :meth:`PhysicsNemoTools.uncompiled_state_dict` /
-  :meth:`PhysicsNemoTools.strip_compile_prefix` - checkpoint I/O that is
+- :meth:`ProcessPhysicsNemo.uncompiled_state_dict` /
+  :meth:`ProcessPhysicsNemo.strip_compile_prefix` - checkpoint I/O that is
   robust to ``torch.compile`` and ``DistributedDataParallel`` wrapping.
-- :class:`DistributedContext` / :meth:`PhysicsNemoTools.distributed_context`
+- :class:`DistributedContext` / :meth:`ProcessPhysicsNemo.distributed_context`
   - the rank, device and world size of the current process, from PhysicsNeMo's
   ``DistributedManager``.  A run started without a launcher gets world size 1,
   so single-process callers need no distributed-specific code.
@@ -145,7 +145,7 @@ def _launched_world_size() -> int:
     return max(sizes, default=1)
 
 
-class PhysicsNemoTools:
+class ProcessPhysicsNemo:
     """Namespace of stateless helpers shared by the PhysicsNeMo workflows.
 
     Every member is a ``@staticmethod``: there is no instance state, so this
@@ -439,7 +439,7 @@ class PhysicsNemoTools:
     @staticmethod
     def uncompiled_state_dict(model: Any) -> dict[str, Any]:
         """Return a model's state dict, unwrapping ``torch.compile`` and DDP."""
-        return cast(dict[str, Any], PhysicsNemoTools.unwrap_model(model).state_dict())
+        return cast(dict[str, Any], ProcessPhysicsNemo.unwrap_model(model).state_dict())
 
     @staticmethod
     def strip_compile_prefix(state: dict) -> dict:
@@ -451,8 +451,8 @@ class PhysicsNemoTools:
 
 
 def distributed_context() -> DistributedContext:
-    """Free-function alias for :meth:`PhysicsNemoTools.distributed_context`."""
-    return PhysicsNemoTools.distributed_context()
+    """Free-function alias for :meth:`ProcessPhysicsNemo.distributed_context`."""
+    return ProcessPhysicsNemo.distributed_context()
 
 
 # --------------------------------------------------------------------------- #
@@ -544,7 +544,7 @@ class PhaseSampleDataset:
             self._cache.move_to_end(path)
             return cached
 
-        values = PhysicsNemoTools.load_target_array(path, self._target_array)
+        values = ProcessPhysicsNemo.load_target_array(path, self._target_array)
         if values.shape[0] != self._n_points:
             raise ValueError(
                 f"{path} has {values.shape[0]} points, expected {self._n_points}."
@@ -559,7 +559,7 @@ class PhaseSampleDataset:
     def __getitem__(self, index: int) -> tuple[np.ndarray, np.ndarray]:
         """Return ``(node_features, normalized_target)`` for one sample."""
         sample = self._samples[index]
-        node_feats = PhysicsNemoTools.build_node_features(
+        node_feats = ProcessPhysicsNemo.build_node_features(
             self._mean_coords_norm, sample.pca_norm, sample.stage
         )
         target = self._target_values(sample.target_mesh) / self._target_scale

--- a/src/monai_physio/process_tests.py
+++ b/src/monai_physio/process_tests.py
@@ -1,7 +1,7 @@
 """
 Test utilities for comparing images in pytest.
 
-Provides TestTools for baseline vs results comparison with configurable
+Provides ProcessTests for baseline vs results comparison with configurable
 tolerances. All image I/O uses ITK with .mha (compressed); 3D images are
 passed as itk.Image at the API level.
 """
@@ -21,7 +21,7 @@ import numpy as np
 
 from .monai_physio_base import MONAIPhysioBase
 
-# Repo root: src/monai_physio/test_tools.py -> parent.parent.parent
+# Repo root: src/monai_physio/process_tests.py -> parent.parent.parent
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # Set by tests/conftest.py from pytest --create-baselines; applies to entire run
@@ -97,7 +97,7 @@ def _read_metrics(path: Path) -> dict[str, Any]:
     raise ValueError(f"Unsupported metrics format (expected .json or .csv): {path}")
 
 
-class TestTools(MONAIPhysioBase):
+class ProcessTests(MONAIPhysioBase):
     """
     Utilities for pytest image comparison: baseline directory, result directory,
     and comparison with configurable tolerances. Inherits from MONAIPhysioBase
@@ -623,7 +623,7 @@ class TestTools(MONAIPhysioBase):
     ) -> Path:
         """Render USD mesh geometry off-screen and save a PNG.
 
-        The scene is loaded through :meth:`USDTools.load_usd_as_vtk` into a
+        The scene is loaded through :meth:`ProcessUSD.load_usd_as_vtk` into a
         PyVista mesh, rendered with a fixed isometric camera and fixed
         ``800 x 600`` window, and centered automatically by PyVista.
 
@@ -642,7 +642,7 @@ class TestTools(MONAIPhysioBase):
 
         import pyvista as pv
 
-        from .usd_tools import USDTools
+        from .process_usd import ProcessUSD
 
         # On headless Linux runners VTK needs an X server or off-screen GL
         # context. If DISPLAY is already provided (e.g. xvfb-run wrapping
@@ -656,7 +656,7 @@ class TestTools(MONAIPhysioBase):
 
         try:
             output_path = self._results_dir / filename
-            mesh = USDTools().load_usd_as_vtk(
+            mesh = ProcessUSD().load_usd_as_vtk(
                 usd_file, prim_path=prim_path, time_code=time_code
             )
             plotter = pv.Plotter(off_screen=True, window_size=[800, 600])

--- a/src/monai_physio/process_transforms.py
+++ b/src/monai_physio/process_transforms.py
@@ -1,7 +1,7 @@
 """
 Tools for transforming and manipulating ITK transforms.
 
-This module provides the TransformTools class with utilities for working with
+This module provides the ProcessTransforms class with utilities for working with
 ITK transforms, including transforming images and contours, generating
 deformation fields, interpolating between transforms, and correcting spatial
 folding artifacts.
@@ -20,11 +20,11 @@ import pyvista as pv
 import SimpleITK as sitk
 import vtk
 
-from .image_tools import ImageTools
 from .monai_physio_base import MONAIPhysioBase
+from .process_images import ProcessImages
 
 
-class TransformTools(MONAIPhysioBase):
+class ProcessTransforms(MONAIPhysioBase):
     """
     Utilities for transforming and manipulating ITK transforms.
 
@@ -48,7 +48,7 @@ class TransformTools(MONAIPhysioBase):
     - Generate visualization grids
 
     Example:
-        >>> transform_tools = TransformTools()
+        >>> transform_tools = ProcessTransforms()
         >>> # Transform a contour mesh
         >>> transformed_contour = transform_tools.transform_pvcontour(
         ...     contour, transform, with_deformation_magnitude=True
@@ -58,7 +58,7 @@ class TransformTools(MONAIPhysioBase):
     """
 
     def __init__(self, log_level: int | str = logging.INFO):
-        """Initialize the TransformTools class.
+        """Initialize the ProcessTransforms class.
 
         Args:
             log_level: Logging level (default: logging.INFO)
@@ -154,7 +154,7 @@ class TransformTools(MONAIPhysioBase):
                 dfield2_arr[:, :, :, dim] = tmp_field
         if mode == "add":
             dfield_composed_arr = tfm1_weight * dfield1_arr + tfm2_weight * dfield2_arr
-            image_tools = ImageTools()
+            image_tools = ProcessImages()
             dfield_composed = image_tools.convert_array_to_image_of_vectors(
                 dfield_composed_arr,
                 ptype=itk.D,
@@ -164,7 +164,7 @@ class TransformTools(MONAIPhysioBase):
             new_tfm.SetDisplacementField(dfield_composed)
             return new_tfm
         # compose
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
 
         dfield1_arr = tfm1_weight * dfield1_arr
         dfield2_arr = tfm2_weight * dfield2_arr
@@ -262,7 +262,7 @@ class TransformTools(MONAIPhysioBase):
         field_arr = itk.array_from_image(field)
         field_arr = field_arr.astype(np_component_type)
 
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
         field = image_tools.convert_array_to_image_of_vectors(
             field_arr,
             ptype=np_component_type,
@@ -320,7 +320,7 @@ class TransformTools(MONAIPhysioBase):
         assert "DisplacementFieldTransform" in str(type(tfm)), (
             "Input transform must be a displacement field transform"
         )
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
 
         field_itk = tfm.GetDisplacementField()
 
@@ -659,7 +659,7 @@ class TransformTools(MONAIPhysioBase):
             )
             tmp_field_arr = itk.array_from_image(tmp_image)
             field_arr[:, :, :, dim] = tmp_field_arr
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
         field = image_tools.convert_array_to_image_of_vectors(
             field_arr,
             ptype=itk.D,
@@ -810,7 +810,7 @@ class TransformTools(MONAIPhysioBase):
             inside = np.clip(mask, 0.0, 1.0)[..., None]
             smoothed = inside * smoothed_sets[0] + (1.0 - inside) * smoothed_sets[1]
 
-        smoothed_field = ImageTools().convert_array_to_image_of_vectors(
+        smoothed_field = ProcessImages().convert_array_to_image_of_vectors(
             smoothed, reference_image=field, ptype=itk.D
         )
         field_transform = itk.DisplacementFieldTransform[itk.D, 3].New()
@@ -904,7 +904,7 @@ class TransformTools(MONAIPhysioBase):
         combined_field_arr = sum_fields_arr / denom
 
         # Copy array data to ITK image
-        combined_field = ImageTools().convert_array_to_image_of_vectors(
+        combined_field = ProcessImages().convert_array_to_image_of_vectors(
             combined_field_arr, field1, itk.F
         )
 
@@ -945,7 +945,7 @@ class TransformTools(MONAIPhysioBase):
         """
         if "VF" not in str(type(field)):
             field_arr = itk.array_from_image(field)
-            field = ImageTools().convert_array_to_image_of_vectors(
+            field = ProcessImages().convert_array_to_image_of_vectors(
                 field_arr, field, itk.F
             )
         jac_filter = itk.DisplacementFieldJacobianDeterminantFilter.New(field)
@@ -1018,7 +1018,7 @@ class TransformTools(MONAIPhysioBase):
         field_arr = itk.array_from_image(field)
         for i in range(field_arr.shape[3]):
             field_arr[:, :, :, i] *= thresh_arr
-        corrected_field = ImageTools().convert_array_to_image_of_vectors(
+        corrected_field = ProcessImages().convert_array_to_image_of_vectors(
             field_arr, field, itk.F
         )
         return corrected_field

--- a/src/monai_physio/process_usd.py
+++ b/src/monai_physio/process_usd.py
@@ -1,5 +1,5 @@
 """
-This module contains the USDTools class for manipulating USD objects and files.
+This module contains the ProcessUSD class for manipulating USD objects and files.
 
 This module provides utilities for working with Universal Scene Description (USD)
 files in the context of medical visualization. It includes functions for merging
@@ -25,7 +25,7 @@ from .convert_vtk_to_usd import add_framing_camera
 from .monai_physio_base import MONAIPhysioBase
 
 
-class USDTools(MONAIPhysioBase):
+class ProcessUSD(MONAIPhysioBase):
     """
     Utilities for manipulating Universal Scene Description (USD) files.
 
@@ -50,7 +50,7 @@ class USDTools(MONAIPhysioBase):
     and MR images.
 
     Example:
-        >>> usd_tools = USDTools()
+        >>> usd_tools = ProcessUSD()
         >>> # Merge multiple anatomical USD files
         >>> usd_tools.merge_usd_files(
         ...     'combined_anatomy.usd', ['heart.usd', 'lungs.usd', 'bones.usd']
@@ -62,7 +62,7 @@ class USDTools(MONAIPhysioBase):
     """
 
     def __init__(self, log_level: int | str = logging.INFO) -> None:
-        """Initialize the USDTools class.
+        """Initialize the ProcessUSD class.
 
         Args:
             log_level: Logging level (default: logging.INFO)
@@ -635,7 +635,7 @@ class USDTools(MONAIPhysioBase):
         method unless you need fine-grained control over what gets copied.
 
         Example:
-            >>> usd_tools = USDTools()
+            >>> usd_tools = ProcessUSD()
             >>> usd_tools.merge_usd_files_flattened(
             ...     'complete_anatomy.usd', ['heart_dynamic.usd', 'lungs_static.usd']
             ... )
@@ -761,7 +761,7 @@ class USDTools(MONAIPhysioBase):
                 - range: Tuple (min, max) for numeric arrays, None otherwise
 
         Example:
-            >>> usd_tools = USDTools()
+            >>> usd_tools = ProcessUSD()
             >>> primvars = usd_tools.list_mesh_primvars("valve.usd", "/World/Meshes/Valve")
             >>> for pv in primvars:
             ...     print(f"{pv['name']}: {pv['interpolation']}, {pv['elements']} elements")
@@ -930,7 +930,7 @@ class USDTools(MONAIPhysioBase):
             ImportError: If matplotlib is not available
 
         Example:
-            >>> usd_tools = USDTools()
+            >>> usd_tools = ProcessUSD()
             >>> usd_tools.apply_colormap_from_primvar(
             ...     "valve.usd",
             ...     "/World/Meshes/Valve",

--- a/src/monai_physio/process_usd_anatomy.py
+++ b/src/monai_physio/process_usd_anatomy.py
@@ -1,5 +1,5 @@
 """
-This module contains the USDAnatomyTools class, which is used to enhance
+This module contains the ProcessUSDAnatomy class, which is used to enhance
 the anatomy meshes in a USD file.
 
 Extensibility
@@ -9,16 +9,16 @@ module-level :data:`DEFAULT_RENDER_PARAMS` dict. A new segmenter that
 introduces a new group (e.g. ``"brain"``, ``"tumor"``) can register a
 matching look in one of three ways:
 
-1. **Globally**, before instantiating any ``USDAnatomyTools``::
+1. **Globally**, before instantiating any ``ProcessUSDAnatomy``::
 
-       from monai_physio.usd_anatomy_tools import DEFAULT_RENDER_PARAMS
+       from monai_physio.process_usd_anatomy import DEFAULT_RENDER_PARAMS
        DEFAULT_RENDER_PARAMS["brain"] = {"name": "Brain", ...}
 
-   Every subsequent ``USDAnatomyTools`` instance picks up the new entry.
+   Every subsequent ``ProcessUSDAnatomy`` instance picks up the new entry.
 
 2. **Per-instance**, after construction::
 
-       tools = USDAnatomyTools(stage)
+       tools = ProcessUSDAnatomy(stage)
        tools.render_params["brain"] = {"name": "Brain", ...}
 
 3. **By subclassing**, overriding ``__init__`` to populate
@@ -770,7 +770,7 @@ DEFAULT_RENDER_PARAMS: dict[str, dict[str, Any]] = {
 
 # Canonical AnatomyTaxonomy group names that carry a group-level entry in
 # DEFAULT_RENDER_PARAMS. Every other key is an organ-level override. Used by
-# :meth:`USDAnatomyTools._resolve_render_params` to mirror ``enhance_meshes``,
+# :meth:`ProcessUSDAnatomy._resolve_render_params` to mirror ``enhance_meshes``,
 # where an organ override always beats the containing group on a substring
 # match (e.g. "lung_veins" -> the "vein" override, not the "lung" group).
 GROUP_RENDER_KEYS: frozenset[str] = frozenset(
@@ -787,7 +787,7 @@ GROUP_RENDER_KEYS: frozenset[str] = frozenset(
 )
 
 
-class USDAnatomyTools(MONAIPhysioBase):
+class ProcessUSDAnatomy(MONAIPhysioBase):
     """Apply OmniSurface materials to anatomy mesh prims in a USD stage.
 
     The instance attribute :attr:`render_params` is initialized from the
@@ -797,7 +797,7 @@ class USDAnatomyTools(MONAIPhysioBase):
     """
 
     def __init__(self, stage: Any, log_level: int | str = logging.INFO) -> None:
-        """Initialize USDAnatomyTools.
+        """Initialize ProcessUSDAnatomy.
 
         Args:
             stage: USD stage to work with. May be ``None`` when the instance
@@ -808,7 +808,7 @@ class USDAnatomyTools(MONAIPhysioBase):
         super().__init__(class_name=self.__class__.__name__, log_level=log_level)
         self.stage = stage
         # Per-instance copy so per-instance mutations don't leak into other
-        # USDAnatomyTools instances.
+        # ProcessUSDAnatomy instances.
         self.render_params: dict[str, dict[str, Any]] = {
             key: dict(params) for key, params in DEFAULT_RENDER_PARAMS.items()
         }

--- a/src/monai_physio/register_images_ants.py
+++ b/src/monai_physio/register_images_ants.py
@@ -20,8 +20,8 @@ import itk
 import numpy as np
 from numpy.typing import NDArray
 
+from .process_transforms import ProcessTransforms
 from .register_images_base import RegisterImagesBase
-from .transform_tools import TransformTools
 
 if TYPE_CHECKING:  # typed for mypy; never imported at runtime
     # antspyx re-exports these at the top level in some releases and not in
@@ -305,10 +305,10 @@ class RegisterImagesANTS(RegisterImagesBase):
         disp_field_itk_raw = self._ants_to_itk_image(disp_field_ANTS)
 
         # Convert to the correct Image[Vector[D, 3], 3] type for DisplacementFieldTransform
-        # Use ImageTools helper to convert array to vector image with correct type
-        from .image_tools import ImageTools
+        # Use ProcessImages helper to convert array to vector image with correct type
+        from .process_images import ProcessImages
 
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
 
         disp_array = itk.array_from_image(disp_field_itk_raw)
         disp_field_itk = image_tools.convert_array_to_image_of_vectors(
@@ -427,7 +427,7 @@ class RegisterImagesANTS(RegisterImagesBase):
         ants.registration() or ants.label_image_registration().
 
         The conversion process:
-        1. Uses TransformTools to convert the ITK transform to a displacement field
+        1. Uses ProcessTransforms to convert the ITK transform to a displacement field
         2. Converts the displacement field image from ITK to ANTs format
         3. Creates an ANTsPy transform object from the displacement field
         4. Writes the ANTs transform to a file
@@ -460,7 +460,7 @@ class RegisterImagesANTS(RegisterImagesBase):
         if isinstance(itk_tfm, itk.DisplacementFieldTransform) or isinstance(
             itk_tfm, itk.CompositeTransform
         ):
-            transform_tools = TransformTools()
+            transform_tools = ProcessTransforms()
             disp_field_itk = transform_tools.convert_transform_to_displacement_field(
                 tfm=itk_tfm,
                 reference_image=reference_image,

--- a/src/monai_physio/register_images_base.py
+++ b/src/monai_physio/register_images_base.py
@@ -21,9 +21,9 @@ from typing import Any, Optional, Union, cast
 import itk
 import numpy as np
 
-from .labelmap_tools import LabelmapTools
 from .monai_physio_base import MONAIPhysioBase
-from .transform_tools import TransformTools
+from .process_labelmaps import ProcessLabelmaps
+from .process_transforms import ProcessTransforms
 
 
 class RegisterImagesBase(MONAIPhysioBase):
@@ -92,7 +92,7 @@ class RegisterImagesBase(MONAIPhysioBase):
         """
         super().__init__(class_name=self.__class__.__name__, log_level=log_level)
 
-        self.labelmap_tools = LabelmapTools(log_level=log_level)
+        self.labelmap_tools = ProcessLabelmaps(log_level=log_level)
 
         self.net: Any = None
 
@@ -487,7 +487,7 @@ class RegisterImagesBase(MONAIPhysioBase):
         if self.fixed_image is None:
             raise ValueError("Fixed image must be set before registration.")
 
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
         background_value = self._prewarp_background_value(moving_image)
         self.log_info(
             "Pre-warping moving data with the initial transform (background %.1f)...",
@@ -533,7 +533,7 @@ class RegisterImagesBase(MONAIPhysioBase):
             already pre-warped data -- not a loss for the composed transform,
             and not comparable to the loss of a stage that started from scratch.
         """
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
 
         # The registration measured the residual from the pre-warped position,
         # so the total is the initial transform followed by that residual. An
@@ -689,7 +689,7 @@ class RegisterImagesBase(MONAIPhysioBase):
             itk.Image: The registered image
         """
         if self.moving_image_registered is None:
-            TfmTools = TransformTools()
+            TfmTools = ProcessTransforms()
             self.moving_image_registered = TfmTools.transform_image(
                 self.moving_image,
                 self.fixed_to_moving_transform,

--- a/src/monai_physio/register_images_greedy.py
+++ b/src/monai_physio/register_images_greedy.py
@@ -20,9 +20,9 @@ import itk
 import numpy as np
 from numpy.typing import NDArray
 
-from .image_tools import ImageTools
+from .process_images import ProcessImages
+from .process_transforms import ProcessTransforms
 from .register_images_base import RegisterImagesBase
-from .transform_tools import TransformTools
 
 
 def _try_import_greedy() -> Any:
@@ -51,7 +51,7 @@ class RegisterImagesGreedy(RegisterImagesBase):
     - Deformable registration with multi-resolution (-n, -s)
     - Metrics: NMI, NCC, SSD (mapped from CC, Mattes, MeanSquares)
     - Optional mask support (-gm fixed, -mm moving when both provided)
-    - SimpleITK in-memory interface via ImageTools
+    - SimpleITK in-memory interface via ProcessImages
 
     Inherits from RegisterImagesBase:
     - Fixed and moving image management
@@ -123,12 +123,12 @@ class RegisterImagesGreedy(RegisterImagesBase):
 
     def _itk_to_sitk(self, itk_image: itk.Image) -> Any:
         """Convert ITK image to SimpleITK (for Greedy)."""
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
         return image_tools.convert_itk_image_to_sitk(itk_image)
 
     def _sitk_to_itk(self, sitk_image: Any) -> itk.Image:
         """Convert SimpleITK image to ITK."""
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
         return image_tools.convert_sitk_image_to_itk(sitk_image)
 
     def _greedy_metric(self) -> str:
@@ -286,9 +286,9 @@ class RegisterImagesGreedy(RegisterImagesBase):
     ) -> itk.Transform:
         """Convert SimpleITK displacement field to ITK DisplacementFieldTransform."""
         field_itk = self._sitk_to_itk(warp_sitk)
-        from .image_tools import ImageTools
+        from .process_images import ProcessImages
 
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
         arr = itk.array_from_image(field_itk)
         disp_itk = image_tools.convert_array_to_image_of_vectors(
             arr, reference_image, itk.D
@@ -459,9 +459,9 @@ class RegisterImagesGreedy(RegisterImagesBase):
         # integer labelmap is piecewise-constant, so NCC sees zero local
         # variance and emits NaN gradients (a native crash). Encode each
         # labelmap as a continuous label-plus-boundary-distance field instead.
-        from .labelmap_tools import LabelmapTools
+        from .process_labelmaps import ProcessLabelmaps
 
-        labelmap_tools = LabelmapTools()
+        labelmap_tools = ProcessLabelmaps()
         fixed_labelmap_sitk = None
         moving_labelmap_sitk = None
         if self.fixed_labelmap is not None:
@@ -555,9 +555,9 @@ class RegisterImagesGreedy(RegisterImagesBase):
                 )
             else:
                 # Assume numpy displacement field (z,y,x,3)
-                from .image_tools import ImageTools
+                from .process_images import ProcessImages
 
-                image_tools = ImageTools()
+                image_tools = ProcessImages()
                 warp_arr = np.asarray(warp_sitk, dtype=np.float64)
                 ref = displacement_reference
                 disp_itk = image_tools.convert_array_to_image_of_vectors(
@@ -576,7 +576,7 @@ class RegisterImagesGreedy(RegisterImagesBase):
                 forward_composite.AddTransform(aff_tfm)
             forward_composite.AddTransform(disp_tfm)
             fixed_to_moving_transform = forward_composite
-            inv_disp = TransformTools().invert_displacement_field_transform(disp_tfm)
+            inv_disp = ProcessTransforms().invert_displacement_field_transform(disp_tfm)
             inv_aff = itk.AffineTransform[itk.D, 3].New()
             if aff_tfm is not None:
                 aff_tfm.GetInverse(inv_aff)

--- a/src/monai_physio/register_models_distance_maps.py
+++ b/src/monai_physio/register_models_distance_maps.py
@@ -48,12 +48,12 @@ from typing import Optional
 import itk
 import pyvista as pv
 
-from .contour_tools import ContourTools
-from .labelmap_tools import LabelmapTools
 from .monai_physio_base import MONAIPhysioBase
+from .process_contours import ProcessContours
+from .process_labelmaps import ProcessLabelmaps
+from .process_transforms import ProcessTransforms
 from .register_images_greedy import RegisterImagesGreedy
 from .register_images_icon import RegisterImagesICON
-from .transform_tools import TransformTools
 
 
 class RegisterModelsDistanceMaps(MONAIPhysioBase):
@@ -87,8 +87,8 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         reference_image (itk.Image): Reference image for coordinate frame
         mask_dilation_mm (float): Dilation amount in mm for binary registration masks
         distance_squared_max (float): Maximum squared distance for distance map normalization
-        transform_tools (TransformTools): Transform utility instance
-        contour_tools (ContourTools): Model utility instance
+        transform_tools (ProcessTransforms): Transform utility instance
+        contour_tools (ProcessContours): Model utility instance
         registrar_Greedy (RegisterImagesGreedy): Greedy registration instance
         registrar_ICON (RegisterImagesICON): ICON registration instance
         fixed_to_moving_transform (itk.CompositeTransform): Optimized fixed-to-moving transform
@@ -155,9 +155,9 @@ class RegisterModelsDistanceMaps(MONAIPhysioBase):
         self.mask_dilation_mm = mask_dilation_mm
 
         # Utilities
-        self.transform_tools = TransformTools()
-        self.contour_tools = ContourTools()
-        self.labelmap_tools = LabelmapTools(log_level=log_level)
+        self.transform_tools = ProcessTransforms()
+        self.contour_tools = ProcessContours()
+        self.labelmap_tools = ProcessLabelmaps(log_level=log_level)
 
         # Registration instances
         self.registrar_Greedy = RegisterImagesGreedy(log_level=log_level)

--- a/src/monai_physio/register_models_icp.py
+++ b/src/monai_physio/register_models_icp.py
@@ -48,7 +48,7 @@ import pyvista as pv
 import vtk
 
 from .monai_physio_base import MONAIPhysioBase
-from .transform_tools import TransformTools
+from .process_transforms import ProcessTransforms
 
 
 class RegisterModelsICP(MONAIPhysioBase):
@@ -71,7 +71,7 @@ class RegisterModelsICP(MONAIPhysioBase):
 
     **Transform Convention:**
         These are POINT transforms, applied with TransformPoint (e.g. via
-        TransformTools.transform_pvcontour); see
+        ProcessTransforms.transform_pvcontour); see
         docs/developer/transform_conventions:
 
         - moving_to_fixed_transform: maps moving points -> fixed points; use it to
@@ -81,7 +81,7 @@ class RegisterModelsICP(MONAIPhysioBase):
     Attributes:
         moving_model (pv.PolyData): Surface model to be aligned
         fixed_model (pv.PolyData): Target surface model
-        transform_tools (TransformTools): Transform utility instance
+        transform_tools (ProcessTransforms): Transform utility instance
         moving_to_fixed_transform (itk.AffineTransform): Optimized moving-to-fixed transform
         fixed_to_moving_transform (itk.AffineTransform): Optimized fixed-to-moving transform
         registered_model (pv.PolyData): Aligned moving model
@@ -132,7 +132,7 @@ class RegisterModelsICP(MONAIPhysioBase):
         self.transform_type = "Affine"
 
         # Transform utilities
-        self.transform_tools = TransformTools()
+        self.transform_tools = ProcessTransforms()
 
         # Registration results
         self.moving_to_fixed_transform: Optional[itk.AffineTransform] = None

--- a/src/monai_physio/register_models_icp_itk.py
+++ b/src/monai_physio/register_models_icp_itk.py
@@ -6,9 +6,9 @@ import numpy as np
 import pyvista as pv
 from scipy.optimize import minimize
 
-from .contour_tools import ContourTools
 from .monai_physio_base import MONAIPhysioBase
-from .transform_tools import TransformTools
+from .process_contours import ProcessContours
+from .process_transforms import ProcessTransforms
 
 
 class RegisterModelsICPITK(MONAIPhysioBase):
@@ -81,8 +81,8 @@ class RegisterModelsICPITK(MONAIPhysioBase):
         self.final_mean_distance = 0
 
         # Transform utilities
-        self._contour_tools = ContourTools()
-        self._transform_tools = TransformTools()
+        self._contour_tools = ProcessContours()
+        self._transform_tools = ProcessTransforms()
 
         # Image interpolator (created when needed)
         self.fixed_distance_map: Optional[itk.Image] = None

--- a/src/monai_physio/register_models_pca.py
+++ b/src/monai_physio/register_models_pca.py
@@ -12,9 +12,9 @@ from scipy.ndimage import map_coordinates
 from scipy.optimize import minimize
 from scipy.spatial import cKDTree
 
-from .contour_tools import ContourTools
 from .monai_physio_base import MONAIPhysioBase
-from .transform_tools import TransformTools
+from .process_contours import ProcessContours
+from .process_transforms import ProcessTransforms
 
 
 class RegisterModelsPCA(MONAIPhysioBase):
@@ -180,7 +180,7 @@ class RegisterModelsPCA(MONAIPhysioBase):
 
         self.post_pca_transform = post_pca_transform
 
-        self._contour_tools = ContourTools()
+        self._contour_tools = ProcessContours()
 
         self.fixed_model: Optional[pv.DataSet] = fixed_model
         self.fixed_distance_map = fixed_distance_map
@@ -1003,7 +1003,7 @@ class RegisterModelsPCA(MONAIPhysioBase):
             template_model_pca_deformation_field_image
         )
 
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
         self.fixed_to_moving_transform = (
             transform_tools.invert_displacement_field_transform(
                 self.moving_to_fixed_transform

--- a/src/monai_physio/register_time_series_images.py
+++ b/src/monai_physio/register_time_series_images.py
@@ -16,9 +16,9 @@ from typing import Literal, Optional, Union, cast
 import itk
 import numpy as np
 
+from .process_transforms import ProcessTransforms
 from .register_images_base import RegisterImagesBase
 from .register_images_greedy import RegisterImagesGreedy
-from .transform_tools import TransformTools
 
 
 class RegisterTimeSeriesImages(RegisterImagesBase):
@@ -38,7 +38,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
     Attributes:
         registrar (RegisterImagesBase): The registration backend in use.
-        transform_tools (TransformTools): Utility for transform operations.
+        transform_tools (ProcessTransforms): Utility for transform operations.
 
     Example:
         >>> # Register a cardiac CT time series
@@ -95,7 +95,7 @@ class RegisterTimeSeriesImages(RegisterImagesBase):
 
         self.composite_reference_image: Optional[itk.Image] = None
 
-        self.transform_tools: TransformTools = TransformTools()
+        self.transform_tools: ProcessTransforms = ProcessTransforms()
 
     def set_mask_dilation(self, mask_dilation_mm: float) -> None:
         """Set the dilation of the fixed and moving image masks.

--- a/src/monai_physio/segment_anatomy_base.py
+++ b/src/monai_physio/segment_anatomy_base.py
@@ -34,7 +34,7 @@ class SegmentAnatomyBase(MONAIPhysioBase):
     ``self.taxonomy.add_organ(group_name, label_id, organ_name)`` for each
     organ; the group is created lazily on first use. To assign a custom
     OmniSurface look to a new group, register it in
-    :data:`monai_physio.usd_anatomy_tools.DEFAULT_RENDER_PARAMS` (see that
+    :data:`monai_physio.process_usd_anatomy.DEFAULT_RENDER_PARAMS` (see that
     module's docstring). Groups without a registered look fall back to the
     ``"other"`` entry, so they still render.
 
@@ -49,7 +49,7 @@ class SegmentAnatomyBase(MONAIPhysioBase):
             index space exceeds 255 (e.g.
             :class:`monai_physio.SegmentNVSegmentCTMRI`) set ``np.uint16``.
         taxonomy (AnatomyTaxonomy): Group→organ mapping shared with
-            :class:`monai_physio.USDAnatomyTools`.
+            :class:`monai_physio.ProcessUSDAnatomy`.
     """
 
     def __init__(self, log_level: int | str = logging.INFO):
@@ -75,7 +75,7 @@ class SegmentAnatomyBase(MONAIPhysioBase):
         self.labelmap_dtype: type = np.uint8
 
         # Single source of truth for the anatomy hierarchy. Subclasses
-        # populate this; USDAnatomyTools and ConvertVTKToUSD consume it.
+        # populate this; ProcessUSDAnatomy and ConvertVTKToUSD consume it.
         self.taxonomy = AnatomyTaxonomy()
 
     def _finalize_other_group(self, id_range: range = range(1, 256)) -> None:

--- a/src/monai_physio/segment_chest_total_segmentator.py
+++ b/src/monai_physio/segment_chest_total_segmentator.py
@@ -14,7 +14,7 @@ import itk
 import nibabel as nib
 import numpy as np
 
-from .image_tools import ImageTools
+from .process_images import ProcessImages
 from .segment_anatomy_base import SegmentAnatomyBase
 
 
@@ -34,7 +34,7 @@ class SegmentChestTotalSegmentator(SegmentAnatomyBase):
 
     Anatomy groups (heart, lung, bone, major_vessels, soft_tissue) are
     populated into :attr:`SegmentAnatomyBase.taxonomy` so downstream
-    consumers (``ConvertVTKToUSD``, ``USDAnatomyTools``) see a single,
+    consumers (``ConvertVTKToUSD``, ``ProcessUSDAnatomy``) see a single,
     consistent group→organ mapping.
 
     For contrast-enhanced studies (CT with contrast-enhanced blood in the
@@ -448,7 +448,7 @@ class SegmentChestTotalSegmentator(SegmentAnatomyBase):
                 interior_arr = interior_mask.astype(np.uint8)
                 interior_image = itk.GetImageFromArray(interior_arr)
                 interior_image.CopyInformation(preprocessed_image)
-                imMath = ImageTools()
+                imMath = ProcessImages()
                 spacing = interior_image.GetSpacing()
                 exterior_image = imMath.binary_dilate_image(
                     interior_image, round(7 / spacing[0]), 1, 0

--- a/src/monai_physio/segment_chest_total_segmentator_with_contrast.py
+++ b/src/monai_physio/segment_chest_total_segmentator_with_contrast.py
@@ -12,7 +12,7 @@ from typing import Optional
 import itk
 import numpy as np
 
-from .image_tools import ImageTools
+from .process_images import ProcessImages
 from .segment_chest_total_segmentator import SegmentChestTotalSegmentator
 
 
@@ -159,7 +159,7 @@ class SegmentChestTotalSegmentatorWithContrast(SegmentChestTotalSegmentator):
             InsideValue=1,
             OutsideValue=0,
         )
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
         connected_component_image = image_tools.binary_dilate_image(
             connected_component_image, hole_fill, 1, 0
         )

--- a/src/monai_physio/segment_heart_simpleware.py
+++ b/src/monai_physio/segment_heart_simpleware.py
@@ -16,7 +16,7 @@ import tempfile
 import itk
 import numpy as np
 
-from .image_tools import ImageTools
+from .process_images import ProcessImages
 from .segment_anatomy_base import SegmentAnatomyBase
 
 
@@ -304,7 +304,7 @@ class SegmentHeartSimpleware(SegmentAnatomyBase):
             # Dilate the interior regions to simulate 3mm myocardium (heart)
             interior_image = itk.GetImageFromArray(interior_array.astype(np.uint8))
             interior_image.CopyInformation(preprocessed_image)
-            imMath = ImageTools()
+            imMath = ProcessImages()
             spacing = interior_image.GetSpacing()
             exterior_image = imMath.binary_dilate_image(
                 interior_image, round(7 / spacing[0]), 1, 0

--- a/src/monai_physio/segment_heart_simpleware_trimmed_branches.py
+++ b/src/monai_physio/segment_heart_simpleware_trimmed_branches.py
@@ -10,7 +10,7 @@ import logging
 import itk
 import numpy as np
 
-from .image_tools import ImageTools
+from .process_images import ProcessImages
 from .segment_heart_simpleware import SegmentHeartSimpleware
 
 
@@ -85,7 +85,7 @@ class SegmentHeartSimplewareTrimmedBranches(SegmentHeartSimpleware):
         heart_arr[heart_arr == 6] = 0
         heart_arr[heart_arr == 5] = 0
 
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
         spacing = labelmap_image.GetSpacing()
 
         #  2) Erode then Dilate Left Atrium label to clip vessels

--- a/src/monai_physio/segment_nv_segment_ct_mri.py
+++ b/src/monai_physio/segment_nv_segment_ct_mri.py
@@ -48,7 +48,7 @@ class SegmentNVSegmentCTMRI(SegmentAnatomyBase):
     TotalSegmentator backend uses, so downstream consumers see the same group
     keys; ``brain_parcellation`` is new and renders with the grey-matter entry
     registered for it in
-    :data:`monai_physio.usd_anatomy_tools.DEFAULT_RENDER_PARAMS`, plus
+    :data:`monai_physio.process_usd_anatomy.DEFAULT_RENDER_PARAMS`, plus
     organ-level overrides for the tissues that differ (white matter, CSF-filled
     ventricles, brainstem, cerebellum, pallidum).
 

--- a/src/monai_physio/train_physicsnemo_base.py
+++ b/src/monai_physio/train_physicsnemo_base.py
@@ -34,10 +34,10 @@ import numpy as np
 import pyvista as pv
 
 from .monai_physio_base import MONAIPhysioBase
-from .physicsnemo_tools import (
+from .process_physicsnemo import (
     DistributedContext,
     PhaseSampleDataset,
-    PhysicsNemoTools,
+    ProcessPhysicsNemo,
 )
 
 if TYPE_CHECKING:  # typed for mypy; imported lazily at runtime
@@ -256,7 +256,7 @@ class TrainPhysicsNeMoBase(MONAIPhysioBase):
         if resume_from is not None:
             ckpt = torch.load(str(resume_from), map_location=device, weights_only=True)
             state = ckpt.get("model_state_dict", ckpt)
-            model.load_state_dict(PhysicsNemoTools.strip_compile_prefix(state))
+            model.load_state_dict(ProcessPhysicsNemo.strip_compile_prefix(state))
             self._log_main(context, "Loaded model weights from %s", resume_from)
 
         self.setup_inputs(device, template_mesh, template_coords)
@@ -372,7 +372,7 @@ class TrainPhysicsNeMoBase(MONAIPhysioBase):
             # against the bare module: the RMSE describes the model, not how
             # the epoch happened to be split across ranks.
             if scored_epoch and context.is_main:
-                bare = PhysicsNemoTools.unwrap_model(model)
+                bare = ProcessPhysicsNemo.unwrap_model(model)
                 train_rmse = self._evaluate_rmse(
                     bare, train_dataset, target_scale, device
                 )
@@ -416,7 +416,7 @@ class TrainPhysicsNeMoBase(MONAIPhysioBase):
         checkpoint, not just the final one.
         """
         checkpoint: dict[str, Any] = {
-            "model_state_dict": PhysicsNemoTools.uncompiled_state_dict(model),
+            "model_state_dict": ProcessPhysicsNemo.uncompiled_state_dict(model),
             "architecture": self.architecture_name,
             "in_features": 3 + int(stats["pca_mean"].shape[0]) + 1,
             "n_pca": int(stats["pca_mean"].shape[0]),

--- a/src/monai_physio/train_physicsnemo_mgn.py
+++ b/src/monai_physio/train_physicsnemo_mgn.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 import numpy as np
 import pyvista as pv
 
-from .physicsnemo_tools import PhysicsNemoTools
+from .process_physicsnemo import ProcessPhysicsNemo
 from .train_physicsnemo_base import TrainPhysicsNeMoBase
 
 if TYPE_CHECKING:  # typed for mypy; imported lazily at runtime
@@ -83,7 +83,7 @@ class TrainPhysicsNeMoMGN(TrainPhysicsNeMoBase):
         self.num_processor_checkpoint_segments = num_segments
 
     def build_model(self, in_features: int, out_features: int) -> torch.nn.Module:
-        MeshGraphNet = PhysicsNemoTools.import_meshgraphnet()
+        MeshGraphNet = ProcessPhysicsNemo.import_meshgraphnet()
 
         model = MeshGraphNet(
             input_dim_nodes=in_features,
@@ -113,8 +113,8 @@ class TrainPhysicsNeMoMGN(TrainPhysicsNeMoBase):
         from torch_geometric.data import Data
 
         self._device = device
-        self._shared_edge_index = PhysicsNemoTools.mesh_to_edge_index(template_mesh)
-        self._shared_edge_feats = PhysicsNemoTools.compute_edge_features(
+        self._shared_edge_index = ProcessPhysicsNemo.mesh_to_edge_index(template_mesh)
+        self._shared_edge_feats = ProcessPhysicsNemo.compute_edge_features(
             template_coords, self._shared_edge_index
         )
         self._shared_graph = Data(

--- a/src/monai_physio/train_physicsnemo_mlp.py
+++ b/src/monai_physio/train_physicsnemo_mlp.py
@@ -50,7 +50,7 @@ class TrainPhysicsNeMoMLP(TrainPhysicsNeMoBase):
             raise ValueError(f"num_layers must be >= 1, got {num_layers}")
         self.num_layers = num_layers
 
-    def build_model(self, in_features: int, out_features: int) -> "torch.nn.Module":
+    def build_model(self, in_features: int, out_features: int) -> torch.nn.Module:
         try:
             from physicsnemo.models.mlp import FullyConnected
         except ImportError as exc:  # pragma: no cover - broken environment
@@ -72,7 +72,7 @@ class TrainPhysicsNeMoMLP(TrainPhysicsNeMoBase):
 
     def setup_inputs(
         self,
-        device: "torch.device",
+        device: torch.device,
         template_mesh: pv.DataSet,
         template_coords: np.ndarray,
     ) -> None:
@@ -80,8 +80,8 @@ class TrainPhysicsNeMoMLP(TrainPhysicsNeMoBase):
         return None
 
     def forward(
-        self, model: "torch.nn.Module", node_feats: "torch.Tensor", batch_len: int
-    ) -> "torch.Tensor":
+        self, model: torch.nn.Module, node_feats: torch.Tensor, batch_len: int
+    ) -> torch.Tensor:
         return cast("torch.Tensor", model(node_feats))
 
     def checkpoint_fields(self) -> dict:

--- a/src/monai_physio/train_physicsnemo_physics_informed_motion.py
+++ b/src/monai_physio/train_physicsnemo_physics_informed_motion.py
@@ -38,9 +38,9 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 import numpy as np
 import pyvista as pv
 
-from .contour_tools import ContourTools
 from .monai_physio_base import MONAIPhysioBase
-from .physicsnemo_tools import DistributedContext, PhaseSampleDataset
+from .process_contours import ProcessContours
+from .process_physicsnemo import DistributedContext, PhaseSampleDataset
 from .train_physicsnemo_mgn import TrainPhysicsNeMoMGN
 
 if TYPE_CHECKING:  # typed for mypy; imported lazily at runtime
@@ -98,7 +98,7 @@ def tet_volumes(points: np.ndarray, tets: np.ndarray) -> tuple[np.ndarray, np.nd
 
     Raises:
         ValueError: If any element is inverted or degenerate.  Templates come
-            from :meth:`monai_physio.ContourTools.trim_tetrahedra_to_surface`,
+            from :meth:`monai_physio.ProcessContours.trim_tetrahedra_to_surface`,
             which holds every cell above a scaled Jacobian of 0.1, so a
             violation here means the template is broken rather than merely
             tight.
@@ -718,7 +718,7 @@ class TrainPhysicsNeMoPhysicsInformedMotion(TrainPhysicsNeMoMGN):
         assert self._tets is not None
         self._reference_cache = {}
         device = context.device
-        contour_tools = ContourTools(log_level=self.log_level)
+        contour_tools = ProcessContours(log_level=self.log_level)
         for subject_id in sorted(set(self._sample_subjects)):
             mesh = cast(
                 "pv.UnstructuredGrid", pv.read(str(self._reference_meshes[subject_id]))

--- a/src/monai_physio/vtk_to_usd/primvar_derivations.py
+++ b/src/monai_physio/vtk_to_usd/primvar_derivations.py
@@ -25,7 +25,7 @@ Naming convention
 
 Use ``<source_name>_<DerivedName>`` (capitalized derived suffix). Capital
 letters sort before lowercase in ASCII, so ``stress_VonMises`` is selected over
-``stress_c0`` by ``USDTools.pick_color_primvar``'s alphabetical tiebreak.
+``stress_c0`` by ``ProcessUSD.pick_color_primvar``'s alphabetical tiebreak.
 """
 
 from __future__ import annotations

--- a/src/monai_physio/vtk_to_usd/usd_mesh_converter.py
+++ b/src/monai_physio/vtk_to_usd/usd_mesh_converter.py
@@ -154,7 +154,6 @@ class UsdMeshConverter:
         elif self.settings.compute_normals:
             logger.debug("Computing normals for mesh")
             # Normals will be computed by renderer or in post-process
-            pass
 
         # Handle vertex colors
         if mesh_data.colors is not None:

--- a/src/monai_physio/vtk_to_usd/usd_utils.py
+++ b/src/monai_physio/vtk_to_usd/usd_utils.py
@@ -332,7 +332,7 @@ def create_primvar(
 
     # If this is a multi-component array that we're storing in a scalar array type
     # (e.g. FloatArray for >4 components), preserve the component grouping via elementSize.
-    # This makes downstream tools (and USDTools.apply_colormap_from_primvar) able to reshape.
+    # This makes downstream tools (and ProcessUSD.apply_colormap_from_primvar) able to reshape.
     if array.num_components > 1 and sdf_type in (
         Sdf.ValueTypeNames.FloatArray,
         Sdf.ValueTypeNames.IntArray,

--- a/src/monai_physio/workflow_convert_image_to_usd.py
+++ b/src/monai_physio/workflow_convert_image_to_usd.py
@@ -15,18 +15,18 @@ import itk
 import numpy as np
 import pyvista as pv
 
-from .contour_tools import ContourTools
 from .convert_vtk_to_usd import ConvertVTKToUSD
-from .image_tools import ImageTools
 from .monai_physio_base import MONAIPhysioBase
+from .process_contours import ProcessContours
+from .process_images import ProcessImages
+from .process_transforms import ProcessTransforms
+from .process_usd_anatomy import ProcessUSDAnatomy
 from .register_images_base import RegisterImagesBase
 from .register_images_greedy import RegisterImagesGreedy
 from .segment_anatomy_base import SegmentAnatomyBase
 from .segment_chest_total_segmentator_with_contrast import (
     SegmentChestTotalSegmentatorWithContrast,
 )
-from .transform_tools import TransformTools
-from .usd_anatomy_tools import USDAnatomyTools
 
 
 class WorkflowConvertImageToUSD(MONAIPhysioBase):
@@ -134,9 +134,9 @@ class WorkflowConvertImageToUSD(MONAIPhysioBase):
         os.makedirs(output_directory, exist_ok=True)
 
         # Initialize processing components
-        self.contour_tools = ContourTools()
-        self.image_tools = ImageTools()
-        self.transform_tools = TransformTools()
+        self.contour_tools = ProcessContours()
+        self.image_tools = ProcessImages()
+        self.transform_tools = ProcessTransforms()
 
         # Data storage for processing pipeline
         self._num_time_points = len(time_series_images)
@@ -464,6 +464,6 @@ class WorkflowConvertImageToUSD(MONAIPhysioBase):
             )
             if os.path.exists(output_filename):
                 os.remove(output_filename)
-            painter = USDAnatomyTools(stage)
+            painter = ProcessUSDAnatomy(stage)
             painter.enhance_meshes(self.segmenter)
             stage.Export(output_filename)

--- a/src/monai_physio/workflow_convert_image_to_vtk.py
+++ b/src/monai_physio/workflow_convert_image_to_vtk.py
@@ -2,7 +2,7 @@
 
 The workflow segments a 3D CT image using a chosen backend, then extracts one
 VTP surface per non-empty anatomy group.  Each output surface carries anatomy
-metadata and solid color from :class:`USDAnatomyTools` as field and cell data
+metadata and solid color from :class:`ProcessUSDAnatomy` as field and cell data
 so that downstream tools (PyVista, Paraview, USD pipeline) can use them
 directly.
 
@@ -20,14 +20,14 @@ Typical usage::
     result = workflow.process(ct, surface_reduction_rate=0.5)
 
     # Combined single-file output (default)
-    ContourTools.save_combined_surfaces(result["surfaces"], "./out/patient.vtp")
+    ProcessContours.save_combined_surfaces(result["surfaces"], "./out/patient.vtp")
 
     # Per-group split output
-    ContourTools.save_surfaces(result["surfaces"], "./out", prefix="patient")
+    ProcessContours.save_surfaces(result["surfaces"], "./out", prefix="patient")
 
     # Per-label split output (one VTP per individual anatomical structure)
     result = workflow.process(ct, extract_label_surfaces=True)
-    ContourTools.save_surfaces(result["label_surfaces"], "./out", prefix="patient")
+    ProcessContours.save_surfaces(result["label_surfaces"], "./out", prefix="patient")
 """
 
 import logging
@@ -37,13 +37,13 @@ import itk
 import numpy as np
 import pyvista as pv
 
-from .contour_tools import ContourTools
 from .monai_physio_base import MONAIPhysioBase
+from .process_contours import ProcessContours
+from .process_usd_anatomy import ProcessUSDAnatomy
 from .segment_anatomy_base import SegmentAnatomyBase
 from .segment_chest_total_segmentator_with_contrast import (
     SegmentChestTotalSegmentatorWithContrast,
 )
-from .usd_anatomy_tools import USDAnatomyTools
 
 
 class WorkflowConvertImageToVTK(MONAIPhysioBase):
@@ -74,15 +74,15 @@ class WorkflowConvertImageToVTK(MONAIPhysioBase):
     - ``field_data['SegmentationLabelNames']`` - individual structure names within the
       group (e.g. ``['left_ventricle', 'right_ventricle', ...]``).
     - ``field_data['SegmentationLabelIds']`` - corresponding integer label IDs.
-    - ``field_data['AnatomyColor']`` - RGB float color from :class:`USDAnatomyTools`.
+    - ``field_data['AnatomyColor']`` - RGB float color from :class:`ProcessUSDAnatomy`.
     - ``cell_data['Color']`` - RGBA uint8 array (n_cells x 4) for direct VTK rendering.
 
     **I/O contract**
 
     :meth:`process` performs *no* file I/O.  Use
-    :class:`ContourTools`'s static helpers
-    :meth:`ContourTools.save_surfaces` and
-    :meth:`ContourTools.save_combined_surfaces` - or the CLI
+    :class:`ProcessContours`'s static helpers
+    :meth:`ProcessContours.save_surfaces` and
+    :meth:`ProcessContours.save_combined_surfaces` - or the CLI
     ``monai-physio-convert-image-to-vtk`` - to write results to disk.
     """
 
@@ -113,7 +113,7 @@ class WorkflowConvertImageToVTK(MONAIPhysioBase):
                 "segmentation_method must be a SegmentAnatomyBase instance or None"
             )
         self._segmenter: SegmentAnatomyBase = segmentation_method
-        self._contour_tools: ContourTools = ContourTools(log_level=log_level)
+        self._contour_tools: ProcessContours = ProcessContours(log_level=log_level)
 
         #: Anatomy group names registered by the active segmenter's taxonomy,
         #: in the order they were first added.
@@ -121,10 +121,10 @@ class WorkflowConvertImageToVTK(MONAIPhysioBase):
             self._segmenter.taxonomy.group_names()
         )
 
-        # Build anatomy-group → RGB color from USDAnatomyTools.
-        # USDAnatomyTools sets up its color dicts entirely in __init__ without
+        # Build anatomy-group → RGB color from ProcessUSDAnatomy.
+        # ProcessUSDAnatomy sets up its color dicts entirely in __init__ without
         # accessing the stage, so stage=None is safe for this lookup-only use.
-        _anatomy_tools = USDAnatomyTools(stage=None, log_level=log_level)
+        _anatomy_tools = ProcessUSDAnatomy(stage=None, log_level=log_level)
         supported_types = set(_anatomy_tools.get_anatomy_types())
         self._anatomy_color_map: dict[str, tuple[float, float, float]] = {
             group: _anatomy_tools.get_anatomy_diffuse_color(group)
@@ -177,7 +177,7 @@ class WorkflowConvertImageToVTK(MONAIPhysioBase):
     def _extract_surface(self, mask_image: Any) -> Optional[pv.PolyData]:
         """Extract a smoothed triangulated surface (VTP) from a binary mask image.
 
-        Delegates to :meth:`ContourTools.extract_contours`.
+        Delegates to :meth:`ProcessContours.extract_contours`.
 
         Returns:
             Smoothed :class:`pyvista.PolyData`, or ``None`` if the mask is empty.
@@ -193,7 +193,7 @@ class WorkflowConvertImageToVTK(MONAIPhysioBase):
         """Extract a smoothed triangulated surface for one individual label.
 
         Isolates *label_id* out of *labelmap_arr* into its own binary mask
-        before delegating to :meth:`ContourTools.extract_contours`.
+        before delegating to :meth:`ProcessContours.extract_contours`.
 
         Args:
             labelmap_image: Source image, used only for ``CopyInformation``

--- a/src/monai_physio/workflow_convert_vtk_to_usd.py
+++ b/src/monai_physio/workflow_convert_vtk_to_usd.py
@@ -19,9 +19,9 @@ import vtk
 
 from .convert_vtk_to_usd import ConvertVTKToUSD
 from .monai_physio_base import MONAIPhysioBase
+from .process_usd import ProcessUSD
+from .process_usd_anatomy import ProcessUSDAnatomy
 from .segment_anatomy_base import SegmentAnatomyBase
-from .usd_anatomy_tools import USDAnatomyTools
-from .usd_tools import USDTools
 
 AppearanceKind = Literal["solid", "anatomy", "colormap"]
 
@@ -106,14 +106,14 @@ class WorkflowConvertVTKToUSD(MONAIPhysioBase):
                 which is positional per frame. None (default) reads the ids off
                 the meshes themselves when they carry the per-cell array, and
                 names them from *segmenter*'s taxonomy - so passing a mesh
-                merged by :meth:`ContourTools.save_combined_surfaces` splits by
+                merged by :meth:`ProcessContours.save_combined_surfaces` splits by
                 structure without further arguments. ``static_merge`` accepts
                 only one labeled mesh: several would collide on one prim path
                 per label.
             segmenter: Segmenter whose taxonomy groups the labels of
                 *label_names* by anatomy type. Also selects each structure's
                 material when appearance == "anatomy", through
-                :meth:`USDAnatomyTools.enhance_meshes`, which falls back to the
+                :meth:`ProcessUSDAnatomy.enhance_meshes`, which falls back to the
                 containing group for a structure with no material of its own.
             colormap_primvar: Primvar name for coloring when appearance == "colormap"
                 (e.g. vtk_point_stress_c0). If None, a candidate is auto-picked when possible.
@@ -166,7 +166,7 @@ class WorkflowConvertVTKToUSD(MONAIPhysioBase):
 
         An explicit ``label_names`` is used as given. Otherwise the meshes are
         searched for the per-cell label array that
-        :meth:`ContourTools.save_combined_surfaces` writes on a merge, and that
+        :meth:`ProcessContours.save_combined_surfaces` writes on a merge, and that
         contouring a multi-label labelmap leaves behind. That array is
         preferred wherever it exists because it survives merging, which the
         per-object ``field_data`` naming does not - so a combined surface file
@@ -366,7 +366,7 @@ class WorkflowConvertVTKToUSD(MONAIPhysioBase):
         stage = converter.convert(str(output_usd))
 
         # Post-process: apply chosen appearance to all meshes under /World/{usd_project_name}
-        usd_tools = USDTools(log_level=self.log_level)
+        usd_tools = ProcessUSD(log_level=self.log_level)
         mesh_paths = usd_tools.list_mesh_paths_under(
             str(output_usd), parent_path=f"/World/{self.usd_project_name}"
         )
@@ -401,13 +401,13 @@ class WorkflowConvertVTKToUSD(MONAIPhysioBase):
             # The label layout names each prim after its structure, and the
             # segmenter's taxonomy supplies the group to fall back on when the
             # structure has no material of its own.
-            USDAnatomyTools(stage, log_level=self.log_level).enhance_meshes(
+            ProcessUSDAnatomy(stage, log_level=self.log_level).enhance_meshes(
                 self.segmenter
             )
             stage.Save()
 
         elif self.appearance == "anatomy":
-            anatomy_tools = USDAnatomyTools(stage, log_level=self.log_level)
+            anatomy_tools = ProcessUSDAnatomy(stage, log_level=self.log_level)
             for mesh_path in mesh_paths:
                 candidates = self._anatomy_candidates(mesh_path, object_groups)
                 selected = next(

--- a/src/monai_physio/workflow_create_mean_surface.py
+++ b/src/monai_physio/workflow_create_mean_surface.py
@@ -32,8 +32,8 @@ import itk
 import numpy as np
 import pyvista as pv
 
-from .contour_tools import ContourTools
 from .monai_physio_base import MONAIPhysioBase
+from .process_contours import ProcessContours
 from .register_models_distance_maps import RegisterModelsDistanceMaps
 from .register_models_icp import RegisterModelsICP
 
@@ -79,7 +79,7 @@ class WorkflowCreateMeanSurface(MONAIPhysioBase):
         if len(surfaces) < 2:
             raise ValueError(f"At least 2 surfaces are required, got {len(surfaces)}")
 
-        self.contour_tools = ContourTools(log_level=log_level)
+        self.contour_tools = ProcessContours(log_level=log_level)
         self.surfaces = [self.contour_tools.extract_surface(s) for s in surfaces]
         self.template_surface = (
             self.contour_tools.extract_surface(template_surface)

--- a/src/monai_physio/workflow_create_statistical_model.py
+++ b/src/monai_physio/workflow_create_statistical_model.py
@@ -16,11 +16,11 @@ import numpy as np
 import pyvista as pv
 from sklearn.decomposition import PCA
 
-from .contour_tools import ContourTools
 from .monai_physio_base import MONAIPhysioBase
+from .process_contours import ProcessContours
+from .process_transforms import ProcessTransforms
 from .register_models_distance_maps import RegisterModelsDistanceMaps
 from .register_models_icp import RegisterModelsICP
-from .transform_tools import TransformTools
 
 
 class WorkflowCreateStatisticalModel(MONAIPhysioBase):
@@ -125,8 +125,8 @@ class WorkflowCreateStatisticalModel(MONAIPhysioBase):
         self.projection_max_distance_mm = projection_max_distance_mm
         self.icon_weights_path: Optional[str] = None
 
-        self.contour_tools = ContourTools()
-        self.transform_tools = TransformTools()
+        self.contour_tools = ProcessContours()
+        self.transform_tools = ProcessTransforms()
 
         # Set by pipeline
         self.reference_model: Optional[pv.DataSet] = None

--- a/src/monai_physio/workflow_evaluate_movement.py
+++ b/src/monai_physio/workflow_evaluate_movement.py
@@ -38,10 +38,10 @@ import itk
 import numpy as np
 import pyvista as pv
 
-from .contour_tools import ContourTools
 from .evaluate_movement_base import EvaluateMovementBase, MovementGroundTruth
 from .monai_physio_base import MONAIPhysioBase
-from .physicsnemo_tools import PhysicsNemoTools
+from .process_contours import ProcessContours
+from .process_physicsnemo import ProcessPhysicsNemo
 from .report_evaluate_movement import ReportEvaluateMovement
 from .workflow_infer_movement import WorkflowInferMovement
 
@@ -87,7 +87,7 @@ class WorkflowEvaluateMovement(MONAIPhysioBase):
     )
 
     # Per-cell structure ids a shape model may carry, written by
-    # ``ContourTools.save_combined_surfaces``.
+    # ``ProcessContours.save_combined_surfaces``.
     _MESH_LABEL_ARRAY = "SegmentationLabelIds"
 
     def __init__(
@@ -110,7 +110,7 @@ class WorkflowEvaluateMovement(MONAIPhysioBase):
             if label_names is not None
             else cast(EvaluateMovementBase, cohort).label_names()
         )
-        self.contour_tools = ContourTools(log_level=log_level)
+        self.contour_tools = ProcessContours(log_level=log_level)
         self.displacement_data_file: Optional[Path] = None
         self.report_tools = ReportEvaluateMovement(log_level=log_level)
 
@@ -640,7 +640,7 @@ class WorkflowEvaluateMovement(MONAIPhysioBase):
         that. A mesh that does not --- the heart is one surface, its chambers
         being cavities the model excludes --- is partitioned by nearest label
         surface instead, the same nearest-label rule
-        :meth:`ContourTools.extract_label_surfaces` already scores the labelmap
+        :meth:`ProcessContours.extract_label_surfaces` already scores the labelmap
         metrics under. A chamber is then scored on the piece of wall bounding
         it. Either way a point belongs to at most one structure, and the
         partition is decided once, at the reference frame.
@@ -757,7 +757,7 @@ class WorkflowEvaluateMovement(MONAIPhysioBase):
         inference = self.movement_workflow.inference_workflow
         checkpoint = Path(inference.checkpoint_file)
         info = checkpoint.stat()
-        coefficients = PhysicsNemoTools.load_pca_coefficients(shape_parameters)
+        coefficients = ProcessPhysicsNemo.load_pca_coefficients(shape_parameters)
         provenance: dict[str, Any] = {
             "case_id": case_id,
             "shape_parameters_file": str(shape_parameters),

--- a/src/monai_physio/workflow_fit_statistical_model_to_patient.py
+++ b/src/monai_physio/workflow_fit_statistical_model_to_patient.py
@@ -30,10 +30,11 @@ import itk
 import numpy as np
 import pyvista as pv
 
-from .contour_tools import ContourTools
-from .image_tools import ImageTools
-from .labelmap_tools import LabelmapTools
 from .monai_physio_base import MONAIPhysioBase
+from .process_contours import ProcessContours
+from .process_images import ProcessImages
+from .process_labelmaps import ProcessLabelmaps
+from .process_transforms import ProcessTransforms
 from .register_images_greedy import RegisterImagesGreedy
 from .register_images_icon import RegisterImagesICON
 from .register_models_distance_maps import RegisterModelsDistanceMaps
@@ -43,7 +44,6 @@ from .segment_anatomy_base import SegmentAnatomyBase
 from .segment_heart_simpleware_trimmed_branches import (
     SegmentHeartSimplewareTrimmedBranches,
 )
-from .transform_tools import TransformTools
 from .workflow_convert_image_to_vtk import WorkflowConvertImageToVTK
 
 
@@ -87,7 +87,7 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         distancemap_squared_max (Optional[float]): Saturation radius of the
             labelmap-to-labelmap distance maps, in squared millimeters. None
             means derive it from mask_dilation_mm as (1.25 * mask_dilation_mm)**2
-        transform_tools (TransformTools): Transform utilities
+        transform_tools (ProcessTransforms): Transform utilities
         registrar_ICON (RegisterImagesICON): ICON registration instance
         registrar_Greedy (RegisterImagesGreedy): Greedy registration instance
         use_pca_registration (bool): Whether PCA registration is enabled (set via set_use_pca_registration)
@@ -217,16 +217,16 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         self.patient_labelmap = patient_labelmap
 
         # Utilities (needed for create_reference_image when patient_image is None)
-        self.transform_tools = TransformTools()
-        self.contour_tools = ContourTools()
-        self.labelmap_tools = LabelmapTools()
+        self.transform_tools = ProcessTransforms()
+        self.contour_tools = ProcessContours()
+        self.labelmap_tools = ProcessLabelmaps()
 
         if patient_image is not None:
             self.patient_image = patient_image
             spacing = np.asarray(patient_image.GetSpacing(), dtype=np.float64)
             isotropic_spacing = bool(np.allclose(spacing, spacing[0]))
             if not isotropic_spacing:
-                self.patient_image = ImageTools().make_isotropic_image(
+                self.patient_image = ProcessImages().make_isotropic_image(
                     self.patient_image
                 )
         else:
@@ -805,7 +805,7 @@ class WorkflowFitStatisticalModelToPatient(MONAIPhysioBase):
         margin_mm = 2.5 * self.mask_dilation_mm
         spacing = np.asarray(self.patient_image.GetSpacing(), dtype=np.float64)
         pad_voxels = np.maximum(1, np.ceil(margin_mm / spacing)).astype(int).tolist()
-        padded_patient_image = ImageTools().pad_image(
+        padded_patient_image = ProcessImages().pad_image(
             self.patient_image, pad_voxels=pad_voxels, background_value=-1000
         )
         labelmap_registrar = RegisterModelsDistanceMaps(

--- a/src/monai_physio/workflow_infer_movement.py
+++ b/src/monai_physio/workflow_infer_movement.py
@@ -25,8 +25,8 @@ import numpy as np
 import pyvista as pv
 
 from .monai_physio_base import MONAIPhysioBase
-from .physicsnemo_tools import PhysicsNemoTools
-from .transform_tools import TransformTools
+from .process_physicsnemo import ProcessPhysicsNemo
+from .process_transforms import ProcessTransforms
 from .workflow_convert_vtk_to_usd import WorkflowConvertVTKToUSD
 from .workflow_infer_physicsnemo import WorkflowInferPhysicsNeMo
 
@@ -106,8 +106,8 @@ class WorkflowInferMovement(MONAIPhysioBase):
             Dict with ``subject_id`` and ``predicted_surfaces`` (paths).
         """
         workflow = self.inference_workflow
-        manifest = PhysicsNemoTools.parse_manifest(subject_manifest)
-        pca_coeffs = PhysicsNemoTools.load_pca_coefficients(manifest.pca_coefficients)
+        manifest = ProcessPhysicsNemo.parse_manifest(subject_manifest)
+        pca_coeffs = ProcessPhysicsNemo.load_pca_coefficients(manifest.pca_coefficients)
         fitted_reference_mesh = cast(
             pv.DataSet, pv.read(str(manifest.fitted_reference_mesh))
         )
@@ -162,7 +162,7 @@ class WorkflowInferMovement(MONAIPhysioBase):
             Dict with ``predicted_surface`` (path) and ``predicted_points``.
         """
         workflow = self.inference_workflow
-        coeffs = PhysicsNemoTools.load_pca_coefficients(shape_parameters)
+        coeffs = ProcessPhysicsNemo.load_pca_coefficients(shape_parameters)
         fitted_mesh = cast(pv.DataSet, pv.read(str(fitted_reference_mesh)))
         fitted_reference_points = self._fitted_reference_points(fitted_mesh)
         pred_points = fitted_reference_points + workflow.predict(coeffs, stage)
@@ -256,7 +256,7 @@ class WorkflowInferMovement(MONAIPhysioBase):
             raise ValueError("process_time_series needs at least one stage.")
 
         workflow = self.inference_workflow
-        coeffs = PhysicsNemoTools.load_pca_coefficients(shape_parameters)
+        coeffs = ProcessPhysicsNemo.load_pca_coefficients(shape_parameters)
         fitted_mesh = cast(pv.DataSet, pv.read(str(fitted_reference_mesh)))
         fitted_reference_points = self._fitted_reference_points(fitted_mesh)
 
@@ -266,7 +266,7 @@ class WorkflowInferMovement(MONAIPhysioBase):
         suffix = ".vtp" if isinstance(fitted_mesh, pv.PolyData) else ".vtu"
         self.log_section("INFER MOVEMENT TIME SERIES [%s]", stem)
 
-        transform_tools = TransformTools(log_level=self.log_level)
+        transform_tools = ProcessTransforms(log_level=self.log_level)
         stage_meshes: list[pv.DataSet] = []
         surfaces: list[Path] = []
         warped_images: list[Path] = []
@@ -391,12 +391,12 @@ class WorkflowInferMovement(MONAIPhysioBase):
             images), ``weight_image`` (the vertex count per voxel, which
             distinguishes an empty voxel from one whose displacement happens to
             be zero and is what
-            :meth:`TransformTools.smooth_deformation_field_transform` normalizes
+            :meth:`ProcessTransforms.smooth_deformation_field_transform` normalizes
             by), ``deformed_surface`` (the stage mesh as ``pv.DataSet``) and,
             when written, their paths.
         """
         workflow = self.inference_workflow
-        coeffs = PhysicsNemoTools.load_pca_coefficients(shape_parameters)
+        coeffs = ProcessPhysicsNemo.load_pca_coefficients(shape_parameters)
         fitted_mesh = cast(pv.DataSet, pv.read(str(fitted_reference_mesh)))
         fitted_reference_points = self._fitted_reference_points(fitted_mesh)
         disps = workflow.predict(coeffs, stage)

--- a/src/monai_physio/workflow_infer_physicsnemo.py
+++ b/src/monai_physio/workflow_infer_physicsnemo.py
@@ -29,7 +29,7 @@ import pyvista as pv
 from .infer_physicsnemo_base import InferPhysicsNeMoBase
 from .infer_physicsnemo_mgn import InferPhysicsNeMoMGN
 from .monai_physio_base import MONAIPhysioBase
-from .physicsnemo_tools import PhysicsNemoTools
+from .process_physicsnemo import ProcessPhysicsNemo
 
 
 class WorkflowInferPhysicsNeMo(MONAIPhysioBase):
@@ -124,7 +124,7 @@ class WorkflowInferPhysicsNeMo(MONAIPhysioBase):
             self.model_directory, len(self._template_coords), self._device
         )
         state = self._load_weights(epoch)
-        model.load_state_dict(PhysicsNemoTools.strip_compile_prefix(state))
+        model.load_state_dict(ProcessPhysicsNemo.strip_compile_prefix(state))
         model.eval()
         self.inference_method.set_model(model, self._device)
 
@@ -163,7 +163,7 @@ class WorkflowInferPhysicsNeMo(MONAIPhysioBase):
     def predict(self, pca_coeffs: np.ndarray, stage: float) -> np.ndarray:
         """Predict ``(n_points, n_target)`` targets for a subject at a stage."""
         pca_norm = (pca_coeffs - self.pca_mean) / self.pca_scale
-        node_feats = PhysicsNemoTools.build_node_features(
+        node_feats = ProcessPhysicsNemo.build_node_features(
             self._mean_coords_norm, pca_norm, stage
         )
         return self.inference_method.predict(node_feats) * self.target_scale
@@ -195,8 +195,8 @@ class WorkflowInferPhysicsNeMo(MONAIPhysioBase):
         Returns:
             Dict with ``subject_id`` and ``predicted_meshes`` (paths).
         """
-        manifest = PhysicsNemoTools.parse_manifest(subject_manifest)
-        pca_coeffs = PhysicsNemoTools.load_pca_coefficients(manifest.pca_coefficients)
+        manifest = ProcessPhysicsNemo.parse_manifest(subject_manifest)
+        pca_coeffs = ProcessPhysicsNemo.load_pca_coefficients(manifest.pca_coefficients)
 
         out_dir = (
             Path(output_directory)

--- a/src/monai_physio/workflow_train_physicsnemo.py
+++ b/src/monai_physio/workflow_train_physicsnemo.py
@@ -11,7 +11,7 @@ payload - lives in the training method it drives
 Design highlights:
 
 - **Data is a list of per-subject manifest files** (see
-  :func:`monai_physio.physicsnemo_tools.parse_manifest`). The caller chooses the
+  :func:`monai_physio.process_physicsnemo.parse_manifest`). The caller chooses the
   train / validation / held-out-test split externally; the workflow receives the
   training manifests and validation manifest(s) and the training method reports
   validation RMSE intermittently as training proceeds.
@@ -20,7 +20,7 @@ Design highlights:
   displacement model is just the case where the caller stored three columns of
   ``phase.points - reference.points``.
 - **The dataset streams lazily** through
-  :class:`monai_physio.physicsnemo_tools.PhaseSampleDataset` with a bounded RAM
+  :class:`monai_physio.process_physicsnemo.PhaseSampleDataset` with a bounded RAM
   cache, so the training set need not fit in memory.
 - **Coordinates are always the PCA template mesh** (shared across subjects), a
   surface or a volume; the subject is described by its PCA parameters and the
@@ -40,10 +40,10 @@ import numpy as np
 import pyvista as pv
 
 from .monai_physio_base import MONAIPhysioBase
-from .physicsnemo_tools import (
+from .process_physicsnemo import (
     DistributedContext,
     PhaseSampleDataset,
-    PhysicsNemoTools,
+    ProcessPhysicsNemo,
     SubjectManifest,
     _Sample,
 )
@@ -176,7 +176,7 @@ class WorkflowTrainPhysicsNeMo(MONAIPhysioBase):
 
         # Picks up torchrun, SLURM or OpenMPI, and reports one rank of one when
         # the process was started without any of them.
-        context = PhysicsNemoTools.distributed_context()
+        context = ProcessPhysicsNemo.distributed_context()
 
         output_dir = self._resolve_output_dir(context)
         if context.is_main:
@@ -263,7 +263,7 @@ class WorkflowTrainPhysicsNeMo(MONAIPhysioBase):
 
         def _load(paths: list[Path], split: str) -> None:
             for manifest_path in paths:
-                manifest: SubjectManifest = PhysicsNemoTools.parse_manifest(
+                manifest: SubjectManifest = ProcessPhysicsNemo.parse_manifest(
                     manifest_path
                 )
                 if manifest.subject_id in subjects:
@@ -281,7 +281,7 @@ class WorkflowTrainPhysicsNeMo(MONAIPhysioBase):
                     )
                 subjects[manifest.subject_id] = {
                     "split": split,
-                    "pca_coeffs": PhysicsNemoTools.load_pca_coefficients(
+                    "pca_coeffs": ProcessPhysicsNemo.load_pca_coefficients(
                         manifest.pca_coefficients
                     ),
                     "target_array": manifest.target_array,
@@ -376,7 +376,7 @@ class WorkflowTrainPhysicsNeMo(MONAIPhysioBase):
             if data["split"] != "train":
                 continue
             for phase in data["phases"]:
-                values = PhysicsNemoTools.load_target_array(
+                values = ProcessPhysicsNemo.load_target_array(
                     phase.mesh, data["target_array"]
                 )
                 if values.shape[0] != n_points:

--- a/statistics.md
+++ b/statistics.md
@@ -55,16 +55,16 @@ tutorials are straightforward top-to-bottom scripts.
 
 | Module                                          | Lines | Purpose                                         |
 | ------------------------------------------------ | ----- | ----------------------------------------------- |
-| `usd_tools.py`                                   | 1,523 | USD file manipulation and inspection            |
-| `contour_tools.py`                               | 1,415 | Mesh extraction and contour manipulation        |
+| `process_usd.py`                                   | 1,523 | USD file manipulation and inspection            |
+| `process_contours.py`                               | 1,415 | Mesh extraction and contour manipulation        |
 | `register_models_pca.py`                         | 1,117 | PCA-based shape model registration              |
 | `convert_vtk_to_usd.py`                          | 1,071 | High-level VTK -> USD converter                 |
-| `transform_tools.py`                             | 1,065 | ITK transform utilities                         |
-| `usd_anatomy_tools.py`                           | 1,053 | OmniSurface materials for labeled anatomy       |
+| `process_transforms.py`                             | 1,065 | ITK transform utilities                         |
+| `process_usd_anatomy.py`                           | 1,053 | OmniSurface materials for labeled anatomy       |
 | `workflow_fit_statistical_model_to_patient.py`   | 1,049 | Model-to-patient registration workflow          |
 | `segment_nv_segment_ct_mri.py`                   | 695   | NVIDIA CT/MRI segmentation bundle bridge        |
 | `register_images_ants.py`                        | 691   | ANTs-based image registration                   |
-| `image_tools.py`                                 | 685   | Image I/O, resampling, preprocessing            |
+| `process_images.py`                                 | 685   | Image I/O, resampling, preprocessing            |
 | `register_images_base.py`                        | 685   | Shared registration base class                  |
 | `workflow_infer_movement.py`                     | 625   | Predicted displacements back into geometry      |
 | `register_images_greedy.py`                      | 593   | Greedy classical deformable registration        |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,9 @@ import numpy as np
 import pytest
 from parameters_base import ParametersBase
 
-from monai_physio.contour_tools import ContourTools
-from monai_physio.data_download_tools import DataDownloadTools
+from monai_physio.download_data import DownloadData
+from monai_physio.process_contours import ProcessContours
+from monai_physio.process_transforms import ProcessTransforms
 from monai_physio.register_images_ants import RegisterImagesANTS
 from monai_physio.register_images_greedy import RegisterImagesGreedy
 from monai_physio.register_images_icon import RegisterImagesICON
@@ -28,7 +29,6 @@ from monai_physio.segment_chest_total_segmentator_with_contrast import (
 )
 from monai_physio.segment_heart_simpleware import SegmentHeartSimpleware
 from monai_physio.segment_nv_segment_ct_mri import SegmentNVSegmentCTMRI
-from monai_physio.transform_tools import TransformTools
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ def pytest_configure(config: pytest.Config) -> None:
     global _pytest_config
     _pytest_config = config
 
-    from monai_physio import test_tools as _test_tools
+    from monai_physio import process_tests as _test_tools
 
     _test_tools.set_create_baseline_if_missing(
         config.getoption("--create-baselines", default=False)
@@ -436,12 +436,12 @@ def download_test_data(test_directories: dict[str, Path]) -> Path:
     data_dir = test_directories["slicer_heart_data"]
 
     try:
-        input_image_filename = DataDownloadTools.DownloadSlicerHeartCTData(data_dir)
+        input_image_filename = DownloadData.DownloadSlicerHeartCTData(data_dir)
     except OSError as e:
         msg = (
             f"Could not download test data: {e}. "
             "Please manually place "
-            f"{DataDownloadTools.SLICER_HEART_CT_FILENAME} in {data_dir}"
+            f"{DownloadData.SLICER_HEART_CT_FILENAME} in {data_dir}"
         )
         if os.environ.get("CI"):
             pytest.fail(msg)
@@ -457,7 +457,7 @@ def download_kcl_heart_model(test_directories: dict[str, Path]) -> Path:
     data_dir = test_directories["data"] / "KCL-Heart-Model"
 
     try:
-        data_dir = DataDownloadTools.DownloadKCLHeartModelData(data_dir)
+        data_dir = DownloadData.DownloadKCLHeartModelData(data_dir)
     except OSError as e:
         msg = (
             f"Could not download KCL-Heart-Model data: {e}. "
@@ -805,9 +805,9 @@ def segmenter_simpleware() -> SegmentHeartSimpleware:
 
 
 @pytest.fixture(scope="session")
-def contour_tools() -> ContourTools:
-    """Create a ContourTools instance."""
-    return ContourTools()
+def contour_tools() -> ProcessContours:
+    """Create a ProcessContours instance."""
+    return ProcessContours()
 
 
 @pytest.fixture(scope="session")
@@ -829,9 +829,9 @@ def registrar_ICON() -> RegisterImagesICON:
 
 
 @pytest.fixture(scope="session")
-def transform_tools() -> TransformTools:
-    """Create a TransformTools instance."""
-    return TransformTools()
+def transform_tools() -> ProcessTransforms:
+    """Create a ProcessTransforms instance."""
+    return ProcessTransforms()
 
 
 class KnownShiftCase:
@@ -853,7 +853,7 @@ class KnownShiftCase:
                 Use a different magnitude and sign per axis so an axis swap or a
                 sign flip cannot pass.
         """
-        self.transform_tools = TransformTools()
+        self.transform_tools = ProcessTransforms()
         self.fixed = fixed_image
         self.shift_mm = shift_mm
         self.expected_displacement = np.array([-v for v in shift_mm])
@@ -945,7 +945,7 @@ class KnownAffineCase:
             origin_offset_mm: Placed the grid's origin here, moving the data in
                 world space. Use it to sit far from the world origin.
         """
-        self.transform_tools = TransformTools()
+        self.transform_tools = ProcessTransforms()
 
         self.fixed = self._synthetic_volume(origin_offset_mm)
         self.origin_offset_mm = origin_offset_mm

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import importlib
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Any
 
 import pytest
-
 
 CLI_MODULES = [
     "monai_physio.cli.convert_image_to_vtk",

--- a/tests/test_contour_mesh_extraction.py
+++ b/tests/test_contour_mesh_extraction.py
@@ -1,4 +1,4 @@
-"""Tests for ContourTools' per-label surface and tetrahedral mesh extraction.
+"""Tests for ProcessContours' per-label surface and tetrahedral mesh extraction.
 
 These use ``data/test/slicer_heart_small``, whose direction matrix is
 right-handed, plus a synthetic left-handed image for the cases that only a
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 import pyvista as pv
 
-from monai_physio.contour_tools import ContourTools
+from monai_physio.process_contours import ProcessContours
 
 #: A label that reaches the volume border, so its surface only closes if the
 #: mask is padded first.
@@ -105,7 +105,7 @@ class TestExtractContours:
     """The multi-label contour must be smooth and keep its labels in contact."""
 
     def test_smoothing_takes_the_voxel_blocks_out(
-        self, contour_tools: ContourTools
+        self, contour_tools: ProcessContours
     ) -> None:
         """Taubin smoothing leaves the surface markedly less faceted.
 
@@ -119,7 +119,7 @@ class TestExtractContours:
         assert _roughness(smooth) < 0.75 * _roughness(blocky)
 
     def test_smoothing_keeps_every_cell_and_its_labels(
-        self, contour_tools: ContourTools
+        self, contour_tools: ProcessContours
     ) -> None:
         """Smoothing only moves points, so the label of each cell survives.
 
@@ -133,7 +133,7 @@ class TestExtractContours:
         assert smooth.n_points == blocky.n_points
         assert _label_pairs(smooth) == _label_pairs(blocky)
 
-    def test_labels_stay_in_contact(self, contour_tools: ContourTools) -> None:
+    def test_labels_stay_in_contact(self, contour_tools: ProcessContours) -> None:
         """The wall between the labels is not torn open by smoothing.
 
         Regression guard for ``non_manifold_smoothing``: the surface net shares
@@ -157,7 +157,7 @@ class TestExtractContours:
         assert open_edges(smooth) == open_edges(blocky)
 
     def test_anisotropic_labelmap_is_contoured_isotropically(
-        self, contour_tools: ContourTools
+        self, contour_tools: ProcessContours
     ) -> None:
         """Boundaries land between the slices rather than terracing at them.
 
@@ -178,7 +178,7 @@ class TestExtractLabelSurfaces:
     """Labels extracted together must stay closed and stay in contact."""
 
     def test_surfaces_are_watertight_and_outward(
-        self, contour_tools: ContourTools
+        self, contour_tools: ProcessContours
     ) -> None:
         """Every label closes and encloses a positive volume."""
         surfaces = contour_tools.extract_label_surfaces(_touching_boxes())
@@ -191,7 +191,7 @@ class TestExtractLabelSurfaces:
             assert surface.volume > 0.0, f"label {label_id} must face outward"
 
     def test_neighbors_share_the_wall_between_them(
-        self, contour_tools: ContourTools
+        self, contour_tools: ProcessContours
     ) -> None:
         """The two surfaces meet on identical vertices, smoothing included.
 
@@ -210,7 +210,7 @@ class TestExtractLabelSurfaces:
         ).point_data["implicit_distance"]
         assert np.count_nonzero(np.abs(distances) < 1e-9) == len(shared)
 
-    def test_volume_matches_the_labelmap(self, contour_tools: ContourTools) -> None:
+    def test_volume_matches_the_labelmap(self, contour_tools: ProcessContours) -> None:
         """Neither label is thinned or fattened by the smoothing.
 
         Not to the voxel exactly: the distance map is zero at the outermost
@@ -232,7 +232,7 @@ class TestExtractWatertightSurface:
     """The per-label surface must be closed and outward-oriented."""
 
     def test_border_label_surface_is_watertight(
-        self, contour_tools: ContourTools, heart_labelmap: itk.Image
+        self, contour_tools: ProcessContours, heart_labelmap: itk.Image
     ) -> None:
         """A label touching the volume border still closes.
 
@@ -248,7 +248,7 @@ class TestExtractWatertightSurface:
             "every edge must be shared by exactly two faces"
         )
 
-    def test_normals_point_outward(self, contour_tools: ContourTools) -> None:
+    def test_normals_point_outward(self, contour_tools: ProcessContours) -> None:
         """A left-handed direction still yields a positive enclosed volume.
 
         Regression guard for ``auto_orient_normals``: VTK winds faces for a
@@ -263,12 +263,14 @@ class TestExtractWatertightSurface:
         )
         assert surface.volume > 0.0, "enclosed volume must be positive"
 
-    def test_empty_surface_is_not_watertight(self, contour_tools: ContourTools) -> None:
+    def test_empty_surface_is_not_watertight(
+        self, contour_tools: ProcessContours
+    ) -> None:
         """A surface with no face fails the test rather than passing it vacuously."""
         assert not contour_tools.is_watertight(pv.PolyData())
 
     def test_decimation_reduces_triangle_count(
-        self, contour_tools: ContourTools, heart_labelmap: itk.Image
+        self, contour_tools: ProcessContours, heart_labelmap: itk.Image
     ) -> None:
         """surface_reduction_rate removes roughly that fraction of triangles."""
         mask = _label_mask(heart_labelmap, BORDER_LABEL)
@@ -284,7 +286,7 @@ class TestExtractTetrahedra:
     """The per-label volume mesh must be tetrahedral and positively oriented."""
 
     def test_cells_are_tetrahedra(
-        self, contour_tools: ContourTools, heart_labelmap: itk.Image
+        self, contour_tools: ProcessContours, heart_labelmap: itk.Image
     ) -> None:
         """Every cell is a tetrahedron, six per labeled voxel."""
         mask = _label_mask(heart_labelmap, BORDER_LABEL)
@@ -295,7 +297,7 @@ class TestExtractTetrahedra:
         assert mesh.n_cells == 6 * voxels
 
     def test_left_handed_direction_yields_positive_volumes(
-        self, contour_tools: ContourTools
+        self, contour_tools: ProcessContours
     ) -> None:
         """No tetrahedron is inverted when the direction determinant is negative.
 
@@ -310,7 +312,7 @@ class TestExtractTetrahedra:
         assert float(np.sum(volumes)) == pytest.approx(4 * 4 * 4 * 6.0)
 
     def test_volume_survives_coarsening(
-        self, contour_tools: ContourTools, heart_labelmap: itk.Image
+        self, contour_tools: ProcessContours, heart_labelmap: itk.Image
     ) -> None:
         """Elements twice the voxel keep the volume while shedding cells cubically."""
         mask = _label_mask(heart_labelmap, BORDER_LABEL)
@@ -323,13 +325,15 @@ class TestExtractTetrahedra:
         assert coarse_volume == pytest.approx(full_volume, rel=0.1)
         assert coarse.n_cells == pytest.approx(full.n_cells * 0.125, rel=0.3)
 
-    def test_empty_mask_yields_an_empty_mesh(self, contour_tools: ContourTools) -> None:
+    def test_empty_mask_yields_an_empty_mesh(
+        self, contour_tools: ProcessContours
+    ) -> None:
         """A mask with nothing in it has no bounding box to mesh."""
         empty = itk.GetImageFromArray(np.zeros((4, 4, 4), dtype=np.uint8))
 
         assert contour_tools.extract_tetrahedra(empty).n_cells == 0
 
-    def test_elements_are_isotropic(self, contour_tools: ContourTools) -> None:
+    def test_elements_are_isotropic(self, contour_tools: ProcessContours) -> None:
         """The requested element size is what the mesh is built on.
 
         Regression guard for the anisotropic default: meshing a mask's own
@@ -356,7 +360,7 @@ class TestTrimTetrahedraToSurface:
         return float(np.abs(distance).mean())
 
     def test_boundary_lands_on_the_surface(
-        self, contour_tools: ContourTools, heart_labelmap: itk.Image
+        self, contour_tools: ProcessContours, heart_labelmap: itk.Image
     ) -> None:
         """The voxel staircase is relaxed onto the surface, not merely clipped.
 
@@ -374,7 +378,7 @@ class TestTrimTetrahedraToSurface:
         assert self._boundary_gap(relaxed, surface) < 0.25 * before
 
     def test_cells_are_kept_whole_and_well_shaped(
-        self, contour_tools: ContourTools, heart_labelmap: itk.Image
+        self, contour_tools: ProcessContours, heart_labelmap: itk.Image
     ) -> None:
         """Cells are only dropped, never cut into slivers.
 
@@ -394,7 +398,7 @@ class TestTrimTetrahedraToSurface:
         )
         assert np.min(quality) >= 0.1, "no tetrahedron may be left a sliver"
 
-    def test_anatomy_color_survives(self, contour_tools: ContourTools) -> None:
+    def test_anatomy_color_survives(self, contour_tools: ProcessContours) -> None:
         """Cell and field data attached at extraction are carried through."""
         mask = _left_handed_box()
         surface = contour_tools.extract_label_surfaces(mask)[1]
@@ -416,7 +420,9 @@ class TestRepairInvertedTetrahedra:
         cells = np.array([4, 0, 1, 2, 3])
         return pv.UnstructuredGrid(cells, [pv.CellType.TETRA], points)
 
-    def test_repairs_an_inverted_tetrahedron(self, contour_tools: ContourTools) -> None:
+    def test_repairs_an_inverted_tetrahedron(
+        self, contour_tools: ProcessContours
+    ) -> None:
         """Swapping two corners inverts the cell; relaxation must restore it."""
         points = np.array(
             [[0.0, 0.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]
@@ -429,7 +435,7 @@ class TestRepairInvertedTetrahedra:
         edges = corners[1:, :] - corners[0:1, :]
         assert np.linalg.det(edges) / 6.0 > 0.0
 
-    def test_raises_when_unrecoverable(self, contour_tools: ContourTools) -> None:
+    def test_raises_when_unrecoverable(self, contour_tools: ProcessContours) -> None:
         """A degenerate cell with no neighbors to average toward can't be fixed."""
         points = np.array(
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]
@@ -439,7 +445,7 @@ class TestRepairInvertedTetrahedra:
         with pytest.raises(ValueError, match="still inverted or degenerate"):
             contour_tools.repair_inverted_tetrahedra(mesh, max_iterations=2)
 
-    def test_raises_when_no_tetra_cells(self, contour_tools: ContourTools) -> None:
+    def test_raises_when_no_tetra_cells(self, contour_tools: ProcessContours) -> None:
         """A mesh without TETRA cells fails with a clear message, not a KeyError."""
         mesh = pv.UnstructuredGrid()
 

--- a/tests/test_convert_vtk_to_usd.py
+++ b/tests/test_convert_vtk_to_usd.py
@@ -15,7 +15,7 @@ import pyvista as pv
 from pxr import UsdGeom
 
 from monai_physio import ConvertVTKToUSD
-from monai_physio.contour_tools import ContourTools
+from monai_physio.process_contours import ProcessContours
 
 
 def _make_poly(label_ids: list[int] | None = None) -> pv.PolyData:
@@ -38,7 +38,7 @@ class TestConvertVTKToUSD:
     @pytest.fixture(scope="class")
     def contour_meshes(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_directories: dict[str, Path],
     ) -> list[Any]:
@@ -168,7 +168,7 @@ class TestConvertVTKToUSD:
 
     def test_convert_with_deformation(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_directories: dict[str, Path],
     ) -> None:
@@ -374,7 +374,7 @@ class TestConvertVTKToUSD:
 
     def test_batch_conversion(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_directories: dict[str, Path],
     ) -> None:

--- a/tests/test_download_data_cli.py
+++ b/tests/test_download_data_cli.py
@@ -8,7 +8,7 @@ from typing import Union
 import pytest
 
 from monai_physio.cli import download_data
-from monai_physio.data_download_tools import DataDownloadTools
+from monai_physio.download_data import DownloadData
 
 
 def test_download_data_cli_with_no_args_prints_help(
@@ -30,9 +30,9 @@ def test_download_data_cli_uses_requested_directory(
 
     def fake_download(dirname: Union[str, Path]) -> Path:
         calls.append(Path(dirname))
-        return Path(dirname) / DataDownloadTools.SLICER_HEART_CT_FILENAME
+        return Path(dirname) / DownloadData.SLICER_HEART_CT_FILENAME
 
-    monkeypatch.setattr(DataDownloadTools, "DownloadSlicerHeartCTData", fake_download)
+    monkeypatch.setattr(DownloadData, "DownloadSlicerHeartCTData", fake_download)
 
     result = download_data.main(["Slicer-Heart-CT", "--directory", str(tmp_path)])
 
@@ -51,7 +51,7 @@ def test_download_data_cli_routes_kcl_heart_model(
         calls.append(Path(dirname))
         return Path(dirname)
 
-    monkeypatch.setattr(DataDownloadTools, "DownloadKCLHeartModelData", fake_download)
+    monkeypatch.setattr(DownloadData, "DownloadKCLHeartModelData", fake_download)
 
     result = download_data.main(["KCL-Heart-Model"])
 
@@ -71,7 +71,7 @@ def test_download_data_cli_routes_chop_valve4d(
         calls.append(Path(dirname))
         return Path(dirname)
 
-    monkeypatch.setattr(DataDownloadTools, "DownloadCHOPValve4DData", fake_download)
+    monkeypatch.setattr(DownloadData, "DownloadCHOPValve4DData", fake_download)
 
     result = download_data.main(["CHOP-Valve4D"])
 
@@ -89,9 +89,9 @@ def test_download_data_cli_routes_chest_ct(
 
     def fake_download(dirname: Union[str, Path]) -> Path:
         calls.append(Path(dirname))
-        return Path(dirname) / DataDownloadTools.CHEST_CT_FILENAME
+        return Path(dirname) / DownloadData.CHEST_CT_FILENAME
 
-    monkeypatch.setattr(DataDownloadTools, "DownloadChestCTData", fake_download)
+    monkeypatch.setattr(DownloadData, "DownloadChestCTData", fake_download)
 
     result = download_data.main(["Chest-CT"])
 

--- a/tests/test_download_heart_data.py
+++ b/tests/test_download_heart_data.py
@@ -12,21 +12,21 @@ from pathlib import Path
 
 import pytest
 
-from monai_physio.data_download_tools import DataDownloadTools
+from monai_physio.download_data import DownloadData
 
 
-class TestDataDownloadTools:
+class TestDownloadData:
     """Synthetic tests for dataset verification helpers."""
 
     def test_verify_slicer_heart_ct_data(self, tmp_path: Path) -> None:
         """Verify Slicer data by expected `TruncalValve_4DCT.seq.nrrd` filename."""
-        data_file = tmp_path / DataDownloadTools.SLICER_HEART_CT_FILENAME
+        data_file = tmp_path / DownloadData.SLICER_HEART_CT_FILENAME
 
-        assert not DataDownloadTools.VerifySlicerHeartCTData(tmp_path)
+        assert not DownloadData.VerifySlicerHeartCTData(tmp_path)
 
         data_file.write_bytes(b"nrrd")
 
-        assert DataDownloadTools.VerifySlicerHeartCTData(tmp_path)
+        assert DownloadData.VerifySlicerHeartCTData(tmp_path)
 
     def test_verify_kcl_heart_model_data(self, tmp_path: Path) -> None:
         """Verify KCL data by expected average mesh and input mesh filenames."""
@@ -34,29 +34,29 @@ class TestDataDownloadTools:
         input_meshes = tmp_path / "input_meshes"
         input_meshes.mkdir()
 
-        assert not DataDownloadTools.VerifyKCLHeartModelData(tmp_path)
+        assert not DownloadData.VerifyKCLHeartModelData(tmp_path)
 
         (input_meshes / "01.vtk").write_text("# vtk\n")
 
-        assert DataDownloadTools.VerifyKCLHeartModelData(tmp_path)
+        assert DownloadData.VerifyKCLHeartModelData(tmp_path)
 
     def test_verify_dirlab_4dct_data(self, tmp_path: Path) -> None:
         """Verify DirLab data requires both the header and its backing data."""
         case1_dir = tmp_path / "Case1"
         case1_dir.mkdir()
 
-        assert not DataDownloadTools.VerifyDirLab4DCTData(tmp_path)
+        assert not DownloadData.VerifyDirLab4DCTData(tmp_path)
 
         # A header alone (as committed to the repo) must not verify --
         # the raw pixel data it points to has not been downloaded yet.
         (case1_dir / "case1_T00.mhd").write_text(
             "ObjectType = Image\nElementDataFile = case1_T00.img\n"
         )
-        assert not DataDownloadTools.VerifyDirLab4DCTData(tmp_path)
+        assert not DownloadData.VerifyDirLab4DCTData(tmp_path)
 
         # Once the backing pixel data the header points to exists, it verifies.
         (case1_dir / "case1_T00.img").write_bytes(b"raw")
-        assert DataDownloadTools.VerifyDirLab4DCTData(tmp_path)
+        assert DownloadData.VerifyDirLab4DCTData(tmp_path)
 
     def test_verify_dirlab_4dct_pack_layout_requires_backing_data(
         self, tmp_path: Path
@@ -71,22 +71,22 @@ class TestDataDownloadTools:
         mhd_file.write_text(
             "ObjectType = Image\nElementDataFile = Case1Pack/Images/case1_T00_s.img\n"
         )
-        assert not DataDownloadTools.VerifyDirLab4DCTData(tmp_path)
+        assert not DownloadData.VerifyDirLab4DCTData(tmp_path)
 
         backing_file = tmp_path / "Case1Pack" / "Images" / "case1_T00_s.img"
         backing_file.parent.mkdir(parents=True)
         backing_file.write_bytes(b"raw")
-        assert DataDownloadTools.VerifyDirLab4DCTData(tmp_path)
+        assert DownloadData.VerifyDirLab4DCTData(tmp_path)
 
     def test_verify_chop_valve_4d_data(self, tmp_path: Path) -> None:
         """Verify CHOP data by expected CT or valve time-series paths."""
-        assert not DataDownloadTools.VerifyCHOPValve4DData(tmp_path)
+        assert not DownloadData.VerifyCHOPValve4DData(tmp_path)
 
         ct_dir = tmp_path / "CT"
         ct_dir.mkdir()
         (ct_dir / "RVOT28-Dias.nii.gz").write_bytes(b"nii")
 
-        assert DataDownloadTools.VerifyCHOPValve4DData(tmp_path)
+        assert DownloadData.VerifyCHOPValve4DData(tmp_path)
 
 
 class TestDownloadHeartData:
@@ -124,7 +124,7 @@ class TestDownloadHeartData:
         """Test that the TruncalValve 4D CT data file is downloaded."""
         data_file = download_test_data
 
-        assert DataDownloadTools.VerifySlicerHeartCTData(
+        assert DownloadData.VerifySlicerHeartCTData(
             test_directories["slicer_heart_data"]
         )
         assert data_file.exists(), f"Data file not found: {data_file}"
@@ -155,14 +155,14 @@ class TestDownloadHeartData:
             return archive_path
 
         urls_to_archives = {}
-        for index in range(1, DataDownloadTools.KCL_HEART_MODEL_MESH_COUNT + 1):
-            url = DataDownloadTools.KCL_HEART_MODEL_INDIVIDUAL_URL_TEMPLATE.format(
+        for index in range(1, DownloadData.KCL_HEART_MODEL_MESH_COUNT + 1):
+            url = DownloadData.KCL_HEART_MODEL_INDIVIDUAL_URL_TEMPLATE.format(
                 index=index
             )
             urls_to_archives[url] = make_archive(
                 f"{index:02d}.vtk", f"# vtk {index}\n".encode()
             )
-        urls_to_archives[DataDownloadTools.KCL_HEART_MODEL_AVERAGE_URL] = make_archive(
+        urls_to_archives[DownloadData.KCL_HEART_MODEL_AVERAGE_URL] = make_archive(
             "average.vtk", b"# vtk average\n"
         )
 
@@ -170,18 +170,18 @@ class TestDownloadHeartData:
             return open(urls_to_archives[url], "rb")
 
         monkeypatch.setattr(
-            "monai_physio.data_download_tools.urllib.request.urlopen", fake_urlopen
+            "monai_physio.download_data.urllib.request.urlopen", fake_urlopen
         )
 
         output_dir = tmp_path / "KCL-Heart-Model"
-        result_dir = DataDownloadTools.DownloadKCLHeartModelData(output_dir)
+        result_dir = DownloadData.DownloadKCLHeartModelData(output_dir)
 
         assert result_dir == output_dir
         assert (output_dir / "average_mesh.vtk").read_text() == "# vtk average\n"
-        for index in range(1, DataDownloadTools.KCL_HEART_MODEL_MESH_COUNT + 1):
+        for index in range(1, DownloadData.KCL_HEART_MODEL_MESH_COUNT + 1):
             mesh_file = output_dir / "input_meshes" / f"{index:02d}.vtk"
             assert mesh_file.read_text() == f"# vtk {index}\n"
-        assert DataDownloadTools.VerifyKCLHeartModelData(output_dir)
+        assert DownloadData.VerifyKCLHeartModelData(output_dir)
 
     def test_download_chop_valve4d_data(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -200,8 +200,8 @@ class TestDownloadHeartData:
         for (
             subdir_name,
             asset_name,
-        ) in DataDownloadTools.CHOP_VALVE4D_ASSETS.items():
-            url = DataDownloadTools.CHOP_VALVE4D_RELEASE_URL + asset_name
+        ) in DownloadData.CHOP_VALVE4D_ASSETS.items():
+            url = DownloadData.CHOP_VALVE4D_RELEASE_URL + asset_name
             urls_to_archives[url] = make_archive(
                 subdir_name,
                 f"{subdir_name}/{subdir_name}.txt",
@@ -212,14 +212,14 @@ class TestDownloadHeartData:
             return open(urls_to_archives[url], "rb")
 
         monkeypatch.setattr(
-            "monai_physio.data_download_tools.urllib.request.urlopen", fake_urlopen
+            "monai_physio.download_data.urllib.request.urlopen", fake_urlopen
         )
 
         output_dir = tmp_path / "CHOP-Valve4D"
-        result_dir = DataDownloadTools.DownloadCHOPValve4DData(output_dir)
+        result_dir = DownloadData.DownloadCHOPValve4DData(output_dir)
 
         assert result_dir == output_dir
-        for subdir_name in DataDownloadTools.CHOP_VALVE4D_ASSETS:
+        for subdir_name in DownloadData.CHOP_VALVE4D_ASSETS:
             extracted_file = output_dir / subdir_name / f"{subdir_name}.txt"
             assert extracted_file.read_text() == f"# {subdir_name}\n"
 
@@ -237,7 +237,7 @@ class TestDownloadHeartData:
     ) -> None:
         """Subdirectories with their expected marker files are not re-downloaded."""
         output_dir = tmp_path / "CHOP-Valve4D"
-        for subdir_name in DataDownloadTools.CHOP_VALVE4D_ASSETS:
+        for subdir_name in DownloadData.CHOP_VALVE4D_ASSETS:
             self._write_chop_valve4d_expected_marker(
                 output_dir / subdir_name, subdir_name
             )
@@ -246,10 +246,10 @@ class TestDownloadHeartData:
             raise AssertionError(f"Should not download populated subdir: {url}")
 
         monkeypatch.setattr(
-            "monai_physio.data_download_tools.urllib.request.urlopen", fake_urlopen
+            "monai_physio.download_data.urllib.request.urlopen", fake_urlopen
         )
 
-        result_dir = DataDownloadTools.DownloadCHOPValve4DData(output_dir)
+        result_dir = DownloadData.DownloadCHOPValve4DData(output_dir)
 
         assert result_dir == output_dir
 
@@ -280,8 +280,8 @@ class TestDownloadHeartData:
         for (
             subdir_name,
             asset_name,
-        ) in DataDownloadTools.CHOP_VALVE4D_ASSETS.items():
-            url = DataDownloadTools.CHOP_VALVE4D_RELEASE_URL + asset_name
+        ) in DownloadData.CHOP_VALVE4D_ASSETS.items():
+            url = DownloadData.CHOP_VALVE4D_RELEASE_URL + asset_name
             leaf = "RVOT28-Dias.mha" if subdir_name == "CT" else "frame_0000.vtk"
             urls_to_archives[url] = make_archive(
                 subdir_name, f"{subdir_name}/{leaf}", f"# {subdir_name}\n".encode()
@@ -291,10 +291,10 @@ class TestDownloadHeartData:
             return open(urls_to_archives[url], "rb")
 
         monkeypatch.setattr(
-            "monai_physio.data_download_tools.urllib.request.urlopen", fake_urlopen
+            "monai_physio.download_data.urllib.request.urlopen", fake_urlopen
         )
 
-        DataDownloadTools.DownloadCHOPValve4DData(output_dir)
+        DownloadData.DownloadCHOPValve4DData(output_dir)
 
         # The stray leftover file did not prevent Alterra from re-downloading.
         assert (partial_dir / "frame_0000.vtk").read_text() == "# Alterra\n"

--- a/tests/test_physics_informed_motion.py
+++ b/tests/test_physics_informed_motion.py
@@ -72,7 +72,7 @@ def _oriented(points: np.ndarray, tets: np.ndarray) -> np.ndarray:
     """Return *tets* with every element positively oriented.
 
     A real template arrives pre-oriented from
-    ``ContourTools.trim_tetrahedra_to_surface``; a mesh built ad hoc for a test
+    ``ProcessContours.trim_tetrahedra_to_surface``; a mesh built ad hoc for a test
     does not, so this stands in for that guarantee.
     """
     corners = points[tets]
@@ -343,7 +343,7 @@ def test_a_residual_on_the_wrong_device_is_refused() -> None:
     """
     import torch
 
-    from monai_physio.physicsnemo_tools import DistributedContext
+    from monai_physio.process_physicsnemo import DistributedContext
     from monai_physio.train_physicsnemo_physics_informed_motion import (
         TrainPhysicsNeMoPhysicsInformedMotion,
     )
@@ -383,7 +383,7 @@ def test_the_device_check_runs_without_a_driver() -> None:
 
     import torch
 
-    from monai_physio.physicsnemo_tools import DistributedContext
+    from monai_physio.process_physicsnemo import DistributedContext
     from monai_physio.train_physicsnemo_physics_informed_motion import (
         TrainPhysicsNeMoPhysicsInformedMotion,
         _resolved_device,
@@ -428,7 +428,7 @@ def test_a_residual_on_another_gpu_is_refused() -> None:
     """
     import torch
 
-    from monai_physio.physicsnemo_tools import DistributedContext
+    from monai_physio.process_physicsnemo import DistributedContext
     from monai_physio.train_physicsnemo_physics_informed_motion import (
         TrainPhysicsNeMoPhysicsInformedMotion,
     )
@@ -463,7 +463,7 @@ def test_the_epoch_log_separates_the_two_loss_terms() -> None:
     """
     import torch
 
-    from monai_physio.physicsnemo_tools import DistributedContext
+    from monai_physio.process_physicsnemo import DistributedContext
     from monai_physio.train_physicsnemo_physics_informed_motion import (
         TrainPhysicsNeMoPhysicsInformedMotion,
     )
@@ -514,7 +514,7 @@ def test_bind_reference_meshes_repairs_against_template_elements(tmp_path: Any) 
     """
     import torch
 
-    from monai_physio.physicsnemo_tools import DistributedContext
+    from monai_physio.process_physicsnemo import DistributedContext
     from monai_physio.train_physicsnemo_physics_informed_motion import (
         TrainPhysicsNeMoPhysicsInformedMotion,
     )
@@ -545,7 +545,7 @@ def test_bind_reference_meshes_tolerates_a_file_with_no_cells(tmp_path: Any) -> 
     """A reference file need not carry any cells at all; only its points do."""
     import torch
 
-    from monai_physio.physicsnemo_tools import DistributedContext
+    from monai_physio.process_physicsnemo import DistributedContext
     from monai_physio.train_physicsnemo_physics_informed_motion import (
         TrainPhysicsNeMoPhysicsInformedMotion,
     )

--- a/tests/test_process_contours.py
+++ b/tests/test_process_contours.py
@@ -13,21 +13,21 @@ import numpy as np
 import pytest
 import pyvista as pv
 
-from monai_physio.contour_tools import ContourTools
+from monai_physio.process_contours import ProcessContours
 
 
 @pytest.mark.slow
-class TestContourTools:
-    """Test suite for ContourTools functionality."""
+class TestProcessContours:
+    """Test suite for ProcessContours functionality."""
 
-    def test_contour_tools_initialization(self, contour_tools: ContourTools) -> None:
-        """Test that ContourTools initializes correctly."""
-        assert contour_tools is not None, "ContourTools not initialized"
-        print("\nContourTools initialized successfully")
+    def test_contour_tools_initialization(self, contour_tools: ProcessContours) -> None:
+        """Test that ProcessContours initializes correctly."""
+        assert contour_tools is not None, "ProcessContours not initialized"
+        print("\nProcessContours initialized successfully")
 
     def test_extract_contours_from_heart_mask(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_directories: dict[str, Path],
     ) -> None:
@@ -60,7 +60,7 @@ class TestContourTools:
 
     def test_extract_contours_from_lung_mask(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_directories: dict[str, Path],
     ) -> None:
@@ -89,7 +89,7 @@ class TestContourTools:
 
     def test_extract_contours_multiple_anatomy(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_directories: dict[str, Path],
     ) -> None:
@@ -127,7 +127,7 @@ class TestContourTools:
 
     def test_create_mask_from_mesh(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_images: list[Any],
         test_directories: dict[str, Path],
@@ -168,7 +168,7 @@ class TestContourTools:
 
     def test_merge_meshes(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_directories: dict[str, Path],
     ) -> None:
@@ -218,7 +218,7 @@ class TestContourTools:
 
     def test_transform_contours_identity(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_directories: dict[str, Path],
     ) -> None:
@@ -264,7 +264,7 @@ class TestContourTools:
 
     def test_transform_contours_with_deformation(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_directories: dict[str, Path],
     ) -> None:
@@ -313,7 +313,7 @@ class TestContourTools:
 
     def test_contours_from_both_time_points(
         self,
-        contour_tools: ContourTools,
+        contour_tools: ProcessContours,
         test_labelmaps: list[dict[str, Any]],
         test_directories: dict[str, Path],
     ) -> None:
@@ -360,7 +360,7 @@ class TestSaveCombinedSurfaces:
         }
 
         output_file = tmp_path / "combined.vtp"
-        ContourTools.save_combined_surfaces(surfaces, str(output_file))
+        ProcessContours.save_combined_surfaces(surfaces, str(output_file))
 
         merged = pv.read(str(output_file))
         label_ids = merged.cell_data["SegmentationLabelIds"]
@@ -382,7 +382,9 @@ class TestSaveCombinedSurfaces:
         )
 
         output_file = tmp_path / "combined_group.vtp"
-        ContourTools.save_combined_surfaces({"heart": group_surface}, str(output_file))
+        ProcessContours.save_combined_surfaces(
+            {"heart": group_surface}, str(output_file)
+        )
 
         merged = pv.read(str(output_file))
         assert set(np.unique(merged.cell_data["SegmentationLabelIds"])) == {0}
@@ -414,7 +416,7 @@ class TestRemeshCarriesCellLabels:
         return surface
 
     def test_remeshing_carries_both_cell_arrays(
-        self, contour_tools: ContourTools
+        self, contour_tools: ProcessContours
     ) -> None:
         """Anatomy splitting downstream reads these off the remeshed surface."""
         original = self._two_label_sphere()

--- a/tests/test_process_images.py
+++ b/tests/test_process_images.py
@@ -1,5 +1,5 @@
 """
-Tests for ImageTools functionality.
+Tests for ProcessImages functionality.
 
 Tests conversion between ITK and SimpleITK image formats for both
 scalar and vector images.
@@ -15,18 +15,18 @@ import numpy as np
 import pytest
 import SimpleITK as sitk
 
-from monai_physio.image_tools import ImageTools
+from monai_physio.process_images import ProcessImages
 
 
-class TestImageTools:
-    """Test suite for ImageTools conversions."""
+class TestProcessImages:
+    """Test suite for ProcessImages conversions."""
 
     @pytest.fixture
-    def image_tools(self) -> ImageTools:
-        """Create ImageTools instance."""
-        return ImageTools()
+    def image_tools(self) -> ProcessImages:
+        """Create ProcessImages instance."""
+        return ProcessImages()
 
-    def test_itk_to_sitk_scalar_image(self, image_tools: ImageTools) -> None:
+    def test_itk_to_sitk_scalar_image(self, image_tools: ProcessImages) -> None:
         """Test conversion of scalar ITK image to SimpleITK."""
         # Create a simple 3D scalar ITK image
         size = [10, 20, 30]
@@ -61,7 +61,7 @@ class TestImageTools:
 
         print("ITK to SimpleITK scalar conversion successful")
 
-    def test_sitk_to_itk_scalar_image(self, image_tools: ImageTools) -> None:
+    def test_sitk_to_itk_scalar_image(self, image_tools: ProcessImages) -> None:
         """Test conversion of scalar SimpleITK image to ITK."""
         # Create a simple 3D scalar SimpleITK image
         size = [10, 20, 30]
@@ -93,7 +93,7 @@ class TestImageTools:
 
         print("SimpleITK to ITK scalar conversion successful")
 
-    def test_roundtrip_scalar_image(self, image_tools: ImageTools) -> None:
+    def test_roundtrip_scalar_image(self, image_tools: ProcessImages) -> None:
         """Test roundtrip conversion: ITK -> SimpleITK -> ITK."""
         # Create ITK image
         size = [15, 25, 35]
@@ -129,7 +129,7 @@ class TestImageTools:
 
         print("Roundtrip scalar conversion successful")
 
-    def test_itk_to_sitk_vector_image(self, image_tools: ImageTools) -> None:
+    def test_itk_to_sitk_vector_image(self, image_tools: ProcessImages) -> None:
         """Test conversion of vector ITK image to SimpleITK."""
         # Create a 3D vector ITK image (like a displacement field)
         size = [8, 12, 16]
@@ -167,7 +167,7 @@ class TestImageTools:
 
         print("ITK to SimpleITK vector conversion successful")
 
-    def test_sitk_to_itk_vector_image(self, image_tools: ImageTools) -> None:
+    def test_sitk_to_itk_vector_image(self, image_tools: ProcessImages) -> None:
         """Test conversion of vector SimpleITK image to ITK."""
         # Create a 3D vector SimpleITK image
         size = [8, 12, 16]
@@ -198,7 +198,7 @@ class TestImageTools:
 
         print("SimpleITK to ITK vector conversion successful")
 
-    def test_roundtrip_vector_image(self, image_tools: ImageTools) -> None:
+    def test_roundtrip_vector_image(self, image_tools: ProcessImages) -> None:
         """Test roundtrip conversion for vector images: ITK -> SimpleITK -> ITK."""
         # Create ITK vector image
         size = [10, 15, 20]
@@ -238,13 +238,13 @@ class TestImageTools:
     @pytest.mark.slow
     def test_imwrite_imread_vd3(
         self,
-        image_tools: ImageTools,
+        image_tools: ProcessImages,
         test_transforms: dict[str, Any],
         test_images: list[Any],
         test_directories: dict[str, Path],
     ) -> None:
         """Test reading and writing double precision vector images."""
-        from monai_physio.transform_tools import TransformTools
+        from monai_physio.process_transforms import ProcessTransforms
 
         output_dir = test_directories["output"]
         img_output_dir = output_dir / "image_tools"
@@ -255,8 +255,8 @@ class TestImageTools:
 
         print("\nTesting imwriteVD3 and imreadVD3...")
 
-        # Generate a deformation field using TransformTools
-        transform_tools = TransformTools()
+        # Generate a deformation field using ProcessTransforms
+        transform_tools = ProcessTransforms()
         deformation_field = transform_tools.convert_transform_to_displacement_field(
             fixed_to_moving_transform, fixed_image
         )
@@ -330,13 +330,15 @@ def _make_synthetic_itk_image(
 
 
 class TestFlipImage:
-    """Unit tests for ImageTools.flip_image (axis flips and direction reset)."""
+    """Unit tests for ProcessImages.flip_image (axis flips and direction reset)."""
 
     @pytest.fixture
-    def image_tools(self) -> ImageTools:
-        return ImageTools()
+    def image_tools(self) -> ProcessImages:
+        return ProcessImages()
 
-    def test_flip_x_flips_along_last_array_axis(self, image_tools: ImageTools) -> None:
+    def test_flip_x_flips_along_last_array_axis(
+        self, image_tools: ProcessImages
+    ) -> None:
         """flip_x flips the image along the x (last) array dimension."""
         # Small image: ITK size (nx, ny, nz) = (3, 2, 2) -> array shape (2, 2, 3)
         shape_xyz = (3, 2, 2)
@@ -350,7 +352,7 @@ class TestFlipImage:
         )
 
     def test_flip_y_flips_along_middle_array_axis(
-        self, image_tools: ImageTools
+        self, image_tools: ProcessImages
     ) -> None:
         """flip_y flips the image along the y (middle) array dimension."""
         shape_xyz = (3, 2, 2)
@@ -363,7 +365,9 @@ class TestFlipImage:
             "flip_y should match np.flip(..., axis=1)"
         )
 
-    def test_flip_z_flips_along_first_array_axis(self, image_tools: ImageTools) -> None:
+    def test_flip_z_flips_along_first_array_axis(
+        self, image_tools: ProcessImages
+    ) -> None:
         """flip_z flips the image along the z (first) array dimension."""
         shape_xyz = (3, 2, 2)
         arr = np.arange(12, dtype=np.float32).reshape(2, 2, 3)
@@ -375,7 +379,7 @@ class TestFlipImage:
             "flip_z should match np.flip(..., axis=0)"
         )
 
-    def test_flip_xy_combines_flips(self, image_tools: ImageTools) -> None:
+    def test_flip_xy_combines_flips(self, image_tools: ProcessImages) -> None:
         """flip_x and flip_y together flip both axes."""
         shape_xyz = (3, 2, 2)
         arr = np.arange(12, dtype=np.float32).reshape(2, 2, 3)
@@ -385,7 +389,7 @@ class TestFlipImage:
         expected = np.flip(np.flip(arr, axis=2), axis=1)
         assert np.allclose(out_arr, expected)
 
-    def test_no_flip_returns_same_image(self, image_tools: ImageTools) -> None:
+    def test_no_flip_returns_same_image(self, image_tools: ProcessImages) -> None:
         """With no flip flags, image is returned unchanged."""
         shape_xyz = (2, 2, 2)
         arr = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
@@ -396,7 +400,9 @@ class TestFlipImage:
         out_arr = itk.array_from_image(out)
         assert np.allclose(out_arr, arr)
 
-    def test_mask_flipped_in_lockstep_with_image(self, image_tools: ImageTools) -> None:
+    def test_mask_flipped_in_lockstep_with_image(
+        self, image_tools: ProcessImages
+    ) -> None:
         """When a mask is provided, it is flipped with the same axes as the image."""
         shape_xyz = (3, 2, 2)
         arr = np.arange(12, dtype=np.float32).reshape(2, 2, 3)
@@ -418,7 +424,7 @@ class TestFlipImage:
         assert np.allclose(out_msk_arr, (out_img_arr % 2 == 0).astype(np.float32))
 
     def test_flip_and_make_identity_sets_direction_to_identity(
-        self, image_tools: ImageTools
+        self, image_tools: ProcessImages
     ) -> None:
         """flip_and_make_identity flips as needed and sets direction matrix to identity."""
         shape_xyz = (2, 2, 2)
@@ -434,7 +440,7 @@ class TestFlipImage:
         )
 
     def test_flip_and_make_identity_with_mask_sets_both_directions_to_identity(
-        self, image_tools: ImageTools
+        self, image_tools: ProcessImages
     ) -> None:
         """With mask and flip_and_make_identity, both image and mask get identity direction."""
         shape_xyz = (2, 2, 2)
@@ -455,7 +461,7 @@ class TestFlipImage:
             )
 
     def test_keep_largest_connected_component_keeps_largest_blob(
-        self, image_tools: ImageTools
+        self, image_tools: ProcessImages
     ) -> None:
         """Pure connected-component unit test on a synthetic 10x10x10 mask
         with two disjoint blobs (shape (X, Y, Z) = (10, 10, 10))."""
@@ -471,7 +477,7 @@ class TestFlipImage:
         assert result_arr[5:9, 5:9, 5:9].sum() == arr[5:9, 5:9, 5:9].sum()
 
     def test_keep_largest_connected_component_no_foreground_returns_empty(
-        self, image_tools: ImageTools
+        self, image_tools: ProcessImages
     ) -> None:
         """An all-background mask (shape (X, Y, Z) = (8, 8, 8)) returns
         an all-background result."""
@@ -485,15 +491,15 @@ class TestFlipImage:
 
 
 class TestResampleImageByScale:
-    """Unit tests for ImageTools.resample_image_by_scale."""
+    """Unit tests for ProcessImages.resample_image_by_scale."""
 
     @pytest.fixture
-    def image_tools(self) -> ImageTools:
-        return ImageTools()
+    def image_tools(self) -> ProcessImages:
+        return ProcessImages()
 
     @pytest.mark.parametrize("scale", [0.5, 0.25, 2.0])
     def test_physical_extent_is_preserved(
-        self, image_tools: ImageTools, scale: float
+        self, image_tools: ProcessImages, scale: float
     ) -> None:
         """Voxel count scales while the physical extent stays put."""
         itk_image = _make_synthetic_itk_image((8, 6, 4))
@@ -509,7 +515,7 @@ class TestResampleImageByScale:
             size * np.asarray(itk_image.GetSpacing()),
         ), "resampling must not change the physical extent"
 
-    def test_direction_is_unchanged(self, image_tools: ImageTools) -> None:
+    def test_direction_is_unchanged(self, image_tools: ProcessImages) -> None:
         """A left-handed direction survives resampling untouched."""
         direction = np.diag([1.0, 1.0, -1.0])
         itk_image = _make_synthetic_itk_image((8, 6, 4), direction=direction)
@@ -518,7 +524,9 @@ class TestResampleImageByScale:
 
         assert np.allclose(itk.array_from_matrix(out.GetDirection()), direction)
 
-    def test_nearest_neighbor_keeps_input_values(self, image_tools: ImageTools) -> None:
+    def test_nearest_neighbor_keeps_input_values(
+        self, image_tools: ProcessImages
+    ) -> None:
         """Nearest-neighbor resampling introduces no new intensities."""
         arr = np.zeros((4, 4, 4), dtype=np.float32)
         arr[1:3, 1:3, 1:3] = 7.0
@@ -532,7 +540,7 @@ class TestResampleImageByScale:
 
     @pytest.mark.parametrize("scale", [0.0, -1.0])
     def test_non_positive_scale_raises(
-        self, image_tools: ImageTools, scale: float
+        self, image_tools: ProcessImages, scale: float
     ) -> None:
         """A scale of zero or less is rejected."""
         itk_image = _make_synthetic_itk_image((4, 4, 4))

--- a/tests/test_process_labelmaps.py
+++ b/tests/test_process_labelmaps.py
@@ -1,5 +1,5 @@
 """
-Tests for LabelmapTools functionality.
+Tests for ProcessLabelmaps functionality.
 
 Covers thresholding a multi-label labelmap into a binary registration mask,
 physically isotropic dilation that respects per-axis spacing, and forcing
@@ -12,18 +12,18 @@ import itk
 import numpy as np
 import pytest
 
-from monai_physio.labelmap_tools import LabelmapTools
+from monai_physio.process_labelmaps import ProcessLabelmaps
 
 
-class TestLabelmapTools:
-    """Test suite for LabelmapTools.convert_labelmap_to_mask."""
+class TestProcessLabelmaps:
+    """Test suite for ProcessLabelmaps.convert_labelmap_to_mask."""
 
     @pytest.fixture
-    def labelmap_tools(self) -> LabelmapTools:
-        """Create LabelmapTools instance."""
-        return LabelmapTools()
+    def labelmap_tools(self) -> ProcessLabelmaps:
+        """Create ProcessLabelmaps instance."""
+        return ProcessLabelmaps()
 
-    def test_threshold_without_dilation(self, labelmap_tools: LabelmapTools) -> None:
+    def test_threshold_without_dilation(self, labelmap_tools: ProcessLabelmaps) -> None:
         """Every non-zero label becomes foreground; no dilation grows it."""
         arr = np.zeros((5, 5, 5), dtype=np.uint8)
         arr[2, 2, 2] = 3  # non-zero label id
@@ -37,7 +37,7 @@ class TestLabelmapTools:
         assert int(mask_arr.sum()) == 1
         assert mask_arr[2, 2, 2] == 1
 
-    def test_dilation_grows_mask(self, labelmap_tools: LabelmapTools) -> None:
+    def test_dilation_grows_mask(self, labelmap_tools: ProcessLabelmaps) -> None:
         """Positive dilation_in_mm grows the mask but keeps the seed voxel."""
         arr = np.zeros((5, 5, 5), dtype=np.uint8)
         arr[2, 2, 2] = 3
@@ -52,7 +52,7 @@ class TestLabelmapTools:
         assert dilated_arr[2, 2, 2] == 1
 
     def test_dilation_respects_anisotropic_spacing(
-        self, labelmap_tools: LabelmapTools
+        self, labelmap_tools: ProcessLabelmaps
     ) -> None:
         """A 5 mm radius covers more voxels along the finely spaced axis."""
         arr = np.zeros((11, 11, 11), dtype=np.uint8)
@@ -74,7 +74,9 @@ class TestLabelmapTools:
         assert dilated[5, 5, 0] == 0
         assert dilated[5, 5, 10] == 0
 
-    def test_exclude_labels_removes_voxels(self, labelmap_tools: LabelmapTools) -> None:
+    def test_exclude_labels_removes_voxels(
+        self, labelmap_tools: ProcessLabelmaps
+    ) -> None:
         """Excluded labels become background before thresholding."""
         arr = np.zeros((5, 5, 5), dtype=np.uint8)
         arr[1, 1, 1] = 2  # kept
@@ -92,7 +94,9 @@ class TestLabelmapTools:
         assert mask_arr[3, 3, 3] == 0
         assert int(mask_arr.sum()) == 1
 
-    def test_preserves_image_information(self, labelmap_tools: LabelmapTools) -> None:
+    def test_preserves_image_information(
+        self, labelmap_tools: ProcessLabelmaps
+    ) -> None:
         """Origin, spacing, and direction are copied from the labelmap."""
         arr = np.zeros((4, 4, 4), dtype=np.uint8)
         arr[2, 2, 2] = 1

--- a/tests/test_process_physicsnemo.py
+++ b/tests/test_process_physicsnemo.py
@@ -15,7 +15,7 @@ import numpy as np
 import pytest
 import pyvista as pv
 
-from monai_physio import physicsnemo_tools as pnt
+from monai_physio import process_physicsnemo as pnt
 
 _TARGET_ARRAY = "displacement"
 _STAGES = (0.0, 0.5)
@@ -78,7 +78,7 @@ def test_parse_manifest_rejects_a_manifest_without_a_fitted_reference_mesh(
     manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
     with pytest.raises(ValueError, match="fitted_reference_mesh"):
-        pnt.PhysicsNemoTools.parse_manifest(manifest_path)
+        pnt.ProcessPhysicsNemo.parse_manifest(manifest_path)
 
 
 def _without_physicsnemo(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -110,7 +110,7 @@ def test_multi_process_launch_without_physicsnemo_is_refused(
     _without_physicsnemo(monkeypatch)
 
     with pytest.raises(ImportError, match="1 of 8"):
-        pnt.PhysicsNemoTools.distributed_context()
+        pnt.ProcessPhysicsNemo.distributed_context()
 
 
 def test_a_single_process_without_physicsnemo_still_runs(
@@ -122,7 +122,7 @@ def test_a_single_process_without_physicsnemo_still_runs(
     monkeypatch.setenv("WORLD_SIZE", "1")
     _without_physicsnemo(monkeypatch)
 
-    context = pnt.PhysicsNemoTools.distributed_context()
+    context = pnt.ProcessPhysicsNemo.distributed_context()
 
     assert context.world_size == 1
     assert context.rank == 0
@@ -136,7 +136,7 @@ def test_parse_manifest_round_trips_the_new_schema(tmp_path: Path) -> None:
         tmp_path, [_targets(n_points, 3, 0.0), _targets(n_points, 3, 1.0)]
     )
 
-    manifest = pnt.PhysicsNemoTools.parse_manifest(manifest_path)
+    manifest = pnt.ProcessPhysicsNemo.parse_manifest(manifest_path)
 
     assert manifest.subject_id == "subject_01"
     assert manifest.target_array == _TARGET_ARRAY
@@ -156,7 +156,7 @@ def test_parse_manifest_requires_the_target_array(tmp_path: Path) -> None:
     manifest_path.write_text(json.dumps(data), encoding="utf-8")
 
     with pytest.raises(ValueError, match="target_array"):
-        pnt.PhysicsNemoTools.parse_manifest(manifest_path)
+        pnt.ProcessPhysicsNemo.parse_manifest(manifest_path)
 
 
 @pytest.mark.parametrize("n_target", [1, 3, 6])
@@ -170,7 +170,7 @@ def test_load_target_array_returns_two_dimensional_targets(
     mesh_file = tmp_path / "target.vtp"
     mesh.save(str(mesh_file))
 
-    loaded = pnt.PhysicsNemoTools.load_target_array(mesh_file, _TARGET_ARRAY)
+    loaded = pnt.ProcessPhysicsNemo.load_target_array(mesh_file, _TARGET_ARRAY)
 
     assert loaded.shape == (mesh.n_points, n_target)
     assert np.allclose(loaded, values)
@@ -181,7 +181,7 @@ def test_load_target_array_reports_missing_arrays(tmp_path: Path) -> None:
     _sphere().save(str(mesh_file))
 
     with pytest.raises(KeyError, match=_TARGET_ARRAY):
-        pnt.PhysicsNemoTools.load_target_array(mesh_file, _TARGET_ARRAY)
+        pnt.ProcessPhysicsNemo.load_target_array(mesh_file, _TARGET_ARRAY)
 
 
 def test_dataset_returns_the_stored_targets_scaled(tmp_path: Path) -> None:
@@ -189,7 +189,7 @@ def test_dataset_returns_the_stored_targets_scaled(tmp_path: Path) -> None:
     n_points = _sphere().n_points
     stored = [_targets(n_points, 3, 0.0), _targets(n_points, 3, 1.0)]
     manifest_path = _write_subject(tmp_path, stored)
-    manifest = pnt.PhysicsNemoTools.parse_manifest(manifest_path)
+    manifest = pnt.ProcessPhysicsNemo.parse_manifest(manifest_path)
 
     target_scale = 2.0
     coords_norm = np.zeros((n_points, 3), dtype=np.float32)
@@ -224,7 +224,7 @@ def test_mesh_to_edge_index_preserves_volumetric_point_ids(tmp_path: Path) -> No
 
     volume = pv.UnstructuredGrid(pv.Box().triangulate().delaunay_3d())
 
-    edge_index = pnt.PhysicsNemoTools.mesh_to_edge_index(volume)
+    edge_index = pnt.ProcessPhysicsNemo.mesh_to_edge_index(volume)
 
     assert isinstance(edge_index, torch.Tensor)
     assert edge_index.shape[0] == 2

--- a/tests/test_process_transforms.py
+++ b/tests/test_process_transforms.py
@@ -14,8 +14,8 @@ import pytest
 import pyvista as pv
 import vtk
 
-from monai_physio.image_tools import ImageTools
-from monai_physio.transform_tools import TransformTools
+from monai_physio.process_images import ProcessImages
+from monai_physio.process_transforms import ProcessTransforms
 
 
 def _sphere_shell_samples(
@@ -72,7 +72,7 @@ def test_smooth_deformation_field_transform_stops_sliding_outside_the_mask() -> 
     weight_image = itk.image_from_array(weights)
     mask_image = itk.image_from_array(interior)
 
-    tools = TransformTools()
+    tools = ProcessTransforms()
 
     def spread(samples: Any, restrict: bool) -> Any:
         field = _as_field(samples)
@@ -116,7 +116,7 @@ def test_smooth_deformation_field_transform_stops_sliding_outside_the_mask() -> 
 def test_smooth_deformation_field_transform_rejects_a_lone_normal_or_mask() -> None:
     """The normals say what to project onto, the mask says where to."""
     normals, radial, _, weights, interior = _sphere_shell_samples()
-    tools = TransformTools()
+    tools = ProcessTransforms()
 
     with pytest.raises(ValueError, match="must be given together"):
         tools.smooth_deformation_field_transform(
@@ -142,7 +142,9 @@ def test_generate_grid_image_clamps_boundary_lines() -> None:
     image_arr[-1, -1, -1] = 5.0
     image = itk.image_from_array(image_arr)
 
-    grid_image = TransformTools().generate_grid_image(image, grid_size=2, line_width=3)
+    grid_image = ProcessTransforms().generate_grid_image(
+        image, grid_size=2, line_width=3
+    )
     grid_arr = itk.array_from_image(grid_image)
 
     assert grid_arr.shape == image_arr.shape
@@ -194,7 +196,7 @@ def test_composing_at_unit_weight_chains_the_inputs_instead_of_rasterizing() -> 
     directions together retained 36.6 GB to hold what is really an affine plus a
     175-cubed field.
     """
-    transform_tools = TransformTools()
+    transform_tools = ProcessTransforms()
     affine, translation = _affine_and_translation()
 
     composed = transform_tools.combine_displacement_field_transforms(
@@ -237,7 +239,7 @@ def test_composing_with_a_weight_or_a_blur_still_rasterizes() -> None:
     This is the half of the branch the existing callers rely on: scaling or
     smoothing a transform cannot be expressed by chaining it unchanged.
     """
-    transform_tools = TransformTools()
+    transform_tools = ProcessTransforms()
     affine, translation = _affine_and_translation()
     reference = _small_reference_image()
 
@@ -254,8 +256,8 @@ def test_composing_with_a_weight_or_a_blur_still_rasterizes() -> None:
 
 
 @pytest.mark.slow
-class TestTransformTools:
-    """Test suite for TransformTools functionality."""
+class TestProcessTransforms:
+    """Test suite for ProcessTransforms functionality."""
 
     @pytest.fixture(scope="class")
     def test_contour(self, test_images: list[Any]) -> Any:
@@ -265,15 +267,15 @@ class TestTransformTools:
         return sphere
 
     def test_transform_tools_initialization(
-        self, transform_tools: TransformTools
+        self, transform_tools: ProcessTransforms
     ) -> None:
-        """Test that TransformTools initializes correctly."""
-        assert transform_tools is not None, "TransformTools not initialized"
-        print("\nTransformTools initialized successfully")
+        """Test that ProcessTransforms initializes correctly."""
+        assert transform_tools is not None, "ProcessTransforms not initialized"
+        print("\nProcessTransforms initialized successfully")
 
     def test_transform_image_linear(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
         test_directories: dict[str, Path],
@@ -316,7 +318,7 @@ class TestTransformTools:
 
     def test_transform_image_nearest(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
         test_directories: dict[str, Path],
@@ -353,7 +355,7 @@ class TestTransformTools:
 
     def test_transform_image_sinc(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
         test_directories: dict[str, Path],
@@ -390,7 +392,7 @@ class TestTransformTools:
 
     def test_transform_image_invalid_method(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
     ) -> None:
@@ -413,7 +415,7 @@ class TestTransformTools:
 
     def test_transform_pvcontour_without_deformation(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_contour: Any,
         test_transforms: dict[str, Any],
     ) -> None:
@@ -448,7 +450,7 @@ class TestTransformTools:
 
     def test_transform_pvcontour_with_deformation(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_contour: Any,
         test_transforms: dict[str, Any],
         test_directories: dict[str, Path],
@@ -491,7 +493,7 @@ class TestTransformTools:
 
     def test_transform_dataset_preserves_unstructured_grid_topology(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
     ) -> None:
         """Transform UnstructuredGrid points with image shape (Z, Y, X) = (3, 3, 3)."""
         points = np.array(
@@ -528,7 +530,7 @@ class TestTransformTools:
 
     def test_convert_transform_to_displacement_field(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
         test_directories: dict[str, Path],
@@ -560,7 +562,7 @@ class TestTransformTools:
         print(f"  Field shape: {field_arr.shape}")
 
         # Save deformation field using imwriteVD3 (for double precision vector images)
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
         image_tools.imwriteVD3(
             deformation_field,
             str(tfm_output_dir / "deformation_field.mha"),
@@ -568,7 +570,7 @@ class TestTransformTools:
         )
 
     def test_convert_vtk_matrix_to_itk_transform(
-        self, transform_tools: TransformTools
+        self, transform_tools: ProcessTransforms
     ) -> None:
         """Test converting VTK matrix to ITK transform."""
         # Create a VTK matrix
@@ -601,7 +603,7 @@ class TestTransformTools:
 
     def test_compute_jacobian_determinant_from_field(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
         test_directories: dict[str, Path],
@@ -652,7 +654,7 @@ class TestTransformTools:
 
     def test_detect_folding_in_field(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
     ) -> None:
@@ -682,7 +684,7 @@ class TestTransformTools:
 
     def test_interpolate_transforms(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
     ) -> None:
@@ -719,7 +721,7 @@ class TestTransformTools:
 
     def test_combine_displacement_field_transforms(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
     ) -> None:
@@ -833,7 +835,7 @@ class TestTransformTools:
 
     def test_smooth_transform(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
     ) -> None:
@@ -859,7 +861,7 @@ class TestTransformTools:
 
     def test_combine_transforms_with_masks(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
     ) -> None:
@@ -906,7 +908,7 @@ class TestTransformTools:
 
     def test_multiple_transform_applications(
         self,
-        transform_tools: TransformTools,
+        transform_tools: ProcessTransforms,
         test_transforms: dict[str, Any],
         test_images: list[Any],
     ) -> None:
@@ -939,7 +941,7 @@ class TestTransformTools:
         print("Multiple sequential transforms applied")
 
     def test_identity_transform(
-        self, transform_tools: TransformTools, test_images: list[Any]
+        self, transform_tools: ProcessTransforms, test_images: list[Any]
     ) -> None:
         """Test that identity transform doesn't change the image."""
         moving_image = test_images[1]

--- a/tests/test_register_images_ants.py
+++ b/tests/test_register_images_ants.py
@@ -15,8 +15,8 @@ import itk
 import numpy as np
 import pytest
 
+from monai_physio.process_transforms import ProcessTransforms
 from monai_physio.register_images_ants import RegisterImagesANTS
-from monai_physio.transform_tools import TransformTools
 
 from .conftest import KnownShiftCase
 
@@ -268,7 +268,7 @@ class TestRegisterImagesANTS:
         print("\nApplying transform to moving image...")
 
         # Apply transform
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
         registered_image = transform_tools.transform_image(
             moving_image,
             fixed_to_moving_transform,
@@ -429,7 +429,7 @@ class TestRegisterImagesANTS:
         threshold = float(np.percentile(fixed_arr, 70.0))
         foreground = fixed_arr > threshold
 
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
 
         def warp_score(fixed_to_moving_transform: Any) -> float:
             warped = transform_tools.transform_image(
@@ -533,7 +533,7 @@ class TestRegisterImagesANTS:
         registrar_ANTS.set_fixed_image(fixed_image)
         result = registrar_ANTS.register_from(translation, moving_image)
 
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
         warped = transform_tools.transform_image(
             moving_image,
             result["fixed_to_moving_transform"],
@@ -572,7 +572,7 @@ class TestRegisterImagesANTS:
             fixed_arr, itk.array_from_image(moving_image), foreground
         )
 
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
         for transform_type in ("Rigid", "Affine"):
             registrar = RegisterImagesANTS()
             registrar.set_modality("ct")
@@ -925,10 +925,10 @@ class TestRegisterImagesANTS:
         print("\nTesting displacement field transform conversion cycle...")
 
         # Create a simple displacement field with double precision
-        # Use ImageTools to create the correct type
-        from monai_physio.image_tools import ImageTools
+        # Use ProcessImages to create the correct type
+        from monai_physio.process_images import ProcessImages
 
-        image_tools = ImageTools()
+        image_tools = ProcessImages()
 
         # Create displacement array (small random displacements)
         ref_size = itk.size(reference_image)

--- a/tests/test_register_images_greedy.py
+++ b/tests/test_register_images_greedy.py
@@ -12,8 +12,8 @@ import itk
 import numpy as np
 import pytest
 
+from monai_physio.process_transforms import ProcessTransforms
 from monai_physio.register_images_greedy import RegisterImagesGreedy
-from monai_physio.transform_tools import TransformTools
 
 from .conftest import KnownAffineCase, KnownShiftCase
 
@@ -333,7 +333,7 @@ class TestRegisterImagesGreedy:
         result = registrar_greedy.register(moving_image=moving_image)
 
         fixed_to_moving_transform = result["fixed_to_moving_transform"]
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
         registered_image = transform_tools.transform_image(
             moving_image,
             fixed_to_moving_transform,

--- a/tests/test_register_images_icon.py
+++ b/tests/test_register_images_icon.py
@@ -13,8 +13,8 @@ import itk
 import numpy as np
 import pytest
 
+from monai_physio.process_transforms import ProcessTransforms
 from monai_physio.register_images_icon import RegisterImagesICON
-from monai_physio.transform_tools import TransformTools
 
 from .conftest import KnownShiftCase
 
@@ -396,7 +396,7 @@ class TestRegisterImagesICON:
         print("\nApplying ICON transform to moving image...")
 
         # Apply transform
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
         registered_image = transform_tools.transform_image(
             moving_image,
             fixed_to_moving_transform,

--- a/tests/test_register_time_series_images.py
+++ b/tests/test_register_time_series_images.py
@@ -13,12 +13,12 @@ import numpy as np
 import pytest
 
 from monai_physio import (
+    ProcessTests,
+    ProcessTransforms,
     RegisterImagesGreedy,
     RegisterImagesGreedyICON,
     RegisterImagesICON,
     RegisterTimeSeriesImages,
-    TestTools,
-    TransformTools,
 )
 
 
@@ -185,7 +185,7 @@ class TestRegisterTimeSeriesImages:
         print(f"  Transforms generated: {len(fixed_to_moving_transforms)}")
         print(f"  Average loss: {np.mean(losses):.6f}")
 
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
         moving_image = transform_tools.transform_image(
             moving_images[0],
             fixed_to_moving_transforms[0],
@@ -193,7 +193,7 @@ class TestRegisterTimeSeriesImages:
             interpolation_method="linear",
         )
 
-        test_tools = TestTools(
+        test_tools = ProcessTests(
             class_name=self._class_name,
             results_dir=test_directories["output"] / self._class_name,
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -239,7 +239,7 @@ class TestRegisterTimeSeriesImages:
         fixed_to_moving_transforms = result["fixed_to_moving_transforms"]
         losses = result["losses"]
 
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
         moving_image = transform_tools.transform_image(
             moving_images[0],
             fixed_to_moving_transforms[0],
@@ -256,7 +256,7 @@ class TestRegisterTimeSeriesImages:
         print("Time series registration from the middle frame complete")
         print(f"  Losses: {[f'{loss:.6f}' for loss in losses]}")
 
-        test_tools = TestTools(
+        test_tools = ProcessTests(
             class_name=self._class_name,
             results_dir=test_directories["output"] / self._class_name,
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -390,7 +390,7 @@ class TestRegisterTimeSeriesImages:
         fixed_to_moving_transforms = result["fixed_to_moving_transforms"]
 
         # Apply transform to first moving image
-        transform_tools = TransformTools()
+        transform_tools = ProcessTransforms()
         registered_image = transform_tools.transform_image(
             moving_images[0],
             fixed_to_moving_transforms[0],
@@ -405,7 +405,7 @@ class TestRegisterTimeSeriesImages:
         print(f"  Registered image size: {itk.size(registered_image)}")
 
         # Save registered image
-        test_tools = TestTools(
+        test_tools = ProcessTests(
             class_name=self._class_name,
             results_dir=test_directories["output"] / self._class_name,
             baselines_dir=test_directories["baselines"] / self._class_name,

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -17,10 +17,10 @@ environment variable, so a runner can keep them off the checkout.
 Output is compared two ways, because neither catches what the other does:
 
 1. Screenshots.  Each tutorial saves PNGs to its output directory, which
-   ``TestTools.compare_result_to_baseline_image`` compares against a stored
+   ``ProcessTests.compare_result_to_baseline_image`` compares against a stored
    baseline with tolerances loose enough to survive a driver change.
 2. Metrics.  The JSON and CSV of numbers each tutorial already reports, which
-   ``TestTools.compare_result_to_baseline_metrics`` compares within tolerance.
+   ``ProcessTests.compare_result_to_baseline_metrics`` compares within tolerance.
    Two renderings can agree pixel for pixel while the numbers behind them move,
    and only this catches that.  Wall-clock files (``*_runtimes.csv``) are left
    out, being a property of the host rather than of the result.
@@ -48,7 +48,7 @@ import pytest
 import pyvista as pv
 from parameters_base import ParametersBase
 
-from monai_physio.test_tools import TestTools
+from monai_physio.process_tests import ProcessTests
 
 from .conftest import skip_or_fail_missing_data, tutorial_data_is_required
 
@@ -75,13 +75,13 @@ _TUTORIAL_WEIGHTS = _TUTORIAL_PATHS.weights_directory(test_mode=True)
 
 @pytest.fixture(autouse=True)
 def _enable_tutorial_test_mode(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Run tutorials against repo data/test through TestTools mode switching."""
+    """Run tutorials against repo data/test through ProcessTests mode switching."""
     monkeypatch.setenv("MONAI_PHYSIO_RUNNING_AS_TEST", "1")
 
 
 def _compare_screenshots(
     screenshots: list[Path],
-    tt: TestTools,
+    tt: ProcessTests,
 ) -> None:
     """Read each PNG as itk.Image and compare against baseline."""
     if not screenshots:
@@ -98,7 +98,7 @@ def _compare_screenshots(
         ), f"Screenshot baseline mismatch: {png_path.name}"
 
 
-def _compare_metrics(tt: TestTools, filenames: list[str]) -> None:
+def _compare_metrics(tt: ProcessTests, filenames: list[str]) -> None:
     """Compare each reported metrics file against its baseline.
 
     Screenshots catch what a rendering shows; these catch the accuracy drift
@@ -142,9 +142,11 @@ def _require_files(directory: Path, pattern: str, reason: str) -> None:
         skip_or_fail_missing_data(f"No {pattern} under {directory}. {reason}")
 
 
-def _baseline_tools(class_name: str, out_dir: Path, baselines_root: Path) -> TestTools:
-    """TestTools reading the tutorial's own output directory."""
-    return TestTools(
+def _baseline_tools(
+    class_name: str, out_dir: Path, baselines_root: Path
+) -> ProcessTests:
+    """ProcessTests reading the tutorial's own output directory."""
+    return ProcessTests(
         class_name=class_name,
         results_dir=out_dir,
         baselines_dir=baselines_root / class_name,
@@ -165,7 +167,7 @@ class TestTutorial01HeartGatedCTToUSD:
         assert Path(results["usd_file"]).exists(), "USD file should exist"
         assert results["screenshots"], "Tutorial 1 should produce screenshots"
 
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=self._class_name,
             results_dir=out_dir,
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -324,7 +326,7 @@ class TestTutorial03HeartReconstructHighres4DCT:
         for f in results["reconstructed_files"]:
             assert f.exists(), f"Reconstructed frame missing: {f}"
 
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=self._class_name,
             results_dir=out_dir,
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -361,7 +363,7 @@ class TestTutorial03LungReconstructHighres4DCT:
         for f in results["reconstructed_files"]:
             assert f.exists(), f"Reconstructed frame missing: {f}"
 
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=self._class_name,
             results_dir=out_dir,
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -388,7 +390,7 @@ class TestTutorial04HeartCTToVTK:
         results = _run_tutorial_script("tutorial_04_heart_ct_to_vtk.py")
         assert results["surface_file"].exists(), "Combined VTP surface should exist"
 
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=self._class_name,
             results_dir=out_dir,
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -430,7 +432,7 @@ class TestTutorial04DukeHeartLabelmapToVTK:
 class TestTutorial04LungCTToVTK:
     """End-to-end test for tutorial_04_lung_ct_to_vtk.py."""
 
-    _class_name = "tutorial_04_lung"  # the script's project_name, its TestTools key
+    _class_name = "tutorial_04_lung"  # the script's project_name, its ProcessTests key
 
     def test_run(
         self,
@@ -486,7 +488,7 @@ class TestTutorial05HeartVTKToUSD:
             "Per-structure surfaces expected, so that each becomes its own prim"
         )
 
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=self._class_name,
             results_dir=out_dir,
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -551,7 +553,7 @@ class TestTutorial06CreateStatisticalModel:
         assert results["model_file"].exists(), "pca_model.json should exist"
         assert results["mean_surface_file"].exists(), "Mean surface VTP should exist"
 
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=self._class_name,
             results_dir=out_dir,
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -657,7 +659,7 @@ class TestTutorial07FitStatisticalModelToPatient:
         )
         assert registered_surface_file.exists(), "Registered surface VTP should exist"
 
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=self._class_name,
             results_dir=out_dir,
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -914,7 +916,7 @@ class TestTutorial09LungTrainPhysicsNeMoMGN:
 
         # The model goes to the shared weights directory; the manifests, the
         # evaluation and the screenshots stay under the tutorial's output.
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=self._class_name,
             results_dir=_TUTORIAL_OUTPUT / "tutorial_09_lung_mgn",
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -981,7 +983,7 @@ class TestTutorial10LungInferPhysicsNeMoMGN:
         assert Path(results["usd_file"]).exists(), "USD file should exist"
 
         out_dir = _TUTORIAL_OUTPUT / "tutorial_10_lung_mgn" / "Case1Pack"
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=self._class_name,
             results_dir=out_dir,
             baselines_dir=test_directories["baselines"] / self._class_name,
@@ -1402,7 +1404,7 @@ class TestTutorial14LungShapeParameterSweep:
 
 
 # Both Tutorial 15 variants clamp themselves to this many folds under
-# TestTools.running_as_test, which the autouse fixture above turns on.
+# ProcessTests.running_as_test, which the autouse fixture above turns on.
 _TUTORIAL_15_TEST_MODE_FOLDS = 2
 
 

--- a/tests/test_usd_merge.py
+++ b/tests/test_usd_merge.py
@@ -11,7 +11,7 @@ from typing import Any
 import pytest
 from pxr import Usd, UsdGeom, UsdShade
 
-from monai_physio import USDTools
+from monai_physio import ProcessUSD
 
 
 def analyze_usd_file(filepath: str) -> dict[str, Any]:
@@ -111,7 +111,7 @@ class TestUSDMerge:
     ) -> None:
         """Test merge_usd_files() manual copy method."""
         # Merge files using manual copy method
-        usd_tools = USDTools()
+        usd_tools = ProcessUSD()
         merged_file = output_dir / "test_merged_copy.usd"
 
         usd_tools.merge_usd_files(
@@ -172,7 +172,7 @@ class TestUSDMerge:
     ) -> None:
         """Test merge_usd_files_flattened() composition method."""
         # Merge files using flattened method
-        usd_tools = USDTools()
+        usd_tools = ProcessUSD()
         merged_file = output_dir / "test_merged_flattened.usd"
 
         usd_tools.merge_usd_files_flattened(
@@ -229,7 +229,7 @@ class TestUSDMerge:
         self, test_data_files: dict[str, str], output_dir: Path
     ) -> None:
         """Verify both merge methods produce equivalent results."""
-        usd_tools = USDTools()
+        usd_tools = ProcessUSD()
 
         # Merge with both methods
         copy_file = output_dir / "test_copy.usd"

--- a/tests/test_usd_time_preservation.py
+++ b/tests/test_usd_time_preservation.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 import pytest
 from pxr import Usd, UsdGeom
 
-from monai_physio import USDTools
+from monai_physio import ProcessUSD
 
 
 def get_time_metadata(filepath: str) -> dict[str, Any]:
@@ -131,7 +131,7 @@ class TestUSDTimePreservation:
         output_dir: Path,
     ) -> None:
         """Test that merge_usd_files() preserves time metadata."""
-        usd_tools = USDTools()
+        usd_tools = ProcessUSD()
         merged_file = output_dir / "test_time_copy.usd"
 
         usd_tools.merge_usd_files(
@@ -163,7 +163,7 @@ class TestUSDTimePreservation:
         output_dir: Path,
     ) -> None:
         """Test that merge_usd_files_flattened() preserves time metadata."""
-        usd_tools = USDTools()
+        usd_tools = ProcessUSD()
         merged_file = output_dir / "test_time_flattened.usd"
 
         usd_tools.merge_usd_files_flattened(
@@ -198,7 +198,7 @@ class TestUSDTimePreservation:
         if source_time_samples is None:
             pytest.skip("Test mesh not found in source data")
 
-        usd_tools = USDTools()
+        usd_tools = ProcessUSD()
         merged_file = output_dir / "test_samples_copy.usd"
 
         usd_tools.merge_usd_files(
@@ -239,7 +239,7 @@ class TestUSDTimePreservation:
         if source_time_samples is None:
             pytest.skip("Test mesh not found in source data")
 
-        usd_tools = USDTools()
+        usd_tools = ProcessUSD()
         merged_file = output_dir / "test_samples_flattened.usd"
 
         usd_tools.merge_usd_files_flattened(
@@ -285,7 +285,7 @@ class TestUSDTimePreservation:
         if source_time_samples is None:
             pytest.skip("Test mesh not found in source data")
 
-        usd_tools = USDTools()
+        usd_tools = ProcessUSD()
         merged_file = output_dir / "test_animation_range.usd"
 
         usd_tools.merge_usd_files_flattened(

--- a/tests/test_vtk_to_usd_library.py
+++ b/tests/test_vtk_to_usd_library.py
@@ -19,8 +19,8 @@ import pyvista as pv
 from pxr import Gf, Usd, UsdGeom, UsdShade
 
 from monai_physio import ConvertVTKToUSD
-from monai_physio.test_tools import TestTools
-from monai_physio.usd_tools import USDTools
+from monai_physio.process_tests import ProcessTests
+from monai_physio.process_usd import ProcessUSD
 
 
 def get_data_dir() -> Path:
@@ -125,7 +125,7 @@ class TestFromFilesValidation:
         assert not stage.HasAuthoredTimeCodeRange()
 
     def test_openusd_screenshot_uses_vtk_loader(self, tmp_path: Path) -> None:
-        """Render a tiny OpenUSD mesh through TestTools without USD imaging plugins."""
+        """Render a tiny OpenUSD mesh through ProcessTests without USD imaging plugins."""
         usd_path = tmp_path / "triangle.usd"
         stage = Usd.Stage.CreateNew(str(usd_path))
         world = stage.DefinePrim("/World", "Xform")
@@ -142,7 +142,7 @@ class TestFromFilesValidation:
         mesh.CreateFaceVertexIndicesAttr([0, 1, 2])
         stage.Save()
 
-        loaded = USDTools().load_usd_as_vtk(usd_path)
+        loaded = ProcessUSD().load_usd_as_vtk(usd_path)
         assert loaded.n_points == 3
         assert "openusd_rgb" in loaded.point_data
         assert np.all(loaded.point_data["openusd_rgb"] == np.array([255, 0, 0]))
@@ -162,7 +162,7 @@ class TestFromFilesValidation:
         # it statically infers the `sys.platform == "win32"` branch above as
         # always-taken and flags this line as unreachable; on the Linux CI
         # runner (or any non-Windows dev machine) it is reachable.
-        tt = TestTools(  # type: ignore[unreachable]
+        tt = ProcessTests(  # type: ignore[unreachable]
             class_name="openusd", results_dir=tmp_path
         )
         screenshot = tt.save_screenshot_openusd(usd_path, "triangle.png")

--- a/tests/test_workflow_finetune_icon_registration.py
+++ b/tests/test_workflow_finetune_icon_registration.py
@@ -24,7 +24,6 @@ from monai_physio.workflow_finetune_icon_registration import (
     WorkflowFinetuneICONRegistration,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_workflow_reconstruct_highres_4d_ct.py
+++ b/tests/test_workflow_reconstruct_highres_4d_ct.py
@@ -3,8 +3,8 @@ instance-based registration_method API."""
 
 from __future__ import annotations
 
-import numpy as np
 import itk
+import numpy as np
 import pytest
 
 from monai_physio.register_images_base import RegisterImagesBase

--- a/tests/test_workflow_train_physicsnemo.py
+++ b/tests/test_workflow_train_physicsnemo.py
@@ -27,7 +27,7 @@ from monai_physio import (
     WorkflowInferPhysicsNeMo,
     WorkflowTrainPhysicsNeMo,
 )
-from monai_physio.physicsnemo_tools import PhysicsNemoTools
+from monai_physio.process_physicsnemo import ProcessPhysicsNemo
 
 _TARGET_ARRAY = "displacement"
 _STAGES = (0.0, 1.0)
@@ -266,7 +266,7 @@ def test_a_ddp_wrapped_model_checkpoints_without_its_prefix() -> None:
     inner = torch.nn.Linear(2, 2)
     wrapped = _FakeDDP(inner)
 
-    state = PhysicsNemoTools.uncompiled_state_dict(wrapped)
+    state = ProcessPhysicsNemo.uncompiled_state_dict(wrapped)
 
     assert set(state) == set(inner.state_dict())
     assert not any(key.startswith("module.") for key in state)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -34,9 +34,9 @@ current working directory.
 | 3 | [tutorial_03_lung_reconstruct_highres_4d_ct.py](tutorial_03_lung_reconstruct_highres_4d_ct.py) | `WorkflowReconstructHighres4DCT` | DirLab-4DCT (manual) |
 | 4 | [tutorial_04_heart_ct_to_vtk.py](tutorial_04_heart_ct_to_vtk.py) | `WorkflowConvertImageToVTK` | Slicer-Heart-CT (prepare first) |
 | 4 | [tutorial_04_lung_ct_to_vtk.py](tutorial_04_lung_ct_to_vtk.py) | `WorkflowConvertImageToVTK` | Lung gated 4D CT (prepare first) |
-| 4 | [duke heart labelmap variant](tutorial_04_duke_heart_labelmap_to_vtk.py) | `ContourTools.extract_label_surfaces`, `ContourTools.extract_tetrahedra` | Duke-Heart-4DLabelmaps (releasing soon) |
+| 4 | [duke heart labelmap variant](tutorial_04_duke_heart_labelmap_to_vtk.py) | `ProcessContours.extract_label_surfaces`, `ProcessContours.extract_tetrahedra` | Duke-Heart-4DLabelmaps (releasing soon) |
 | 5 | [tutorial_05_heart_vtk_to_usd.py](tutorial_05_heart_vtk_to_usd.py) | `WorkflowConvertVTKToUSD` | Output of tutorial 4 |
-| 5 | [duke heart variant](tutorial_05_duke_heart_vtk_to_usd.py) | `ConvertVTKToUSD`, `USDAnatomyTools` | Output of tutorial 4 (duke heart labelmap) |
+| 5 | [duke heart variant](tutorial_05_duke_heart_vtk_to_usd.py) | `ConvertVTKToUSD`, `ProcessUSDAnatomy` | Output of tutorial 4 (duke heart labelmap) |
 | 6 | [tutorial_06_heart_create_statistical_model.py](tutorial_06_heart_create_statistical_model.py) | `WorkflowCreateStatisticalModel` | KCL-Heart-Model |
 | 6 | [tutorial_06_lung_create_statistical_model.py](tutorial_06_lung_create_statistical_model.py) | `WorkflowCreateMeanSurface`, `WorkflowCreateStatisticalModel` | DirLab-4DCT `Case*T70.mha`, which it segments itself |
 | 6 | [duke heart variant](tutorial_06_duke_heart_create_statistical_model.py) | `WorkflowCreateMeanSurface`, `WorkflowCreateStatisticalModel` | Reference-frame heart surfaces from Tutorial 4 (duke heart labelmap) |
@@ -52,13 +52,13 @@ current working directory.
 | 11 | [tutorial_11_lung_evaluate_physicsnemo.py](tutorial_11_lung_evaluate_physicsnemo.py) | `WorkflowEvaluateMovement`, `SegmentNVSegmentCTMRI` | DirLab-4DCT plus Tutorial 8 and 9 (lung) output |
 | 11 | [duke heart variant](tutorial_11_duke_heart_evaluate_physicsnemo.py) | `WorkflowEvaluateMovement` | Duke-Heart-4DLabelmaps plus Tutorial 8 and 9 (duke heart) output |
 | 12 | [tutorial_12_lung_end_to_end_inference.py](tutorial_12_lung_end_to_end_inference.py) | `WorkflowConvertImageToVTK`, `WorkflowFitStatisticalModelToPatient`, `WorkflowInferMovement` | DirLab-4DCT plus Tutorial 6 and 9 (lung) output |
-| 12 | [duke heart variant](tutorial_12_duke_heart_end_to_end_inference.py) | `ContourTools`, `WorkflowFitStatisticalModelToPatient`, `WorkflowInferMovement` | Duke-Heart-4DLabelmaps plus Tutorial 6 and 9 (duke heart) output |
+| 12 | [duke heart variant](tutorial_12_duke_heart_end_to_end_inference.py) | `ProcessContours`, `WorkflowFitStatisticalModelToPatient`, `WorkflowInferMovement` | Duke-Heart-4DLabelmaps plus Tutorial 6 and 9 (duke heart) output |
 | 13 | [tutorial_13_heart_and_lung_motion.py](tutorial_13_heart_and_lung_motion.py) | `WorkflowInferMovement`, `WorkflowFitStatisticalModelToPatient`, `ConvertVTKToUSD` (requires Simpleware Medical) | Chest-CT plus Tutorial 7 (lung) and Tutorial 9 (lung and duke heart) output |
 | 14 | [tutorial_14_lung_shape_parameter_sweep.py](tutorial_14_lung_shape_parameter_sweep.py) | `WorkflowEvaluateMovement`, `SegmentNVSegmentCTMRI` | DirLab-4DCT plus Tutorial 8 and 9 (lung) output |
 | 14 | [duke heart variant](tutorial_14_duke_heart_shape_parameter_sweep.py) | `WorkflowEvaluateMovement` | Duke-Heart-4DLabelmaps plus Tutorial 8 and 9 (duke heart) output |
 | 15 | [tutorial_15_lung_leave_one_out.py](tutorial_15_lung_leave_one_out.py) | `WorkflowCreateStatisticalModel`, `WorkflowFitStatisticalModelToPatient`, `WorkflowTrainPhysicsNeMo`, `WorkflowEvaluateMovement` | DirLab-4DCT |
 | 15 | [duke heart variant](tutorial_15_duke_heart_leave_one_out.py) | `WorkflowCreateStatisticalModel`, `WorkflowFitStatisticalModelToPatient`, `WorkflowTrainPhysicsNeMo`, `WorkflowEvaluateMovement` | Duke-Heart-4DLabelmaps |
-| 16 | [tutorial_16_duke_heart_physics_informed_motion_prep.py](tutorial_16_duke_heart_physics_informed_motion_prep.py) | `ContourTools.extract_tetrahedra`, `WorkflowCreateStatisticalModel`, `WorkflowFitStatisticalModelToPatient` | Duke-Heart-4DLabelmaps plus Tutorial 4 (duke heart) output |
+| 16 | [tutorial_16_duke_heart_physics_informed_motion_prep.py](tutorial_16_duke_heart_physics_informed_motion_prep.py) | `ProcessContours.extract_tetrahedra`, `WorkflowCreateStatisticalModel`, `WorkflowFitStatisticalModelToPatient` | Duke-Heart-4DLabelmaps plus Tutorial 4 (duke heart) output |
 | 17 | [tutorial_17_duke_heart_physics_informed_motion_train.py](tutorial_17_duke_heart_physics_informed_motion_train.py) | `TrainPhysicsNeMoPhysicsInformedMotion`, `WorkflowTrainPhysicsNeMo` | Tutorial 16 output |
 | 18 | [tutorial_18_duke_heart_physics_informed_motion_infer.py](tutorial_18_duke_heart_physics_informed_motion_infer.py) | `WorkflowEvaluateMovement`, `ConvertVTKToUSD` | Tutorial 16 and 17 output |
 

--- a/tutorials/parameters_base.py
+++ b/tutorials/parameters_base.py
@@ -20,7 +20,7 @@ Variable                             Default
 ===================================  =====================================
 
 Every root has a ``test`` subdirectory holding the small, fast counterpart used
-when a tutorial runs under ``TestTools.running_as_test``. Keeping the test data,
+when a tutorial runs under ``ProcessTests.running_as_test``. Keeping the test data,
 the test results and the test checkpoints in their own subtree is what stops a
 test run from reading or overwriting the datasets, results and trained networks
 of a full run.

--- a/tutorials/parameters_duke_heart_labelmaps.py
+++ b/tutorials/parameters_duke_heart_labelmaps.py
@@ -56,10 +56,10 @@ class ParametersDukeHeartLabelmaps(ParametersBase):
             carry as one vector of ``3 * model_points``.
         number_of_pca_components: PCA components retained when building the
             heart statistical model, and used when fitting it to a patient.
-        number_of_pca_components_test: Same, under ``TestTools.running_as_test``.
+        number_of_pca_components_test: Same, under ``ProcessTests.running_as_test``.
         number_of_iterations_greedy: Greedy coarse-to-fine iteration schedule.
         number_of_iterations_greedy_test: Same, under
-            ``TestTools.running_as_test``.
+            ``ProcessTests.running_as_test``.
         segmenter_class: Segmenter that produced these labelmaps, so the
             tutorials name their labels the way it does.
         anatomy_group: Anatomy group name that segmenter registers for the heart.

--- a/tutorials/parameters_duke_heart_physics_informed.py
+++ b/tutorials/parameters_duke_heart_physics_informed.py
@@ -65,7 +65,7 @@ class ParametersDukeHeartPhysicsInformed(ParametersDukeHeartLabelmaps):
             the data. ``0`` disables warmup.
         number_of_epochs: Training epochs, matching Tutorial 9 so the two are
             comparable.
-        number_of_epochs_test: Same, under ``TestTools.running_as_test``.
+        number_of_epochs_test: Same, under ``ProcessTests.running_as_test``.
         train_ablation_baseline: Whether Tutorial 17 also trains a second model
             with ``lambda_physics`` at zero.  That model sees exactly the same
             volumetric data, so it is the only comparison that isolates the

--- a/tutorials/parameters_heart_ct_kcl.py
+++ b/tutorials/parameters_heart_ct_kcl.py
@@ -49,15 +49,15 @@ class ParametersHeartCTKCL(ParametersBase):
             that the myocardium survives the coarsening.
         model_points: Points kept per surface when building the shape model.
             ``0`` keeps every point, which is what a full run does.
-        model_points_test: Same, under ``TestTools.running_as_test``, where the
+        model_points_test: Same, under ``ProcessTests.running_as_test``, where the
             KCL meshes are read at full resolution because that dataset has no
             downsampled test subset.
         number_of_pca_components: PCA components retained when building the
             heart statistical model, and used when fitting it to a patient.
-        number_of_pca_components_test: Same, under ``TestTools.running_as_test``.
+        number_of_pca_components_test: Same, under ``ProcessTests.running_as_test``.
         number_of_iterations_greedy: Greedy coarse-to-fine iteration schedule.
         number_of_iterations_greedy_test: Same, under
-            ``TestTools.running_as_test``.
+            ``ProcessTests.running_as_test``.
         segmenter_class: Segmenter every heart tutorial instantiates, so the
             surfaces they compare share a definition of "heart".
         anatomy_group: Anatomy group name that segmenter registers for the heart.
@@ -66,10 +66,10 @@ class ParametersHeartCTKCL(ParametersBase):
             myocardium, so a distance map must not measure to them.
         input_dir: Population Tutorial 6 builds the model from, and
             ``input_dir_test`` its counterpart under
-            ``TestTools.running_as_test``.
+            ``ProcessTests.running_as_test``.
         hold_out_dir: Dataset the held-out case is read from by Tutorial 7, and
             ``hold_out_dir_test`` its counterpart under
-            ``TestTools.running_as_test``.  A different dataset from
+            ``ProcessTests.running_as_test``.  A different dataset from
             ``input_dir``: the model is built from KCL meshes and fitted to a
             DIR-Lab patient.
         pca_json_file: Shape model Tutorial 6 writes and Tutorial 7 reads.

--- a/tutorials/parameters_lung_ct_dirlab.py
+++ b/tutorials/parameters_lung_ct_dirlab.py
@@ -48,13 +48,13 @@ class ParametersLungCTDirLab(ParametersBase):
             tetrahedron count falls by roughly ``(1 - rate) ** 3``.
         model_points: Points kept per surface when building the shape model.
             ``0`` keeps every point, which is what a full run does.
-        model_points_test: Same, under ``TestTools.running_as_test``.
+        model_points_test: Same, under ``ProcessTests.running_as_test``.
         number_of_pca_components: PCA components retained when building the
             lung statistical model, and used when fitting it to a patient.
-        number_of_pca_components_test: Same, under ``TestTools.running_as_test``.
+        number_of_pca_components_test: Same, under ``ProcessTests.running_as_test``.
         number_of_iterations_greedy: Greedy coarse-to-fine iteration schedule.
         number_of_iterations_greedy_test: Same, under
-            ``TestTools.running_as_test``.
+            ``ProcessTests.running_as_test``.
         segmenter_class: Segmenter every lung tutorial instantiates, so the
             surfaces they compare share a definition of "lung".
         anatomy_group: Anatomy group name that segmenter registers for lungs.

--- a/tutorials/tutorial_01_heart_gated_ct_to_usd.py
+++ b/tutorials/tutorial_01_heart_gated_ct_to_usd.py
@@ -33,7 +33,7 @@ Strengths
 - Single call (``WorkflowConvertImageToUSD.process()``) runs the full pipeline.
 - Registers on the CPU with ``RegisterImagesGreedy``; no GPU needed for this stage.
 - Automatically detects contrast enhancement and adjusts segmentation thresholds.
-- Output is Omniverse-ready with anatomical materials (USDAnatomyTools).
+- Output is Omniverse-ready with anatomical materials (ProcessUSDAnatomy).
 
 Weaknesses / Limitations
 ------------------------
@@ -50,9 +50,9 @@ Classes Used
     Deep-learning segmentation of 117 anatomical structures (used internally).
 - RegisterImagesGreedy (register_images_greedy.py):
     Frame-to-frame image registration (used internally).
-- ContourTools (contour_tools.py):
+- ProcessContours (process_contours.py):
     Extracts and transforms surface meshes from segmentation masks (used internally).
-- USDAnatomyTools (usd_anatomy_tools.py):
+- ProcessUSDAnatomy (process_usd_anatomy.py):
     Applies clinical material colours to USD prims (used internally).
 
 Data Required
@@ -74,9 +74,9 @@ import itk
 from parameters_heart_ct_kcl import HEART_CT_KCL
 
 from monai_physio import (
+    ProcessTests,
     RegisterImagesGreedy,
     SegmentChestTotalSegmentatorWithContrast,
-    TestTools,
     WorkflowConvertImageToUSD,
 )
 
@@ -92,7 +92,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_01_heart_gated_ct_to_usd"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = HEART_CT_KCL.output_directory(test_mode) / "tutorial_01_heart"
 
@@ -155,7 +155,7 @@ if __name__ == "__main__":
         usd_file = output_dir / workflow_results["all"]
 
     # Result saving
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         log_level=log_level,

--- a/tutorials/tutorial_01_lung_gated_ct_to_usd.py
+++ b/tutorials/tutorial_01_lung_gated_ct_to_usd.py
@@ -31,7 +31,7 @@ Strengths
 ---------
 - Single call (``WorkflowConvertImageToUSD.process()``) runs the full pipeline.
 - Registers on the CPU with ``RegisterImagesGreedy``; no GPU needed for this stage.
-- Output is Omniverse-ready with anatomical materials (USDAnatomyTools).
+- Output is Omniverse-ready with anatomical materials (ProcessUSDAnatomy).
 
 Weaknesses / Limitations
 ------------------------
@@ -48,9 +48,9 @@ Classes Used
     Deep-learning segmentation of 117 anatomical structures (used internally).
 - RegisterImagesGreedy (register_images_greedy.py):
     Frame-to-frame image registration (used internally).
-- ContourTools (contour_tools.py):
+- ProcessContours (process_contours.py):
     Extracts and transforms surface meshes from segmentation masks (used internally).
-- USDAnatomyTools (usd_anatomy_tools.py):
+- ProcessUSDAnatomy (process_usd_anatomy.py):
     Applies clinical material colours to USD prims (used internally).
 
 Data Required
@@ -72,9 +72,9 @@ import itk
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
+    ProcessTests,
     RegisterImagesGreedy,
     SegmentChestTotalSegmentator,
-    TestTools,
     WorkflowConvertImageToUSD,
 )
 
@@ -90,7 +90,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_01_lung_gated_ct_to_usd"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_01_lung"
 
@@ -156,7 +156,7 @@ if __name__ == "__main__":
         usd_file = output_dir / workflow_results["all"]
 
     # Result saving
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         log_level=log_level,

--- a/tutorials/tutorial_02_duke_heart_distancemap_finetune_icon.py
+++ b/tutorials/tutorial_02_duke_heart_distancemap_finetune_icon.py
@@ -57,13 +57,13 @@ import numpy as np
 from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
-    ContourTools,
     MONAIPhysioBase,
+    ProcessContours,
+    ProcessTests,
+    ProcessTransforms,
     RegisterImagesBase,
     RegisterImagesGreedy,
     RegisterImagesICON,
-    TestTools,
-    TransformTools,
     WorkflowFinetuneICONRegistration,
 )
 
@@ -78,7 +78,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_02_duke_heart_distancemap_finetune_icon"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = (
         DUKE_HEART.output_directory(test_mode) / "tutorial_02_heart_distancemap"
@@ -116,8 +116,8 @@ if __name__ == "__main__":
 
     derived_dir.mkdir(parents=True, exist_ok=True)
 
-    contour_tools = ContourTools(log_level=log_level)
-    transform_tools = TransformTools()
+    contour_tools = ProcessContours(log_level=log_level)
+    transform_tools = ProcessTransforms()
 
     # Labels left out of the surface a distance map is measured to; see the
     # parameters module.
@@ -473,7 +473,7 @@ if __name__ == "__main__":
         )
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_02_lung_distancemap_finetune_icon.py
+++ b/tutorials/tutorial_02_lung_distancemap_finetune_icon.py
@@ -81,15 +81,15 @@ import pyvista as pv
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
-    ContourTools,
     MONAIPhysioBase,
+    ProcessContours,
+    ProcessTests,
+    ProcessTransforms,
     RegisterImagesBase,
     RegisterImagesGreedy,
     RegisterImagesGreedyICON,
     RegisterImagesICON,
     SegmentNVSegmentCTMRI,
-    TestTools,
-    TransformTools,
     WorkflowConvertImageToVTK,
     WorkflowFinetuneICONRegistration,
 )
@@ -106,7 +106,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_02_lung_distancemap_finetune_icon"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = (
         LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_02_lung_distancemap"
@@ -182,8 +182,8 @@ if __name__ == "__main__":
     lung_label_ids = np.array(
         sorted(segmenter.taxonomy.labels_in_group("lung")), dtype=np.uint16
     )
-    contour_tools = ContourTools(log_level=log_level)
-    transform_tools = TransformTools()
+    contour_tools = ProcessContours(log_level=log_level)
+    transform_tools = ProcessTransforms()
 
     def segment_phase(image_file: Path) -> tuple[Path, Path]:
         """Segment one phase's lungs and rasterize their distance map.
@@ -588,7 +588,7 @@ if __name__ == "__main__":
     reporter.log_info("Wrote summary: %s", summary_file)
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_02_lung_finetune_icon.py
+++ b/tutorials/tutorial_02_lung_finetune_icon.py
@@ -92,13 +92,13 @@ from parameters_base import ParametersBase
 
 from monai_physio import (
     MONAIPhysioBase,
+    ProcessTests,
+    ProcessTransforms,
     RegisterImagesBase,
     RegisterImagesGreedy,
     RegisterImagesGreedyICON,
     RegisterImagesICON,
     SegmentNVSegmentCTMRI,
-    TestTools,
-    TransformTools,
     WorkflowFinetuneICONRegistration,
 )
 
@@ -116,7 +116,7 @@ if __name__ == "__main__":
     # Only the shared directory roots are needed here; no dataset-specific
     # parameters module applies to this tutorial.
     tutorial_paths = ParametersBase()
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = tutorial_paths.output_directory(test_mode) / "tutorial_02_lung"
     # The workflow writes its dataset JSON, YAML config, and checkpoint tree
@@ -243,7 +243,7 @@ if __name__ == "__main__":
     # Registration comparison
     fixed_image = itk.imread(str(fixed_file), pixel_type=itk.F)
     moving_image = itk.imread(str(moving_file), pixel_type=itk.F)
-    transform_tools = TransformTools()
+    transform_tools = ProcessTransforms()
 
     def read_landmarks(landmark_file: Path, image: itk.Image) -> np.ndarray:
         """Read a DIR-Lab landmark file as an (N, 3) array of world points.
@@ -649,7 +649,7 @@ if __name__ == "__main__":
     reporter.log_info("Wrote summary: %s", summary_file)
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_03_heart_reconstruct_highres_4d_ct.py
+++ b/tutorials/tutorial_03_heart_reconstruct_highres_4d_ct.py
@@ -24,8 +24,8 @@ import itk
 from parameters_base import ParametersBase
 
 from monai_physio import (
+    ProcessTests,
     RegisterImagesGreedy,
-    TestTools,
     WorkflowReconstructHighres4DCT,
 )
 
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     # Only the shared directory roots are needed here; no dataset-specific
     # parameters module applies to this tutorial.
     tutorial_paths = ParametersBase()
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = tutorial_paths.output_directory(test_mode) / "tutorial_03_heart"
     baselines_dir = repo_root / "tests" / "baselines"
@@ -115,7 +115,7 @@ if __name__ == "__main__":
         itk.transformwrite(moving_to_fixed_transform[frame_index], str(out_path))
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_03_lung_reconstruct_highres_4d_ct.py
+++ b/tutorials/tutorial_03_lung_reconstruct_highres_4d_ct.py
@@ -30,8 +30,8 @@ import itk
 from parameters_base import ParametersBase
 
 from monai_physio import (
+    ProcessTests,
     RegisterImagesGreedy,
-    TestTools,
     WorkflowReconstructHighres4DCT,
 )
 
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     # Only the shared directory roots are needed here; no dataset-specific
     # parameters module applies to this tutorial.
     tutorial_paths = ParametersBase()
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = tutorial_paths.output_directory(test_mode) / "tutorial_03_lung"
     baselines_dir = repo_root / "tests" / "baselines"
@@ -126,7 +126,7 @@ if __name__ == "__main__":
         itk.transformwrite(moving_to_fixed_transform[frame_index], str(out_path))
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_04_duke_heart_labelmap_to_vtk.py
+++ b/tutorials/tutorial_04_duke_heart_labelmap_to_vtk.py
@@ -20,15 +20,15 @@ hundred times the short one:
 Files written per frame, the per-label ones only under ``"full"``:
 
 - ``<frame_stem>_surfaces.vtp`` -- every label's watertight, outward-oriented
-  surface in one file, via ``ContourTools.extract_label_surfaces`` on the whole
+  surface in one file, via ``ProcessContours.extract_label_surfaces`` on the whole
   labelmap.  Extracting the labels together is what keeps neighbors touching:
   a wall between two of them is contoured from the same field on the same
   isotropic grid, so both surfaces carry the same vertices there.  Per-cell
   ``SegmentationLabelIds`` says which label each triangle came from.
 - ``<frame_stem>_<name>.vtu`` -- one tetrahedral mesh per structure, six
-  ``VTK_TETRA`` per isotropic voxel, via ``ContourTools.extract_tetrahedra``,
+  ``VTK_TETRA`` per isotropic voxel, via ``ProcessContours.extract_tetrahedra``,
   then relaxed onto that structure's surface by
-  ``ContourTools.trim_tetrahedra_to_surface``.
+  ``ProcessContours.trim_tetrahedra_to_surface``.
 
 The mesh starts as a voxel staircase and ends up bounded by the smooth
 surface: the relaxation projects its boundary onto that surface while smoothing
@@ -36,7 +36,7 @@ the interior to make room, so no trace of the voxel blocks is left.  What
 remains between the two geometries is faceting at the element size, logged per
 structure in millimeters.
 
-Both carry the structure's ``USDAnatomyTools`` color, as ``AnatomyColor`` and
+Both carry the structure's ``ProcessUSDAnatomy`` color, as ``AnatomyColor`` and
 as a per-cell ``Color``, so they render the same way as the surfaces
 ``WorkflowConvertImageToVTK`` writes.
 
@@ -67,10 +67,10 @@ import pyvista as pv
 from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
-    ContourTools,
     MONAIPhysioBase,
+    ProcessContours,
+    ProcessTests,
     SegmentHeartSimplewareTrimmedBranches,
-    TestTools,
 )
 
 # Only run if this script is not imported as a module
@@ -79,7 +79,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_04_duke_heart_labelmap_to_vtk"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = (
         DUKE_HEART.output_directory(test_mode) / "tutorial_04_duke_heart_labelmap"
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     log_level = logging.INFO
     reporter = MONAIPhysioBase(class_name=class_name, log_level=log_level)
 
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
     taxonomy = SegmentHeartSimplewareTrimmedBranches(log_level=logging.WARNING).taxonomy
     label_names = taxonomy.all_labels()
 
@@ -141,9 +141,9 @@ if __name__ == "__main__":
 
         ``SegmentationLabelIds`` holds one id for a per-label structure and
         every retained id for the whole-heart one; a single id is what
-        ``ContourTools.save_combined_surfaces`` needs to tag the merged file's
+        ``ProcessContours.save_combined_surfaces`` needs to tag the merged file's
         cells with the structure they came from.  The anatomy color is attached
-        separately, by ``ContourTools.apply_anatomy_color``.
+        separately, by ``ProcessContours.apply_anatomy_color``.
         """
         mesh.field_data["SegmentationLabelIds"] = np.asarray(label_ids, dtype=np.int32)
         mesh.field_data["LabelName"] = np.array([name])
@@ -180,7 +180,7 @@ if __name__ == "__main__":
         finest_spacing = float(np.min(np.asarray(mask.GetSpacing())))
         element_size = mesh_element_size_mm
         while True:
-            # USDAnatomyTools has no override for names like "left_ventricle",
+            # ProcessUSDAnatomy has no override for names like "left_ventricle",
             # so the structure's anatomy group is offered as the fallback color.
             tet_mesh = contour_tools.extract_tetrahedra(
                 mask,
@@ -324,7 +324,9 @@ if __name__ == "__main__":
                     )
                     if displacement is not None:
                         displacements.append(displacement)
-                ContourTools.save_combined_surfaces(named_surfaces, str(surfaces_file))
+                ProcessContours.save_combined_surfaces(
+                    named_surfaces, str(surfaces_file)
+                )
 
             # Written last, so an interrupted frame is redone rather than
             # skipped by the check above.
@@ -342,7 +344,7 @@ if __name__ == "__main__":
         reporter.log_section(f"Wrote {surface_count} surfaces")
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         log_level=log_level,

--- a/tutorials/tutorial_04_heart_ct_to_vtk.py
+++ b/tutorials/tutorial_04_heart_ct_to_vtk.py
@@ -24,11 +24,11 @@ import pyvista as pv
 from parameters_heart_ct_kcl import HEART_CT_KCL
 
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
+    ProcessTests,
     SegmentAnatomyBase,
     SegmentChestTotalSegmentatorWithContrast,
     SegmentHeartSimpleware,
-    TestTools,
     WorkflowConvertImageToVTK,
 )
 
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_04_heart_ct_to_vtk"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = HEART_CT_KCL.output_directory(test_mode) / "tutorial_04_heart"
 
@@ -120,24 +120,24 @@ if __name__ == "__main__":
         result["label_surfaces"] if save_label_surfaces else result["surfaces"]
     )
     surface_file = Path(
-        ContourTools.save_combined_surfaces(
+        ProcessContours.save_combined_surfaces(
             combined_input,
             str(output_dir / "patient_surfaces.vtp"),
         )
     )
     if save_group_surfaces:
-        ContourTools.save_surfaces(
+        ProcessContours.save_surfaces(
             result["surfaces"], str(output_dir), prefix="patient"
         )
     if save_label_surfaces:
-        ContourTools.save_surfaces(
+        ProcessContours.save_surfaces(
             result["label_surfaces"], str(output_dir), prefix="patient"
         )
     labelmap_file = output_dir / "patient_labelmap.mha"
     itk.imwrite(result["labelmap"], str(labelmap_file), compression=True)
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         log_level=log_level,

--- a/tutorials/tutorial_04_lung_ct_to_vtk.py
+++ b/tutorials/tutorial_04_lung_ct_to_vtk.py
@@ -24,9 +24,9 @@ import pyvista as pv
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
+    ProcessTests,
     SegmentChestTotalSegmentator,
-    TestTools,
     WorkflowConvertImageToVTK,
 )
 
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 
     project_name = "tutorial_04_lung"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / project_name
 
@@ -104,24 +104,24 @@ if __name__ == "__main__":
         result["label_surfaces"] if save_label_surfaces else result["surfaces"]
     )
     surface_file = Path(
-        ContourTools.save_combined_surfaces(
+        ProcessContours.save_combined_surfaces(
             combined_input,
             str(output_dir / "patient_surfaces.vtp"),
         )
     )
     if save_group_surfaces:
-        ContourTools.save_surfaces(
+        ProcessContours.save_surfaces(
             result["surfaces"], str(output_dir), prefix="patient"
         )
     if save_label_surfaces:
-        ContourTools.save_surfaces(
+        ProcessContours.save_surfaces(
             result["label_surfaces"], str(output_dir), prefix="patient"
         )
     labelmap_file = output_dir / "patient_labelmap.mha"
     itk.imwrite(result["labelmap"], str(labelmap_file), compression=True)
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=project_name,
         results_dir=output_dir,
         log_level=log_level,

--- a/tutorials/tutorial_05_duke_heart_vtk_to_usd.py
+++ b/tutorials/tutorial_05_duke_heart_vtk_to_usd.py
@@ -43,8 +43,8 @@ from parameters_base import ParametersBase
 
 from monai_physio import (
     MONAIPhysioBase,
+    ProcessTests,
     SegmentHeartSimplewareTrimmedBranches,
-    TestTools,
     WorkflowConvertVTKToUSD,
 )
 
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     # Only the shared directory roots are needed here; no dataset-specific
     # parameters module applies to this tutorial.
     tutorial_paths = ParametersBase()
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     input_dir = (
         tutorial_paths.output_directory(test_mode) / "tutorial_04_duke_heart_labelmap"
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     reporter.log_section(f"Wrote {len(usd_files)} animated USD files to {output_dir}")
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         log_level=log_level,

--- a/tutorials/tutorial_05_heart_vtk_to_usd.py
+++ b/tutorials/tutorial_05_heart_vtk_to_usd.py
@@ -28,7 +28,7 @@ import pyvista as pv
 from parameters_base import ParametersBase
 
 from monai_physio import (
-    TestTools,
+    ProcessTests,
     WorkflowConvertVTKToUSD,
 )
 
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     # Only the shared directory roots are needed here; no dataset-specific
     # parameters module applies to this tutorial.
     tutorial_paths = ParametersBase()
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = tutorial_paths.output_directory(test_mode) / "tutorial_05_heart"
     baselines_dir = repo_root / "tests" / "baselines"
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     results = workflow.process()
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_06_duke_heart_create_statistical_model.py
+++ b/tutorials/tutorial_06_duke_heart_create_statistical_model.py
@@ -47,8 +47,8 @@ import pyvista as pv
 from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
-    ContourTools,
-    TestTools,
+    ProcessContours,
+    ProcessTests,
     WorkflowCreateMeanSurface,
     WorkflowCreateStatisticalModel,
 )
@@ -60,7 +60,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_06_duke_heart_create_statistical_model"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_06_duke_heart"
     weights_dir = DUKE_HEART.weights_directory(test_mode)
@@ -97,7 +97,7 @@ if __name__ == "__main__":
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
 
     # One reference-frame surface per case, less the held-out one: Tutorial 7
     # fits this model to that case, so the model must not have seen it.
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     mean_surface.save(str(mean_surface_file))
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_06_heart_create_statistical_model.py
+++ b/tutorials/tutorial_06_heart_create_statistical_model.py
@@ -26,8 +26,8 @@ import pyvista as pv
 from parameters_heart_ct_kcl import HEART_CT_KCL
 
 from monai_physio import (
-    ContourTools,
-    TestTools,
+    ProcessContours,
+    ProcessTests,
     WorkflowCreateStatisticalModel,
 )
 
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_06_heart_create_statistical_model"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = HEART_CT_KCL.output_directory(test_mode) / "tutorial_06_heart"
     weights_dir = HEART_CT_KCL.weights_directory(test_mode)
@@ -107,7 +107,7 @@ if __name__ == "__main__":
             "See data/README.md for download instructions."
         )
 
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
 
     def read_model_surface(path: Path) -> pv.DataSet:
         """Read a mesh, reduced to ``model_points`` when a budget is set."""
@@ -172,7 +172,7 @@ if __name__ == "__main__":
     mean_surface.save(str(mean_surface_file))
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_06_lung_create_statistical_model.py
+++ b/tutorials/tutorial_06_lung_create_statistical_model.py
@@ -43,9 +43,9 @@ import pyvista as pv
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
+    ProcessTests,
     SegmentNVSegmentCTMRI,
-    TestTools,
     WorkflowConvertImageToVTK,
     WorkflowCreateMeanSurface,
     WorkflowCreateStatisticalModel,
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_06_lung_create_statistical_model"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_06_lung"
     weights_dir = LUNG_CT_DIRLAB.weights_directory(test_mode)
@@ -110,7 +110,7 @@ if __name__ == "__main__":
         segmentation_method=segmentation_method, log_level=log_level
     )
 
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
 
     # Tutorial 7 fits this model to the held-out study, so the model must not
     # have seen it.  That study lives in another dataset, so this drops nothing
@@ -235,7 +235,7 @@ if __name__ == "__main__":
     mean_surface.save(str(mean_surface_file))
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_07_duke_heart_fit_statistical_model_to_patient.py
+++ b/tutorials/tutorial_07_duke_heart_fit_statistical_model_to_patient.py
@@ -44,8 +44,8 @@ import pyvista as pv
 from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
-    ContourTools,
-    TestTools,
+    ProcessContours,
+    ProcessTests,
     WorkflowFitStatisticalModelToPatient,
 )
 
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
     project_name = "tutorial_07_duke_heart"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = DUKE_HEART.output_directory(test_mode) / project_name
     weights_dir = DUKE_HEART.weights_directory(test_mode)
@@ -99,7 +99,7 @@ if __name__ == "__main__":
 
     log_level = logging.INFO
 
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
 
     # Directory setup and data reading
 
@@ -217,7 +217,7 @@ if __name__ == "__main__":
     )
 
     # Testing
-    TestTools(
+    ProcessTests(
         class_name=project_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_07_heart_fit_statistical_model_to_patient.py
+++ b/tutorials/tutorial_07_heart_fit_statistical_model_to_patient.py
@@ -26,11 +26,11 @@ import pyvista as pv
 from parameters_heart_ct_kcl import HEART_CT_KCL
 
 from monai_physio import (
-    ContourTools,
-    SegmentChestTotalSegmentator,
+    ProcessContours,
     # SegmentHeartSimplewareTrimmedBranches,
     # SegmentChestTotalSegmentatorWithContrast,
-    TestTools,
+    ProcessTests,
+    SegmentChestTotalSegmentator,
     WorkflowFitStatisticalModelToPatient,
 )
 
@@ -47,7 +47,7 @@ if __name__ == "__main__":
 
     project_name = "tutorial_07_heart"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = HEART_CT_KCL.output_directory(test_mode) / project_name
     weights_dir = HEART_CT_KCL.weights_directory(test_mode)
@@ -129,7 +129,7 @@ if __name__ == "__main__":
             compression=True,
         )
 
-        contour_tools = ContourTools()
+        contour_tools = ProcessContours()
         heart_surface = contour_tools.extract_contours(
             labelmap_image=heart_labelmap,
             surface_reduction_rate=HEART_CT_KCL.surface_reduction_rate,
@@ -217,7 +217,7 @@ if __name__ == "__main__":
     )
 
     # Testing
-    TestTools(
+    ProcessTests(
         class_name=project_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_07_lung_fit_statistical_model_to_patient.py
+++ b/tutorials/tutorial_07_lung_fit_statistical_model_to_patient.py
@@ -34,9 +34,9 @@ import pyvista as pv
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
+    ProcessTests,
     SegmentNVSegmentCTMRI,
-    TestTools,
     WorkflowConvertImageToVTK,
     WorkflowFitStatisticalModelToPatient,
 )
@@ -54,7 +54,7 @@ if __name__ == "__main__":
 
     project_name = "tutorial_07_lung"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / project_name
     weights_dir = LUNG_CT_DIRLAB.weights_directory(test_mode)
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     segmentation_workflow = WorkflowConvertImageToVTK(
         segmentation_method=segmentation_method, log_level=log_level
     )
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
 
     # Directory setup and data reading
 
@@ -204,7 +204,7 @@ if __name__ == "__main__":
     )
 
     # Testing
-    TestTools(
+    ProcessTests(
         class_name=project_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_08_duke_heart_fit_model_to_4d_patients.py
+++ b/tutorials/tutorial_08_duke_heart_fit_model_to_4d_patients.py
@@ -67,9 +67,9 @@ import pyvista as pv
 from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
+    ProcessTests,
     RegisterModelsDistanceMaps,
-    TestTools,
     WorkflowFitStatisticalModelToPatient,
 )
 
@@ -89,7 +89,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_08_duke_heart_fit_model_to_4d_patients"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     output_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_08_duke_heart"
     weights_dir = DUKE_HEART.weights_directory(test_mode)
@@ -177,7 +177,7 @@ if __name__ == "__main__":
             "See data/Duke-Heart-4DLabelmaps/README.md."
         )
 
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
 
     def heart_surface_for(labelmap_file: Path, case_output_dir: Path) -> pv.PolyData:
         """Return one frame's whole heart, minus its chamber cavities.
@@ -335,7 +335,7 @@ if __name__ == "__main__":
         )
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_08_lung_fit_model_to_4d_patients.py
+++ b/tutorials/tutorial_08_lung_fit_model_to_4d_patients.py
@@ -16,7 +16,7 @@ statistical-shape-model (SSM) surface per respiratory phase:
 2. Propagate the fitted surface to every respiratory phase. Each phase is
    registered to the reference phase with ``RegisterImagesGreedy``
    (``WorkflowReconstructHighres4DCT``). The forward transform for each phase
-   warps the fitted SSM surface (``TransformTools.transform_pvcontour``, with
+   warps the fitted SSM surface (``ProcessTransforms.transform_pvcontour``, with
    deformation magnitude attached), producing one ``*_T{PP}_ssm_surface.vtp``
    per phase.
 
@@ -57,11 +57,11 @@ import pyvista as pv
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
+    ProcessTests,
+    ProcessTransforms,
     RegisterImagesGreedy,
     SegmentNVSegmentCTMRI,
-    TestTools,
-    TransformTools,
     WorkflowConvertImageToVTK,
     WorkflowFitStatisticalModelToPatient,
     WorkflowReconstructHighres4DCT,
@@ -80,7 +80,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_08_lung_fit_model_to_4d_patients"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
 
     data_dir = LUNG_CT_DIRLAB.input_directory(test_mode)
 
@@ -159,8 +159,8 @@ if __name__ == "__main__":
     segmentation_workflow = WorkflowConvertImageToVTK(
         segmentation_method=segmentation_method, log_level=log_level
     )
-    contour_tools = ContourTools(log_level=log_level)
-    transform_tools = TransformTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
+    transform_tools = ProcessTransforms(log_level=log_level)
 
     tutorial_results: dict[str, Any] = {"cases": {}, "screenshots": []}
 
@@ -303,7 +303,7 @@ if __name__ == "__main__":
         }
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_09_duke_heart_train_physicsnemo_mgn.py
+++ b/tutorials/tutorial_09_duke_heart_train_physicsnemo_mgn.py
@@ -85,7 +85,7 @@ import pyvista as pv
 from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
-    TestTools,
+    ProcessTests,
     TrainPhysicsNeMoMGN,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
@@ -182,7 +182,7 @@ def _write_case_manifest(
 if __name__ == "__main__":
     # Data directory specification
     tutorials_dir = Path(__file__).resolve().parent
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     # Fitted SSM surfaces and PCA coefficients written by Tutorial 8 (Duke Heart).
     data_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_08_duke_heart"
@@ -317,7 +317,7 @@ if __name__ == "__main__":
         )
 
     # Testing: render the first predicted surface of the last held-out case.
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=tutorials_dir.parent / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_09_lung_train_physicsnemo_mgn.py
+++ b/tutorials/tutorial_09_lung_train_physicsnemo_mgn.py
@@ -91,7 +91,7 @@ import pyvista as pv
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
-    TestTools,
+    ProcessTests,
     TrainPhysicsNeMoMGN,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
@@ -184,7 +184,7 @@ def _write_case_manifest(
 if __name__ == "__main__":
     # Data directory specification
     tutorials_dir = Path(__file__).resolve().parent
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     # Fitted SSM surfaces and PCA coefficients written by Tutorial 8 (lung).
     data_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_08_lung"
@@ -315,7 +315,7 @@ if __name__ == "__main__":
         )
 
     # Testing: render the first predicted surface of the last held-out case.
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=tutorials_dir.parent / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_10_duke_heart_infer_physicsnemo_mgn.py
+++ b/tutorials/tutorial_10_duke_heart_infer_physicsnemo_mgn.py
@@ -60,7 +60,7 @@ import pyvista as pv
 from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
-    TestTools,
+    ProcessTests,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
 )
@@ -88,7 +88,7 @@ def _cardiac_stage_from_filename(surface_file: Path) -> float:
 if __name__ == "__main__":
     # Data directory specification
     tutorials_dir = Path(__file__).resolve().parent
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     # Fitted SSM surfaces and PCA coefficients written by Tutorial 8 (Duke Heart).
     data_dir = DUKE_HEART.output_directory(test_mode) / "tutorial_08_duke_heart"
@@ -179,7 +179,7 @@ if __name__ == "__main__":
 
     # Testing: render the first predicted stage beside the ground-truth frame it
     # is scored against.
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=tutorials_dir.parent / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_10_lung_infer_physicsnemo_mgn.py
+++ b/tutorials/tutorial_10_lung_infer_physicsnemo_mgn.py
@@ -57,7 +57,7 @@ import pyvista as pv
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
-    TestTools,
+    ProcessTests,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
 )
@@ -80,7 +80,7 @@ def _respiratory_stage_from_filename(surface_file: Path) -> float:
 if __name__ == "__main__":
     # Data directory specification
     tutorials_dir = Path(__file__).resolve().parent
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     # Fitted SSM surfaces and PCA coefficients written by Tutorial 8 (lung).
     data_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_08_lung"
@@ -178,7 +178,7 @@ if __name__ == "__main__":
 
     # Testing: render the first predicted stage beside the ground-truth phase it
     # is scored against.
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=tutorials_dir.parent / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_11_duke_heart_evaluate_physicsnemo.py
+++ b/tutorials/tutorial_11_duke_heart_evaluate_physicsnemo.py
@@ -69,7 +69,7 @@ from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
     EvaluateMovementDukeHeart,
-    TestTools,
+    ProcessTests,
     WorkflowEvaluateMovement,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     case_id = DUKE_HEART.hold_out_case
 
     # Fitted SSM surface and PCA coefficients written by Tutorial 8 (Duke Heart).
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     case_dir = (
         DUKE_HEART.output_directory(test_mode) / "tutorial_08_duke_heart" / case_id
@@ -193,7 +193,7 @@ if __name__ == "__main__":
     tutorial_results: dict[str, Any] = dict(result)
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=repo_root / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_11_lung_evaluate_physicsnemo.py
+++ b/tutorials/tutorial_11_lung_evaluate_physicsnemo.py
@@ -70,7 +70,7 @@ from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
     EvaluateMovementLung,
-    TestTools,
+    ProcessTests,
     WorkflowEvaluateMovement,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     reference_phase = "T70"
 
     # Fitted SSM surface and PCA coefficients written by Tutorial 8 (lung).
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     case_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_08_lung" / case_id
     # Weights Tutorial 9 trained, and the checkpoint epoch Tutorial 10 infers
@@ -201,7 +201,7 @@ if __name__ == "__main__":
     tutorial_results["ground_truth_labelmap_dir"] = ground_truth_dir
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=repo_root / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_12_duke_heart_end_to_end_inference.py
+++ b/tutorials/tutorial_12_duke_heart_end_to_end_inference.py
@@ -75,8 +75,8 @@ import pyvista as pv
 from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
-    ContourTools,
-    TestTools,
+    ProcessContours,
+    ProcessTests,
     WorkflowFitStatisticalModelToPatient,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     # Case to predict: the case held out of every fit in this chain.
     case_id = DUKE_HEART.hold_out_case
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     weights_dir = DUKE_HEART.weights_directory(test_mode)
 
@@ -221,7 +221,7 @@ if __name__ == "__main__":
     # vessels the shape model leaves out, on the pitch Tutorial 4 contoured the
     # model's training surfaces at.
     heart_surface_file = output_dir / f"{case_id}_heart_surface.vtp"
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
     labels = itk.GetArrayViewFromImage(reference_labelmap)
     wall_ids = [
         int(value)
@@ -308,7 +308,7 @@ if __name__ == "__main__":
     tutorial_results["fitted_reference_mesh_file"] = fitted_reference_mesh_file
 
     # Testing: the fitted reference surface beside the first predicted stage.
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=repo_root / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_12_lung_end_to_end_inference.py
+++ b/tutorials/tutorial_12_lung_end_to_end_inference.py
@@ -71,9 +71,9 @@ import pyvista as pv
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
+    ProcessTests,
     SegmentNVSegmentCTMRI,
-    TestTools,
     WorkflowConvertImageToVTK,
     WorkflowFitStatisticalModelToPatient,
     WorkflowInferMovement,
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     # phase, so the network's reference frame is this one.
     reference_phase = "T70"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     weights_dir = LUNG_CT_DIRLAB.weights_directory(test_mode)
 
@@ -217,7 +217,7 @@ if __name__ == "__main__":
     lung_surface_file = output_dir / f"{reference_file.stem}.vtp"
     lung_labelmap_file = output_dir / f"{reference_file.stem}_labelmap.nii.gz"
     logger.info("Segmenting the reference phase %s", reference_file.name)
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
     segmentation_result = WorkflowConvertImageToVTK(
         segmentation_method=SegmentNVSegmentCTMRI(log_level=log_level),
         log_level=log_level,
@@ -305,7 +305,7 @@ if __name__ == "__main__":
     tutorial_results["fitted_reference_mesh_file"] = fitted_reference_mesh_file
 
     # Testing: the fitted reference surface beside the first predicted stage.
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=repo_root / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_13_heart_and_lung_motion.py
+++ b/tutorials/tutorial_13_heart_and_lung_motion.py
@@ -15,7 +15,7 @@ single 3D scan.
 
 Each stage's per-vertex displacements are rasterized onto the Chest-CT grid by
 ``WorkflowInferMovement.create_deformation_field`` and spread into a continuous
-deformation by ``TransformTools.smooth_deformation_field_transform``. The 100
+deformation by ``ProcessTransforms.smooth_deformation_field_transform``. The 100
 combined frames are written as VTP surfaces and assembled into a single animated
 4D USD split by anatomy label, alongside the CT and labelmap warped by the same
 per-frame deformation.
@@ -88,7 +88,7 @@ unchanged through every warp (each frame is a deep copy with only its points
 moved; remeshing carries them over to the new cells when enabled).
 ``ConvertVTKToUSD``,
 given ``segmenter.taxonomy.all_labels()`` and the segmenter, splits each frame
-into per-organ prims, and ``USDAnatomyTools.enhance_meshes`` then binds the
+into per-organ prims, and ``ProcessUSDAnatomy.enhance_meshes`` then binds the
 matching OmniSurface material (diffuse color, subsurface scattering, etc.).
 
 Prerequisites
@@ -140,14 +140,14 @@ from parameters_duke_heart_labelmaps import DUKE_HEART
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
-    ContourTools,
     ConvertVTKToUSD,
-    ImageTools,
+    ProcessContours,
+    ProcessImages,
+    ProcessTests,
+    ProcessTransforms,
+    ProcessUSDAnatomy,
     SegmentHeartSimplewareTrimmedBranches,
     SegmentNVSegmentCTMRI,
-    TestTools,
-    TransformTools,
-    USDAnatomyTools,
     WorkflowConvertVTKToUSD,
     WorkflowFitStatisticalModelToPatient,
     WorkflowInferMovement,
@@ -168,7 +168,7 @@ if __name__ == "__main__":
     tutorials_dir = Path(__file__).resolve().parent
 
     # ---- Inputs ------------------------------------------------------------
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     weights_dir = DUKE_HEART.weights_directory(test_mode)
 
@@ -249,7 +249,7 @@ if __name__ == "__main__":
     # full-resolution field of a 512x512x526 scan costs 1.6 GB and the frame loop
     # blends four of them at a time. Raise it toward 1.0 to sample them finer.
     deformation_field_scale = 0.3
-    # Pitch the animated surface is contoured at. ContourTools.extract_contours
+    # Pitch the animated surface is contoured at. ProcessContours.extract_contours
     # works on an isotropic grid of the labelmap's finest pitch, which for this
     # scan is 0.6 mm and yields a 4.5-million-point thorax: a hundred frames of
     # it is 5.5 GB of warped points held at once and 135 MB per frame on disk.
@@ -294,9 +294,9 @@ if __name__ == "__main__":
                 f"Required input not found: {required}\nRun tutorials/{hint} first."
             )
 
-    contour_tools = ContourTools(log_level=log_level)
-    transform_tools = TransformTools(log_level=log_level)
-    image_tools = ImageTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
+    transform_tools = ProcessTransforms(log_level=log_level)
+    image_tools = ProcessImages(log_level=log_level)
 
     patient_image = itk.imread(str(patient_image_file))
 
@@ -711,7 +711,7 @@ if __name__ == "__main__":
     # ========================================================================
     # Labeled contour surface: each cell carries `boundary_labels`, which survive
     # the warps (deep copies) and let ConvertVTKToUSD split the USD by anatomy so
-    # USDAnatomyTools.enhance_meshes can bind per-organ OmniSurface materials.
+    # ProcessUSDAnatomy.enhance_meshes can bind per-organ OmniSurface materials.
     # Contoured from a coarsened copy of the labelmap, so the animated surface
     # is sampled at surface_spacing_mm rather than at the scan's finest pitch.
     # Its heart cells come from the Simpleware segmentation merged in at Stage 0.
@@ -911,14 +911,14 @@ if __name__ == "__main__":
     )
     usd_file = output_dir / "heart_and_lung_motion.usd"
     stage = converter.convert(str(usd_file))
-    USDAnatomyTools(stage).enhance_meshes(segmenter)
+    ProcessUSDAnatomy(stage).enhance_meshes(segmenter)
     stage.Save()
     logger.info("Wrote 4D USD with anatomy materials: %s", usd_file)
 
     # Testing: the first combined frame, as geometry and as the labelmap the
     # same frame rasterizes to.
     class_name = "tutorial_13_heart_and_lung_motion"
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=tutorials_dir.parent / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
+++ b/tutorials/tutorial_14_duke_heart_shape_parameter_sweep.py
@@ -105,7 +105,7 @@ from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
     EvaluateMovementDukeHeart,
-    TestTools,
+    ProcessTests,
     WorkflowEvaluateMovement,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
@@ -153,7 +153,7 @@ if __name__ == "__main__":
     case_id = DUKE_HEART.hold_out_case
 
     # Fitted SSM surface and PCA coefficients written by Tutorial 8 (Duke Heart).
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     case_dir = (
         DUKE_HEART.output_directory(test_mode) / "tutorial_08_duke_heart" / case_id
@@ -378,7 +378,7 @@ if __name__ == "__main__":
     baseline_index = int(np.argmin(grid_distances))
     extreme_index = int(np.argmax(grid_distances))
 
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=repo_root / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_14_lung_shape_parameter_sweep.py
+++ b/tutorials/tutorial_14_lung_shape_parameter_sweep.py
@@ -113,7 +113,7 @@ from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
     EvaluateMovementLung,
-    TestTools,
+    ProcessTests,
     WorkflowEvaluateMovement,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     reference_phase = "T70"
 
     # Fitted SSM surface and PCA coefficients written by Tutorial 8 (lung).
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     case_dir = LUNG_CT_DIRLAB.output_directory(test_mode) / "tutorial_08_lung" / case_id
     # Weights Tutorial 9 trained, and the checkpoint epoch to infer with; None
@@ -389,7 +389,7 @@ if __name__ == "__main__":
     baseline_index = int(np.argmin(grid_distances))
     extreme_index = int(np.argmax(grid_distances))
 
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=repo_root / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_15_duke_heart_leave_one_out.py
+++ b/tutorials/tutorial_15_duke_heart_leave_one_out.py
@@ -107,12 +107,12 @@ import pyvista as pv
 from parameters_duke_heart_labelmaps import DUKE_HEART
 
 from monai_physio import (
-    ContourTools,
     DistributedContext,
     EvaluateMovementDukeHeart,
-    PhysicsNemoTools,
+    ProcessContours,
+    ProcessPhysicsNemo,
+    ProcessTests,
     RegisterModelsDistanceMaps,
-    TestTools,
     TrainPhysicsNeMoMGN,
     WorkflowCreateMeanSurface,
     WorkflowCreateStatisticalModel,
@@ -414,7 +414,7 @@ if __name__ == "__main__":
     # reported, and still below the thinnest wall of the heart.
     evaluation_spacing_mm = 1.0
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     weights_dir = DUKE_HEART.weights_directory(test_mode)
 
@@ -428,7 +428,7 @@ if __name__ == "__main__":
     # Under torchrun / SLURM / mpirun this is one rank of many; started plainly
     # it reports a world of one and every branch below collapses to a single
     # process.
-    context = PhysicsNemoTools.distributed_context()
+    context = ProcessPhysicsNemo.distributed_context()
 
     data_dir = DUKE_HEART.hold_out_directory(test_mode)
     tutorial_04_dir = DUKE_HEART.input_directory(test_mode)
@@ -519,7 +519,7 @@ if __name__ == "__main__":
             icon_weights_path,
         )
 
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
 
     # The cohort names the structures every fold reports and, in Step 5, reads
     # each fold's ground truth: the acquired labelmaps and this fold's own fits.
@@ -872,7 +872,7 @@ if __name__ == "__main__":
         tutorial_results["rows"] = all_rows
 
         # Testing
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=class_name,
             results_dir=output_dir,
             baselines_dir=repo_root / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_15_lung_leave_one_out.py
+++ b/tutorials/tutorial_15_lung_leave_one_out.py
@@ -111,15 +111,15 @@ import pyvista as pv
 from parameters_lung_ct_dirlab import LUNG_CT_DIRLAB
 
 from monai_physio import (
-    ContourTools,
     DistributedContext,
     EvaluateMovementLung,
-    PhysicsNemoTools,
+    ProcessContours,
+    ProcessPhysicsNemo,
+    ProcessTests,
+    ProcessTransforms,
     RegisterImagesGreedy,
     SegmentNVSegmentCTMRI,
-    TestTools,
     TrainPhysicsNeMoMGN,
-    TransformTools,
     WorkflowConvertImageToVTK,
     WorkflowCreateMeanSurface,
     WorkflowCreateStatisticalModel,
@@ -415,7 +415,7 @@ if __name__ == "__main__":
     # that a lobe boundary is not quantized away.
     evaluation_spacing_mm = 2.0
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     # Keep a test run out of the directories a full run reads and writes.
     weights_dir = LUNG_CT_DIRLAB.weights_directory(test_mode)
 
@@ -429,7 +429,7 @@ if __name__ == "__main__":
     # Under torchrun / SLURM / mpirun this is one rank of many; started plainly
     # it reports a world of one and every branch below collapses to a single
     # process.
-    context = PhysicsNemoTools.distributed_context()
+    context = ProcessPhysicsNemo.distributed_context()
 
     data_dir = LUNG_CT_DIRLAB.input_directory(test_mode)
     number_of_pca_components = LUNG_CT_DIRLAB.pca_components(test_mode)
@@ -505,8 +505,8 @@ if __name__ == "__main__":
     segmentation_workflow = WorkflowConvertImageToVTK(
         segmentation_method=segmentation_method, log_level=log_level
     )
-    contour_tools = ContourTools(log_level=log_level)
-    transform_tools = TransformTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
+    transform_tools = ProcessTransforms(log_level=log_level)
 
     # The cohort names the structures every fold reports and, in Step 5, reads
     # each fold's ground truth back out of the shared cache below.
@@ -893,7 +893,7 @@ if __name__ == "__main__":
         tutorial_results["rows"] = all_rows
 
         # Testing
-        tt = TestTools(
+        tt = ProcessTests(
             class_name=class_name,
             results_dir=output_dir,
             baselines_dir=repo_root / "tests" / "baselines" / class_name,

--- a/tutorials/tutorial_16_duke_heart_physics_informed_motion_prep.py
+++ b/tutorials/tutorial_16_duke_heart_physics_informed_motion_prep.py
@@ -15,7 +15,7 @@ This tutorial therefore builds the same model volumetrically:
 1. Build the unbiased mean surface of the population, exactly as Tutorial 6
    does.
 2. Fill that surface with tetrahedra
-   (``ContourTools.extract_tetrahedra`` then ``trim_tetrahedra_to_surface``).
+   (``ProcessContours.extract_tetrahedra`` then ``trim_tetrahedra_to_surface``).
    Those cells become the elements the strain energy is summed over, and
    because every subject and phase inherits the template's topology, one set of
    element node ids stays valid across the whole cohort.
@@ -81,9 +81,9 @@ import pyvista as pv
 from parameters_duke_heart_physics_informed import DUKE_HEART_PHYSICS_INFORMED
 
 from monai_physio import (
-    ContourTools,
+    ProcessContours,
+    ProcessTests,
     RegisterModelsDistanceMaps,
-    TestTools,
     WorkflowCreateMeanSurface,
     WorkflowCreateStatisticalModel,
     WorkflowFitStatisticalModelToPatient,
@@ -187,7 +187,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_16_duke_heart_physics_informed_motion_prep"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     parameters = DUKE_HEART_PHYSICS_INFORMED
 
     output_dir = parameters.prep_directory(test_mode)
@@ -261,7 +261,7 @@ if __name__ == "__main__":
         )
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    contour_tools = ContourTools(log_level=log_level)
+    contour_tools = ProcessContours(log_level=log_level)
 
     tutorial_results: dict[str, Any] = {"cases": {}, "screenshots": []}
 
@@ -642,7 +642,7 @@ if __name__ == "__main__":
     logger.info("Wrote %d manifests under %s", len(manifests), manifests_dir)
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_17_duke_heart_physics_informed_motion_train.py
+++ b/tutorials/tutorial_17_duke_heart_physics_informed_motion_train.py
@@ -79,7 +79,7 @@ import numpy as np
 import pyvista as pv
 from parameters_duke_heart_physics_informed import DUKE_HEART_PHYSICS_INFORMED
 
-from monai_physio import TestTools, WorkflowTrainPhysicsNeMo
+from monai_physio import ProcessTests, WorkflowTrainPhysicsNeMo
 from monai_physio.train_physicsnemo_physics_informed_motion import (
     PhysicsInformedMotion,
     TrainPhysicsNeMoPhysicsInformedMotion,
@@ -153,7 +153,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_17_duke_heart_physics_informed_motion_train"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     parameters = DUKE_HEART_PHYSICS_INFORMED
 
     prep_dir = parameters.prep_directory(test_mode)
@@ -357,7 +357,7 @@ if __name__ == "__main__":
     logger.info("Physics-informed model: %s", physics_result["output_directory"])
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=prep_dir,
         baselines_dir=baselines_dir,

--- a/tutorials/tutorial_18_duke_heart_physics_informed_motion_infer.py
+++ b/tutorials/tutorial_18_duke_heart_physics_informed_motion_infer.py
@@ -64,7 +64,7 @@ from parameters_duke_heart_physics_informed import DUKE_HEART_PHYSICS_INFORMED
 from monai_physio import (
     ConvertVTKToUSD,
     EvaluateMovementDukeHeart,
-    TestTools,
+    ProcessTests,
     WorkflowEvaluateMovement,
     WorkflowInferMovement,
     WorkflowInferPhysicsNeMo,
@@ -129,7 +129,7 @@ def _stress_at_points(
 def _render_stress(surface: pv.DataSet, plot_file: Path) -> Path:
     """Render a surface colored by von Mises stress and return the written path.
 
-    ``TestTools.save_screenshot_mesh`` paints a mesh one flat color, so a scalar
+    ``ProcessTests.save_screenshot_mesh`` paints a mesh one flat color, so a scalar
     field needs its own plotter.
     """
     xvfb_started = False
@@ -173,7 +173,7 @@ if __name__ == "__main__":
 
     class_name = "tutorial_18_duke_heart_physics_informed_motion_infer"
 
-    test_mode = TestTools.running_as_test()
+    test_mode = ProcessTests.running_as_test()
     parameters = DUKE_HEART_PHYSICS_INFORMED
 
     # The case held out of every fit in this chain.
@@ -369,7 +369,7 @@ if __name__ == "__main__":
     logger.info("USD: %s", usd_file)
 
     # Testing
-    tt = TestTools(
+    tt = ProcessTests(
         class_name=class_name,
         results_dir=output_dir,
         baselines_dir=baselines_dir,

--- a/utils/ai_agent_github_reviews.py
+++ b/utils/ai_agent_github_reviews.py
@@ -61,7 +61,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Union, cast
 
-
 # ---------------------------------------------------------------------------
 # Git / repo helpers
 # ---------------------------------------------------------------------------
@@ -471,7 +470,7 @@ def resolve_review_threads(thread_ids: list[str], repo: str) -> None:
     if not thread_ids:
         return
     print(f"[*] Resolving {len(thread_ids)} inline-comment thread(s)...")
-    owner, name = repo.split("/", 1)  # noqa: F841 - kept for future use
+    owner, name = repo.split("/", 1)
     for tid in thread_ids:
         try:
             _gh_graphql(_RESOLVE_THREAD_MUTATION, {"threadId": tid})

--- a/utils/rename_tools_to_process.py
+++ b/utils/rename_tools_to_process.py
@@ -1,0 +1,281 @@
+"""Rename the `*_tools` module and class family to `process_*` / `Process*`.
+
+Renames each old module (and, where present, its dedicated test file and
+Sphinx API page) via ``git mv``, then rewrites, tree-wide, only the
+*anchored* forms of each old module/class name - import statements, dotted
+``monai_physio.<module>`` references, Sphinx cross-reference roles, and
+``<module>.py`` filename mentions in prose - plus the whole-word PascalCase
+class names (including their ``Test<Class>`` pytest mirrors). It deliberately
+does not touch bare lowercase identifiers such as ``self.transform_tools``
+instance attributes or the ``contour_tools``/``transform_tools`` pytest
+fixtures, since those are a separate, intentionally unchanged, kind of name.
+
+Usage::
+
+    py utils/rename_tools_to_process.py --dry-run   # preview the diff
+    py utils/rename_tools_to_process.py              # apply
+
+Safe to run from any directory inside the target checkout; the file list
+comes from ``git ls-files``, so it never touches build artifacts, caches, or
+untracked files, and it refuses to run against a dirty working tree unless
+``--allow-dirty`` is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+#: (old_module, new_module, old_class_or_None, new_class_or_None)
+RENAMES: list[tuple[str, str, str | None, str | None]] = [
+    ("image_tools", "process_images", "ImageTools", "ProcessImages"),
+    ("labelmap_tools", "process_labelmaps", "LabelmapTools", "ProcessLabelmaps"),
+    ("transform_tools", "process_transforms", "TransformTools", "ProcessTransforms"),
+    ("landmark_tools", "process_landmarks", "LandmarkTools", "ProcessLandmarks"),
+    ("contour_tools", "process_contours", "ContourTools", "ProcessContours"),
+    ("test_tools", "process_tests", "TestTools", "ProcessTests"),
+    ("data_download_tools", "download_data", "DataDownloadTools", "DownloadData"),
+    (
+        "physicsnemo_tools",
+        "process_physicsnemo",
+        "PhysicsNemoTools",
+        "ProcessPhysicsNemo",
+    ),
+    (
+        "usd_anatomy_tools",
+        "process_usd_anatomy",
+        "USDAnatomyTools",
+        "ProcessUSDAnatomy",
+    ),
+    ("usd_tools", "process_usd", "USDTools", "ProcessUSD"),
+]
+
+#: Extra ``git mv`` pairs (relative to repo root) that don't follow the
+#: ``src/monai_physio/<old>.py`` / ``tests/test_<old>.py`` naming pattern.
+EXTRA_FILE_RENAMES: list[tuple[str, str]] = [
+    ("tests/test_physicsnemo_tools.py", "tests/test_process_physicsnemo.py"),
+    ("docs/api/utilities/data_download.rst", "docs/api/utilities/download_data.rst"),
+    ("docs/api/usd/anatomy_tools.rst", "docs/api/usd/process_usd_anatomy.rst"),
+    ("docs/api/usd/tools.rst", "docs/api/usd/process_usd.rst"),
+    ("docs/api/utilities/test_tools.rst", "docs/api/utilities/process_tests.rst"),
+]
+
+_ALLOWED_SUFFIXES = {".py", ".rst", ".md", ".txt"}
+
+
+def _git_mv(root: Path, old: str, new: str, dry_run: bool) -> None:
+    old_path = root / old
+    if not old_path.exists():
+        return
+    if dry_run:
+        print(f"would rename: {old} -> {new}")
+        return
+    subprocess.run(["git", "mv", old, new], cwd=root, check=True)
+    print(f"renamed: {old} -> {new}")
+
+
+def _rename_files(root: Path, dry_run: bool) -> None:
+    for old_mod, new_mod, _old_cls, _new_cls in RENAMES:
+        _git_mv(
+            root,
+            f"src/monai_physio/{old_mod}.py",
+            f"src/monai_physio/{new_mod}.py",
+            dry_run,
+        )
+        _git_mv(
+            root,
+            f"tests/test_{old_mod}.py",
+            f"tests/test_{new_mod}.py",
+            dry_run,
+        )
+        _git_mv(
+            root,
+            f"docs/api/utilities/{old_mod}.rst",
+            f"docs/api/utilities/{new_mod}.rst",
+            dry_run,
+        )
+    for old, new in EXTRA_FILE_RENAMES:
+        _git_mv(root, old, new, dry_run)
+
+
+def _tracked_files(root: Path, file_list: list[str] | None) -> list[Path]:
+    """Return every git-tracked file under *root* worth scanning.
+
+    ``git ls-files`` already respects ``.gitignore``, so build artifacts and
+    caches (``docs/_build/``, ``.mypy_cache/``, ``graphify-out/``, ...) are
+    never touched without a manual exclusion list. *file_list*, when given
+    (one ``git ls-files``-style relative path per line), is used instead of
+    shelling out to git - some environments don't have git on the Python
+    process's ``PATH`` even though the shell running this script does.
+    """
+    if file_list is None:
+        result = subprocess.run(
+            ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+        )
+        file_list = result.stdout.splitlines()
+    files = []
+    for line in file_list:
+        rel = line.strip()
+        if not rel:
+            continue
+        path = Path(rel)
+        if path.suffix not in _ALLOWED_SUFFIXES:
+            continue
+        # Migration docs deliberately document the *old* names in their
+        # Before/After snippets and must stay accurate.
+        if re.fullmatch(r"docs/developer/migration(_next|_[\w.]+)?\.md", rel):
+            continue
+        files.append(root / path)
+    return files
+
+
+def _build_patterns() -> list[tuple[re.Pattern[str], str]]:
+    patterns: list[tuple[re.Pattern[str], str]] = []
+    for old_mod, new_mod, old_cls, new_cls in RENAMES:
+        old_mod_re = re.escape(old_mod)
+        new_mod_esc = new_mod.replace("\\", "\\\\")
+
+        # Dotted references: `monai_physio.<old_mod>`, `import
+        # monai_physio.<old_mod>`, autodoc directives, Sphinx cross-reference
+        # roles (`:func:`monai_physio.<old_mod>.foo``), etc.
+        patterns.append(
+            (re.compile(rf"\bmonai_physio\.{old_mod_re}\b"), f"monai_physio.{new_mod}")
+        )
+        # Relative imports, only meaningful inside src/monai_physio/*.py or its
+        # subpackages: `from .<old_mod> import ...` / `from ..<old_mod> import ...`.
+        patterns.append(
+            (re.compile(rf"from (\.\.?){old_mod_re}\b"), rf"from \g<1>{new_mod_esc}")
+        )
+        # Bare-name imports: `from monai_physio import <old_mod>` /
+        # `from monai_physio import <old_mod> as alias`, and the relative form
+        # `from . import <old_mod> as alias` / `from .. import <old_mod>`.
+        patterns.append(
+            (
+                re.compile(rf"(from monai_physio import ){old_mod_re}\b"),
+                rf"\g<1>{new_mod_esc}",
+            )
+        )
+        patterns.append(
+            (
+                re.compile(rf"(from \.\.? import ){old_mod_re}\b"),
+                rf"\g<1>{new_mod_esc}",
+            )
+        )
+        # Filename mentions in prose/docs: `<old_mod>.py`.
+        patterns.append((re.compile(rf"\b{old_mod_re}\.py\b"), f"{new_mod}.py"))
+
+        if old_cls and new_cls:
+            new_cls_esc = new_cls.replace("\\", "\\\\")
+            # The pytest mirror class first, so `TestContourTools` becomes
+            # `TestProcessContours` rather than leaving a `TestContourTools`/
+            # `ProcessContours` mismatch (the bare-class pattern below cannot
+            # match inside `TestContourTools`: no word boundary precedes it).
+            patterns.append((re.compile(rf"\bTest{old_cls}\b"), f"Test{new_cls_esc}"))
+            patterns.append((re.compile(rf"\b{old_cls}\b"), new_cls_esc))
+
+    # Doc-page filename mentions that don't mirror the module 1:1.
+    patterns.append(
+        (
+            re.compile(r"\bdocs/api/utilities/data_download\.rst\b"),
+            "docs/api/utilities/download_data.rst",
+        )
+    )
+    patterns.append(
+        (
+            re.compile(r"\bdocs/api/usd/anatomy_tools\.rst\b"),
+            "docs/api/usd/process_usd_anatomy.rst",
+        )
+    )
+    patterns.append(
+        (re.compile(r"\bdocs/api/usd/tools\.rst\b"), "docs/api/usd/process_usd.rst")
+    )
+    patterns.append(
+        (
+            re.compile(r"\bdocs/api/utilities/test_tools\.rst\b"),
+            "docs/api/utilities/process_tests.rst",
+        )
+    )
+    return patterns
+
+
+def _rewrite(text: str, patterns: list[tuple[re.Pattern[str], str]]) -> str:
+    for pattern, replacement in patterns:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root", type=Path, default=Path.cwd(), help="Repository root (default: cwd)"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print a diff-style report, change nothing",
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="Skip the clean-working-tree check",
+    )
+    parser.add_argument(
+        "--files-from",
+        type=Path,
+        default=None,
+        help=(
+            "Read the tracked-file list (one 'git ls-files'-style relative "
+            "path per line) from this file instead of shelling out to git."
+        ),
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    if not args.allow_dirty:
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        if status.stdout.strip():
+            print(
+                "Working tree is not clean; commit/stash first or pass --allow-dirty.",
+                file=sys.stderr,
+            )
+            return 1
+
+    _rename_files(root, args.dry_run)
+
+    file_list = (
+        args.files_from.read_text(encoding="utf-8").splitlines()
+        if args.files_from
+        else None
+    )
+    patterns = _build_patterns()
+    changed_files = 0
+    for path in _tracked_files(root, file_list):
+        if not path.exists():
+            continue
+        original = path.read_text(encoding="utf-8")
+        updated = _rewrite(original, patterns)
+        if updated == original:
+            continue
+        changed_files += 1
+        rel = path.relative_to(root)
+        if args.dry_run:
+            print(f"would change: {rel}")
+        else:
+            path.write_text(updated, encoding="utf-8")
+            print(f"changed: {rel}")
+
+    print(f"\n{changed_files} file(s) {'would be ' if args.dry_run else ''}changed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/setup_feature_worktree.py
+++ b/utils/setup_feature_worktree.py
@@ -34,7 +34,6 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-
 # ---------------------------------------------------------------------------
 # Shell command helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Standardize the object-first `*_tools.py`/`*Tools` naming used throughout
src/monai_physio/ to the verb-first convention used elsewhere in the project
(workflow_train_physicsnemo.py, register_images_ants.py,
segment_chest_total_segmentator.py).

contour_tools/ContourTools -> process_contours/ProcessContours, and similarly
for transform, test, image, physicsnemo, usd_anatomy, usd, labelmap, and
landmark tools. data_download_tools/DataDownloadTools -> download_data/
DownloadData as a naming exception.

Only import paths and PascalCase class names changed; lowercase instance
attributes and pytest fixtures (self.image_tools, the contour_tools fixture,
etc.) are unaffected. Corresponding Sphinx API pages and toctrees were moved
and retargeted to match.

Adds utils/rename_tools_to_process.py, a reusable git-mv + regex migration
script, and records the break in docs/developer/migration_next.md per
project policy.
